### PR TITLE
Refine UI icons and orientation layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,15 @@
 <nav class="top-menu">
   <button id="menu-button" aria-label="Menu">☰</button>
   <button id="back-button" aria-label="Back" style="display:none;">←</button>
-  <button id="character-button" aria-label="Character">👤</button>
-  <button id="theme-toggle" aria-label="Toggle theme">☀</button>
-  <button id="layout-toggle" aria-label="Toggle layout">⟳</button>
-  <button id="scale-dec" aria-label="Decrease UI size" class="push-right">-</button>
+  <button id="character-button" aria-label="Character">
+    <svg viewBox="0 0 24 24">
+      <circle cx="12" cy="8" r="4" />
+      <path d="M4 20c0-4 4-6 8-6s8 2 8 6" />
+    </svg>
+  </button>
+  <button id="theme-toggle" aria-label="Toggle theme"></button>
+  <button id="layout-toggle" aria-label="Toggle layout"></button>
+  <button id="scale-dec" aria-label="Decrease UI size">-</button>
   <button id="scale-inc" aria-label="Increase UI size">+</button>
 </nav>
 

--- a/script.js
+++ b/script.js
@@ -234,7 +234,7 @@ function startCharacterCreation() {
         inputHTML = `<input type="range" id="cc-input" min="${min}" max="${max}" value="${val}"><span id="cc-value">${formatHeight(val)}</span>`;
       }
 
-      main.innerHTML = `<div class="character-creation"><div class="progress-container">${progressHTML}</div><div class="no-character"><h1>${field.label}</h1>${inputHTML}<button id="next-step">Next</button></div></div>`;
+      main.innerHTML = `<div class="character-creation"><div class="progress-container">${progressHTML}</div><div class="cc-column"><h1>${field.label}</h1>${inputHTML}<button id="next-step">Next</button></div></div>`;
 
       if (field.type === 'range') {
         const rangeInput = document.getElementById('cc-input');
@@ -254,7 +254,7 @@ function startCharacterCreation() {
       });
     } else {
       const nameVal = character.name || '';
-      main.innerHTML = `<div class="character-creation"><div class="progress-container">${progressHTML}</div><div class="no-character"><h1>Name your character...</h1><input type="text" id="name-input" value="${nameVal}"><button id="create-character">Create</button></div></div>`;
+      main.innerHTML = `<div class="character-creation"><div class="progress-container">${progressHTML}</div><div class="cc-column"><h1>Name your character...</h1><input type="text" id="name-input" value="${nameVal}"><button id="create-character">Create</button></div></div>`;
       document.getElementById('create-character').addEventListener('click', () => {
         const name = document.getElementById('name-input').value.trim();
         if (!name) return;
@@ -377,7 +377,14 @@ function loadPreferences() {
 // Theme toggle
 const themeToggle = document.getElementById('theme-toggle');
 const themes = ['light', 'dark', 'sepia'];
-const themeIcons = { light: '☀', dark: '☾', sepia: '▤' };
+const themeIcons = {
+  light:
+    '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="4"/><line x1="12" y1="20" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="4" y2="12"/><line x1="20" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>',
+  dark:
+    '<svg viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>',
+  sepia:
+    '<svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="5"/><rect x="11" y="13" width="2" height="8"/></svg>'
+};
 let currentThemeIndex = themes.indexOf(
   [...body.classList].find(c => c.startsWith('theme-')).replace('theme-', '')
 );
@@ -385,7 +392,7 @@ const setTheme = index => {
   body.classList.remove('theme-light', 'theme-dark', 'theme-sepia');
   const theme = themes[index];
   body.classList.add(`theme-${theme}`);
-  themeToggle.textContent = themeIcons[theme];
+  themeToggle.innerHTML = themeIcons[theme];
   savePreference('theme', theme);
 };
 themeToggle.addEventListener('click', () => {
@@ -412,10 +419,12 @@ document.getElementById('scale-inc').addEventListener('click', () => {
 const layoutToggle = document.getElementById('layout-toggle');
 const layouts = ['landscape', 'portrait', 'auto'];
 const layoutIcons = {
-  landscape: '<span style="display:inline-block; transform: rotate(90deg);">📱</span>',
-  portrait: '📱',
+  landscape:
+    '<svg viewBox="0 0 24 24"><rect x="2" y="6" width="20" height="12" rx="2" ry="2"/></svg>',
+  portrait:
+    '<svg viewBox="0 0 24 24"><rect x="6" y="2" width="12" height="20" rx="2" ry="2"/></svg>',
   auto:
-    '<span style="position:relative; display:inline-block;"><span>📱</span><span style="position:absolute; left:0; top:0; transform: rotate(90deg);">📱</span></span>'
+    '<svg viewBox="0 0 24 24"><rect x="6" y="2" width="12" height="20" rx="2" ry="2"/><rect x="2" y="6" width="20" height="12" rx="2" ry="2"/></svg>'
 };
 let currentLayoutIndex = layouts.indexOf(
   [...body.classList].find(c => c.startsWith('layout-')).replace('layout-', '')

--- a/style.css
+++ b/style.css
@@ -34,6 +34,8 @@ body {
 .top-menu button {
   width: 2.5rem;
   height: 2.5rem;
+  padding: 2px;
+  box-sizing: border-box;
   font-size: 1rem;
   display: flex;
   align-items: center;
@@ -45,8 +47,12 @@ body {
   cursor: pointer;
 }
 
-.top-menu .push-right {
-  margin-left: auto;
+.top-menu button svg {
+  width: 100%;
+  height: 100%;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2;
 }
 
 #dropdownMenu {
@@ -218,16 +224,70 @@ body.theme-dark {
     margin-left: 0.5rem;
   }
 
+  .cc-column {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
   #cc-cancel {
     margin-top: 2rem;
     width: 1.5rem;
     height: 1.5rem;
     border-radius: 50%;
     border: 2px solid red;
-    background: #fff;
+    background: var(--background);
     color: red;
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
+    line-height: 1;
   }
+
+/* Orientation layouts */
+body.layout-landscape .top-menu {
+  flex-direction: row;
+  width: 100%;
+  height: auto;
+}
+
+body.layout-landscape main {
+  margin-top: 4rem;
+  margin-left: 0;
+}
+
+body.layout-portrait .top-menu {
+  flex-direction: column;
+  width: 3.5rem;
+  height: 100vh;
+}
+
+body.layout-portrait main {
+  margin-top: 0;
+  margin-left: 3.5rem;
+}
+
+@media (orientation: portrait) {
+  body.layout-auto .top-menu {
+    flex-direction: column;
+    width: 3.5rem;
+    height: 100vh;
+  }
+  body.layout-auto main {
+    margin-top: 0;
+    margin-left: 3.5rem;
+  }
+}
+
+@media (orientation: landscape) {
+  body.layout-auto .top-menu {
+    flex-direction: row;
+    width: 100%;
+    height: auto;
+  }
+  body.layout-auto main {
+    margin-top: 4rem;
+    margin-left: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Replace menu icons with theme-colored SVG outlines
- Orient layouts based on portrait, landscape, or auto mode
- Keep zoom controls visible within the top menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5df4cc4188325afa2bbcabc26e19c