### PR TITLE
Add portrait regeneration and persistent character creation

### DIFF
--- a/style.css
+++ b/style.css
@@ -141,3 +141,19 @@ body.theme-dark {
   background: var(--foreground);
   transition: width 0.1s linear;
 }
+
+.color-box {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid var(--foreground);
+  vertical-align: middle;
+  margin-left: 0.25rem;
+}
+
+.portrait-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- Generate a single portrait automatically and allow regenerating from the profile screen
- Preserve character creation progress so refreshing doesn't lose data
- Show hair/eye colors as swatches and offer common color presets

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a546a050048325bef291b723d2b36d