### PR TITLE
Add background image generation and improved portrait controls

### DIFF
--- a/style.css
+++ b/style.css
@@ -281,9 +281,34 @@ body.theme-dark {
 
   .portrait-wrapper {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     align-items: center;
     gap: 0.5rem;
+  }
+
+  .icon-button {
+    width: 2rem;
+    height: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--foreground);
+    background: var(--background);
+    color: var(--foreground);
+    cursor: pointer;
+  }
+
+  .icon-button:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .icon-button svg {
+    width: 1.5rem;
+    height: 1.5rem;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 2;
   }
 
   .character-creation {


### PR DESCRIPTION
## Summary
- Add `generateCharacterImage` to build full-body prompts with character location and fetch images in the background
- Introduce icon-based portrait regeneration workflow with preview, download, and apply steps
- Style portrait area with inline icon buttons and disable state while generating

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a76a2a0d288325be127eaf15839eaf