### PR TITLE
refactor: add toggle buttons for theme and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,16 +9,12 @@
 <body class="theme-light layout-auto">
 
 <nav class="top-menu">
-  <button id="theme-light" aria-label="Light theme">🌞</button>
-  <button id="theme-sepia" aria-label="Sepia theme">📜</button>
-  <button id="theme-dark" aria-label="Dark theme">🌙</button>
+  <button id="theme-toggle" aria-label="Toggle theme">☀</button>
 
   <button id="scale-dec" aria-label="Decrease UI size">-</button>
   <button id="scale-inc" aria-label="Increase UI size">+</button>
 
-  <button id="layout-landscape" aria-label="Landscape layout">🖼️</button>
-  <button id="layout-portrait" aria-label="Portrait layout">📱</button>
-  <button id="layout-auto" aria-label="Auto layout">🔁</button>
+  <button id="layout-toggle" aria-label="Toggle layout">⟳</button>
 
   <button id="menu-button" aria-label="Menu">☰</button>
 </nav>

--- a/script.js
+++ b/script.js
@@ -1,18 +1,23 @@
 const body = document.body;
 
-// Theme buttons
-const themeButtons = {
-  light: document.getElementById('theme-light'),
-  sepia: document.getElementById('theme-sepia'),
-  dark: document.getElementById('theme-dark')
+// Theme toggle
+const themeToggle = document.getElementById('theme-toggle');
+const themes = ['light', 'dark', 'sepia'];
+const themeIcons = { light: '☀', dark: '☾', sepia: '▤' };
+let currentThemeIndex = themes.indexOf(
+  [...body.classList].find(c => c.startsWith('theme-')).replace('theme-', '')
+);
+const setTheme = index => {
+  body.classList.remove('theme-light', 'theme-dark', 'theme-sepia');
+  const theme = themes[index];
+  body.classList.add(`theme-${theme}`);
+  themeToggle.textContent = themeIcons[theme];
 };
-
-Object.entries(themeButtons).forEach(([theme, btn]) => {
-  btn.addEventListener('click', () => {
-    body.classList.remove('theme-light', 'theme-sepia', 'theme-dark');
-    body.classList.add(`theme-${theme}`);
-  });
+themeToggle.addEventListener('click', () => {
+  currentThemeIndex = (currentThemeIndex + 1) % themes.length;
+  setTheme(currentThemeIndex);
 });
+setTheme(currentThemeIndex);
 
 // UI scale buttons
 let uiScale = 1;
@@ -28,18 +33,24 @@ document.getElementById('scale-inc').addEventListener('click', () => {
   updateScale();
 });
 
-// Layout buttons
-const layoutButtons = {
-  landscape: document.getElementById('layout-landscape'),
-  portrait: document.getElementById('layout-portrait'),
-  auto: document.getElementById('layout-auto')
+// Layout toggle
+const layoutToggle = document.getElementById('layout-toggle');
+const layouts = ['landscape', 'portrait', 'auto'];
+const layoutIcons = { landscape: '▭', portrait: '▯', auto: '⟳' };
+let currentLayoutIndex = layouts.indexOf(
+  [...body.classList].find(c => c.startsWith('layout-')).replace('layout-', '')
+);
+const setLayout = index => {
+  body.classList.remove('layout-landscape', 'layout-portrait', 'layout-auto');
+  const layout = layouts[index];
+  body.classList.add(`layout-${layout}`);
+  layoutToggle.textContent = layoutIcons[layout];
 };
-Object.entries(layoutButtons).forEach(([layout, btn]) => {
-  btn.addEventListener('click', () => {
-    body.classList.remove('layout-landscape', 'layout-portrait', 'layout-auto');
-    body.classList.add(`layout-${layout}`);
-  });
+layoutToggle.addEventListener('click', () => {
+  currentLayoutIndex = (currentLayoutIndex + 1) % layouts.length;
+  setLayout(currentLayoutIndex);
 });
+setLayout(currentLayoutIndex);
 
 // Dropdown menu
 const menuButton = document.getElementById('menu-button');

--- a/style.css
+++ b/style.css
@@ -2,6 +2,8 @@
   --ui-scale: 1;
   --background: #ffffff;
   --foreground: #000000;
+  --menu-color-dark: #003366;
+  --menu-color-light: #66a3ff;
 }
 
 html {
@@ -35,9 +37,10 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--foreground);
-  background: var(--background);
-  color: var(--foreground);
+  border: 2px solid var(--menu-color-light);
+  background: transparent;
+  color: var(--menu-color-dark);
+  -webkit-text-stroke: 1px var(--menu-color-light);
   cursor: pointer;
 }
 
@@ -74,8 +77,8 @@ body.theme-light {
 }
 
 body.theme-sepia {
-  --background: #f4ecd8;
-  --foreground: #5b4636;
+  --background: #e8dcc2;
+  --foreground: #4a3b2d;
 }
 
 body.theme-dark {


### PR DESCRIPTION
## Summary
- consolidate theme switching into a single toggle button cycling light, dark, sepia
- replace separate orientation controls with one layout toggle
- style menu icons as outlined elements with contrasting blue shades and darken sepia theme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4efe09d8c8325bf82a8fc7bcef884