### PR TITLE
Add skin color picker and reorganize menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,19 +9,16 @@
 <body class="theme-light layout-auto">
 
 <nav class="top-menu">
-  <button id="back-button" aria-label="Back" style="display:none;">←</button>
-  <button id="theme-toggle" aria-label="Toggle theme">☀</button>
-
-  <button id="scale-dec" aria-label="Decrease UI size">-</button>
-  <button id="scale-inc" aria-label="Increase UI size">+</button>
-
-  <button id="layout-toggle" aria-label="Toggle layout">⟳</button>
-
   <button id="menu-button" aria-label="Menu">☰</button>
+  <button id="back-button" aria-label="Back" style="display:none;">←</button>
+  <button id="character-button" aria-label="Character">👤</button>
+  <button id="theme-toggle" aria-label="Toggle theme">☀</button>
+  <button id="layout-toggle" aria-label="Toggle layout">⟳</button>
+  <button id="scale-dec" aria-label="Decrease UI size" class="push-right">-</button>
+  <button id="scale-inc" aria-label="Increase UI size">+</button>
 </nav>
 
 <div id="dropdownMenu">
-  <button data-action="character">Character</button>
   <button data-action="new-character">New Character</button>
   <button data-action="inventory">Inventory</button>
   <button data-action="equipment">Equipment</button>

--- a/style.css
+++ b/style.css
@@ -45,6 +45,10 @@ body {
   cursor: pointer;
 }
 
+.top-menu .push-right {
+  margin-left: auto;
+}
+
 #dropdownMenu {
   position: fixed;
   top: 3.5rem;


### PR DESCRIPTION
## Summary
- add race-specific skin color step to character creation and portrait generation
- restructure top bar so the menu sits left, character icon added, and scale buttons move right

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d41cbd648325b0f462b188c44bbc