### PR TITLE
feat: add character slide-out menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,13 +25,51 @@
 
 <div id="dropdownMenu">
   <button data-action="new-character">New Character</button>
-  <button data-action="inventory">Inventory</button>
-  <button data-action="equipment">Equipment</button>
-  <button data-action="spellbook">Spellbook</button>
-  <button data-action="abilities">Abilities</button>
-  <button data-action="quests">Quests</button>
   <button data-action="map">Map</button>
   <button data-action="settings">Settings</button>
+</div>
+
+<div id="characterMenu">
+  <button data-action="profile">
+    <svg viewBox="0 0 24 24">
+      <circle cx="12" cy="8" r="4" />
+      <path d="M4 20c0-4 4-6 8-6s8 2 8 6" />
+    </svg>
+    Profile
+  </button>
+  <button data-action="inventory">
+    <svg viewBox="0 0 24 24">
+      <path d="M5 7h14l-1 13H6L5 7Z" />
+      <path d="M9 7V5a3 3 0 0 1 6 0v2" />
+    </svg>
+    Inventory
+  </button>
+  <button data-action="equipment">
+    <svg viewBox="0 0 24 24">
+      <path d="M6 4l6-2 6 2v5l-2 2v9l-4-2-4 2v-9l-2-2V4Z" />
+    </svg>
+    Equipment
+  </button>
+  <button data-action="spellbook">
+    <svg viewBox="0 0 24 24">
+      <path d="M3 4h9v16H3z" />
+      <path d="M12 4h9v16h-9z" />
+      <path d="M12 4v16" />
+      <path d="M15 8l1 2 2 1-2 1-1 2-1-2-2-1 2-1 1-2z" />
+    </svg>
+    Spellbook
+  </button>
+  <button data-action="abilities">
+    <span class="letter-icon">A</span>
+    Abilities
+  </button>
+  <button data-action="quests">
+    <svg viewBox="0 0 24 24">
+      <path d="M4 4h13a3 3 0 0 1 0 6H7v10a3 3 0 1 1-6 0V7a3 3 0 0 1 3-3Z" />
+      <path d="M17 4v12a3 3 0 1 0 6 0V9a3 3 0 0 0-3-3h-3" />
+    </svg>
+    Quests
+  </button>
 </div>
 
 <main style="margin-top:4rem; padding:1rem;"></main>

--- a/script.js
+++ b/script.js
@@ -499,6 +499,7 @@ layoutToggle.addEventListener('click', () => {
 const menuButton = document.getElementById('menu-button');
 const characterButton = document.getElementById('character-button');
 const dropdownMenu = document.getElementById('dropdownMenu');
+const characterMenu = document.getElementById('characterMenu');
 
 const adjustMenuWidth = () => {
   dropdownMenu.style.width = 'auto';
@@ -517,10 +518,11 @@ window.addEventListener('resize', adjustMenuWidth);
 
 menuButton.addEventListener('click', () => {
   dropdownMenu.classList.toggle('active');
+  characterMenu.classList.remove('active');
 });
 characterButton.addEventListener('click', () => {
   dropdownMenu.classList.remove('active');
-  showCharacterUI();
+  characterMenu.classList.toggle('active');
 });
 
 dropdownMenu.addEventListener('click', e => {
@@ -535,8 +537,21 @@ dropdownMenu.addEventListener('click', e => {
   }
 });
 
+characterMenu.addEventListener('click', e => {
+  const action = e.target.dataset.action;
+  if (!action) return;
+  characterMenu.classList.remove('active');
+  if (action === 'profile') {
+    showCharacterUI();
+  } else {
+    showBackButton();
+    main.innerHTML = `<div class="no-character"><h1>${action} not implemented</h1></div>`;
+  }
+});
+
 backButton.addEventListener('click', () => {
   dropdownMenu.classList.remove('active');
+  characterMenu.classList.remove('active');
   showMainUI();
 });
 

--- a/style.css
+++ b/style.css
@@ -81,6 +81,61 @@ body {
   font-size: 1rem;
 }
 
+#characterMenu {
+  position: fixed;
+  top: 3.5rem;
+  left: 0;
+  height: calc(100vh - 3.5rem);
+  width: 14rem;
+  background: var(--background);
+  box-shadow: 2px 0 4px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 200;
+  pointer-events: none;
+}
+
+#characterMenu.active {
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+#characterMenu button {
+  margin: 0.25rem;
+  padding: 0.5rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: none;
+  background: var(--background);
+  color: var(--foreground);
+  font-size: 1rem;
+  text-align: left;
+}
+
+#characterMenu button svg,
+#characterMenu .letter-icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+}
+
+#characterMenu .letter-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+
+#characterMenu button svg {
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2;
+}
+
 /* Landscape slide-down menu */
 body.layout-landscape #dropdownMenu {
   top: 3.5rem;


### PR DESCRIPTION
## Summary
- Add slide-out character menu accessed via Character button
- Move inventory, equipment, spellbook, abilities, and quests into character menu with themed icons
- Keep main menu for new character, map, and settings

## Testing
- `node --check script.js`
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a62ac2c19c8325b425ecc1ff39ee46