### PR TITLE
Expand magic proficiencies and add gain function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ No build steps are required. After publishing the repository with GitHub Pages, 
 - `index.html` – entry point for the game UI
 - `style.css` – basic styles and themes
 - `script.js` – behaviour for the menu and layout controls
+  and core mechanics such as proficiency gain
 - `assets/images/` – image assets
 - `assets/data/` – data assets
 
 Additional functionality will be added over time.
+
+### Magical Proficiencies
+
+Characters now track separate proficiencies for Stone, Water, Wind, Fire, Ice, Thunder, Dark, Light, Destructive, Healing, Reinforcement, Enfeebling and Summoning magic. The `gainProficiencyWithChance` function in `script.js` calculates how these values increase when spells are cast.


### PR DESCRIPTION
## Summary
- Replace generic elemental proficiency with specific Stone, Water, Wind, Fire, Ice, Thunder, Dark, and Light proficiencies
- Introduce Destructive and Healing magic proficiencies and hook them into gain calculations
- Implement `gainProficiencyWithChance` and `applySpellProficiencyGain` to update relevant proficiencies when spells are cast
- Document new magic proficiencies in README

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68a751180de0832584a98f4899d94fc7