### PR TITLE
feat: add profile and character system

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,10 +30,7 @@
   <button>Settings</button>
 </div>
 
-<main style="margin-top:4rem; padding:1rem;">
-  <h1>Welcome to the Text RPG</h1>
-  <p>Adventure awaits...</p>
-</main>
+<main style="margin-top:4rem; padding:1rem;"></main>
 
 <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,106 @@
 const body = document.body;
+const main = document.querySelector('main');
+
+// --- Profile and save management ---
+const STORAGE_KEY = 'rpgProfiles';
+const LAST_PROFILE_KEY = 'rpgLastProfile';
+let profiles = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+let currentProfileId = localStorage.getItem(LAST_PROFILE_KEY);
+let currentProfile = currentProfileId ? profiles[currentProfileId] : null;
+let currentCharacter = null;
+
+const saveProfiles = () => localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles));
+
+const savePreference = (key, value) => {
+  if (!currentProfile) return;
+  currentProfile.preferences = currentProfile.preferences || {};
+  currentProfile.preferences[key] = value;
+  saveProfiles();
+};
+
+function createProfile(name) {
+  const profileName = name || prompt('Enter profile name:');
+  if (!profileName) return null;
+  const id = Date.now().toString();
+  profiles[id] = { id, name: profileName, preferences: {}, characters: {}, lastCharacter: null };
+  currentProfileId = id;
+  currentProfile = profiles[id];
+  localStorage.setItem(LAST_PROFILE_KEY, id);
+  saveProfiles();
+  return id;
+}
+
+function selectProfile() {
+  const ids = Object.keys(profiles);
+  if (currentProfileId && profiles[currentProfileId]) {
+    currentProfile = profiles[currentProfileId];
+    return;
+  }
+  if (ids.length === 0) {
+    while (!currentProfile) {
+      createProfile();
+    }
+  } else {
+    let choice = '';
+    while (!currentProfile) {
+      choice = prompt(`Select profile (${ids.map(id => profiles[id].name).join(', ')})\nEnter a new name to create one:`);
+      if (choice === null) continue;
+      const existingId = ids.find(id => profiles[id].name === choice);
+      if (existingId) {
+        currentProfileId = existingId;
+        currentProfile = profiles[existingId];
+        localStorage.setItem(LAST_PROFILE_KEY, currentProfileId);
+      } else if (choice) {
+        createProfile(choice);
+      }
+    }
+  }
+}
+
+function showCharacter() {
+  if (!currentCharacter) return;
+  main.innerHTML = `<h1>Welcome, ${currentCharacter.name}</h1>`;
+}
+
+function showNoCharacterUI() {
+  main.innerHTML = `<div class="no-character"><h1>Start your journey...</h1><button id="new-character">New Character</button></div>`;
+  document.getElementById('new-character').addEventListener('click', () => {
+    const name = prompt('Enter character name:');
+    if (!name) return;
+    const id = Date.now().toString();
+    currentProfile.characters[id] = { id, name };
+    currentProfile.lastCharacter = id;
+    currentCharacter = currentProfile.characters[id];
+    saveProfiles();
+    showCharacter();
+  });
+}
+
+function loadCharacter() {
+  const charId = currentProfile?.lastCharacter;
+  if (charId && currentProfile.characters && currentProfile.characters[charId]) {
+    currentCharacter = currentProfile.characters[charId];
+    showCharacter();
+  } else {
+    showNoCharacterUI();
+  }
+}
+
+function loadPreferences() {
+  const prefs = currentProfile?.preferences || {};
+  if (prefs.theme && themes.includes(prefs.theme)) {
+    currentThemeIndex = themes.indexOf(prefs.theme);
+  }
+  if (typeof prefs.uiScale === 'number') {
+    uiScale = prefs.uiScale;
+  }
+  if (prefs.layout && layouts.includes(prefs.layout)) {
+    currentLayoutIndex = layouts.indexOf(prefs.layout);
+  }
+  setTheme(currentThemeIndex);
+  updateScale();
+  setLayout(currentLayoutIndex);
+}
 
 // Theme toggle
 const themeToggle = document.getElementById('theme-toggle');
@@ -12,17 +114,18 @@ const setTheme = index => {
   const theme = themes[index];
   body.classList.add(`theme-${theme}`);
   themeToggle.textContent = themeIcons[theme];
+  savePreference('theme', theme);
 };
 themeToggle.addEventListener('click', () => {
   currentThemeIndex = (currentThemeIndex + 1) % themes.length;
   setTheme(currentThemeIndex);
 });
-setTheme(currentThemeIndex);
 
 // UI scale buttons
 let uiScale = 1;
 const updateScale = () => {
   document.documentElement.style.setProperty('--ui-scale', uiScale);
+  savePreference('uiScale', uiScale);
 };
 document.getElementById('scale-dec').addEventListener('click', () => {
   uiScale = Math.max(0.5, uiScale - 0.1);
@@ -45,12 +148,12 @@ const setLayout = index => {
   const layout = layouts[index];
   body.classList.add(`layout-${layout}`);
   layoutToggle.textContent = layoutIcons[layout];
+  savePreference('layout', layout);
 };
 layoutToggle.addEventListener('click', () => {
   currentLayoutIndex = (currentLayoutIndex + 1) % layouts.length;
   setLayout(currentLayoutIndex);
 });
-setLayout(currentLayoutIndex);
 
 // Dropdown menu
 const menuButton = document.getElementById('menu-button');
@@ -58,3 +161,9 @@ const dropdownMenu = document.getElementById('dropdownMenu');
 menuButton.addEventListener('click', () => {
   dropdownMenu.classList.toggle('active');
 });
+
+// Initialization
+selectProfile();
+loadPreferences();
+loadCharacter();
+

--- a/style.css
+++ b/style.css
@@ -71,6 +71,21 @@ body {
   font-size: 1rem;
 }
 
+.no-character {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: calc(100vh - 4rem);
+  text-align: center;
+}
+
+.no-character button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}
+
 body.theme-light {
   --background: #ffffff;
   --foreground: #000000;


### PR DESCRIPTION
## Summary
- add localStorage-based user profiles and character saves
- persist theme, scale, and layout preferences per profile
- show start screen with "Start your journey..." and New Character button when no character exists

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a50790d2748325857be2b5c72eac0a