### PR TITLE
Add proficiencies menu and scroll quest icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,10 +65,14 @@
     <span class="letter-icon">A</span>
     Abilities
   </button>
+  <button data-action="proficiencies">
+    <span class="letter-icon">P</span>
+    Proficiencies
+  </button>
   <button data-action="quests">
     <svg viewBox="0 0 24 24">
-      <path d="M4 4h13a3 3 0 0 1 0 6H7v10a3 3 0 1 1-6 0V7a3 3 0 0 1 3-3Z" />
-      <path d="M17 4v12a3 3 0 1 0 6 0V9a3 3 0 0 0-3-3h-3" />
+      <path d="M19 17V5a2 2 0 0 0-2-2H4" />
+      <path d="M8 21h12a2 2 0 0 0 2-2v-1a1 1 0 0 0-1-1H11a1 1 0 0 0-1 1v1a2 2 0 1 1-4 0V5a2 2 0 1 0-4 0v2a1 1 0 0 0 1 1h3" />
     </svg>
     Quests
   </button>

--- a/script.js
+++ b/script.js
@@ -72,6 +72,35 @@ const defaultProficiencies = {
   dualWield: 0
 };
 
+const proficiencyCategories = {
+  Magical: [
+    'elementalMagic',
+    'lightMagic',
+    'darkMagic',
+    'reinforcementMagic',
+    'enfeeblingMagic',
+    'summoningMagic'
+  ],
+  Combat: [
+    'evasion',
+    'block',
+    'parry',
+    'sword',
+    'polearm',
+    'axe',
+    'staff',
+    'marksmanship',
+    'mage',
+    'dagger',
+    'shield',
+    'lightArmor',
+    'mediumArmor',
+    'heavyArmor',
+    'dualWield'
+  ],
+  'Non Combat': ['singing', 'instrument', 'dancing']
+};
+
 const saveProfiles = () => localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles));
 
 const formatHeight = cm => {
@@ -177,6 +206,23 @@ function showCharacterUI() {
       showCharacterUI();
     });
   });
+}
+
+function showProficienciesUI() {
+  if (!currentCharacter) return;
+  showBackButton();
+  let html = '<div class="no-character"><h1>Proficiencies</h1>';
+  for (const [type, list] of Object.entries(proficiencyCategories)) {
+    html += `<h2>${type}</h2><ul>`;
+    list.forEach(key => {
+      const value = currentCharacter[key] ?? 0;
+      const name = key.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase());
+      html += `<li>${name}: ${value}</li>`;
+    });
+    html += '</ul>';
+  }
+  html += '</div>';
+  main.innerHTML = html;
 }
 
 function startCharacterCreation() {
@@ -528,6 +574,8 @@ characterMenu.addEventListener('click', e => {
   characterMenu.classList.remove('active');
   if (action === 'profile') {
     showCharacterUI();
+  } else if (action === 'proficiencies') {
+    showProficienciesUI();
   } else {
     showBackButton();
     main.innerHTML = `<div class="no-character"><h1>${action} not implemented</h1></div>`;


### PR DESCRIPTION
## Summary
- Add proficiencies option to character menu that displays grouped proficiency values
- Replace quest icon with a papyrus-style scroll SVG

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a64f1d49708325b7d97e0a94485377