### PR TITLE
Add character selection menu and improve menu styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,10 +24,11 @@
 </nav>
 
 <div id="dropdownMenu">
-  <button data-action="new-character">New Character</button>
-  <button data-action="map">Map</button>
-  <button data-action="settings">Settings</button>
-</div>
+    <button data-action="character-select">Character Select</button>
+    <button data-action="new-character">New Character</button>
+    <button data-action="map">Map</button>
+    <button data-action="settings">Settings</button>
+  </div>
 
 <div id="characterMenu">
   <button data-action="profile">

--- a/script.js
+++ b/script.js
@@ -174,6 +174,33 @@ function showNoCharacterUI() {
   document.getElementById('new-character').addEventListener('click', startCharacterCreation);
 }
 
+function showCharacterSelectUI() {
+  showBackButton();
+  const characters = currentProfile?.characters || {};
+  const ids = Object.keys(characters);
+  let html = '<div class="no-character"><h1>Select Character</h1><div class="option-grid">';
+  if (ids.length === 0) {
+    html += '<p>No characters available</p>';
+  } else {
+    ids.forEach(id => {
+      const c = characters[id];
+      const cls = currentCharacter && currentCharacter.id === id ? 'selected' : '';
+      html += `<button data-id="${id}" class="${cls}">${c.name}</button>`;
+    });
+  }
+  html += '</div></div>';
+  main.innerHTML = html;
+  main.querySelectorAll('.option-grid button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.dataset.id;
+      currentProfile.lastCharacter = id;
+      currentCharacter = { ...defaultProficiencies, ...currentProfile.characters[id] };
+      saveProfiles();
+      showMainUI();
+    });
+  });
+}
+
 function showMainUI() {
   if (currentCharacter) {
     showCharacter();
@@ -562,6 +589,8 @@ dropdownMenu.addEventListener('click', e => {
   dropdownMenu.classList.remove('active');
   if (action === 'new-character') {
     startCharacterCreation();
+  } else if (action === 'character-select') {
+    showCharacterSelectUI();
   } else {
     showBackButton();
     main.innerHTML = `<div class="no-character"><h1>${action} not implemented</h1></div>`;

--- a/style.css
+++ b/style.css
@@ -82,6 +82,7 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-size: 1rem;
+  position: relative;
 }
 
 #characterMenu {
@@ -113,6 +114,26 @@ body {
   color: var(--foreground);
   font-size: 1rem;
   text-align: left;
+  position: relative;
+}
+
+#dropdownMenu button:hover,
+#dropdownMenu button.selected,
+#characterMenu button:hover,
+#characterMenu button.selected {
+  background: var(--foreground);
+  color: var(--background);
+}
+
+#dropdownMenu button:not(:last-child)::after,
+#characterMenu button:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -0.25rem;
+  height: 1px;
+  background: linear-gradient(to right, var(--background), var(--foreground) 50%, var(--background));
 }
 
 #characterMenu button svg,
@@ -335,6 +356,11 @@ body.theme-dark {
     cursor: pointer;
     width: 100%;
     box-sizing: border-box;
+  }
+
+  .option-grid button:hover {
+    background: var(--foreground);
+    color: var(--background);
   }
 
   .option-grid button.selected {


### PR DESCRIPTION
## Summary
- Highlight dropdown and character menu items with reverse color hover/selected states and gradient separators.
- Introduce a Character Select entry in the main menu and dedicated UI for choosing active characters.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a73bf7854c8325bf107c2e43a4cc8f