### PR TITLE
Add settings toggle and dynamic proficiency layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,17 +17,26 @@
       <path d="M4 20c0-4 4-6 8-6s8 2 8 6" />
     </svg>
   </button>
-  <button id="theme-toggle" aria-label="Toggle theme"></button>
-  <button id="layout-toggle" aria-label="Toggle layout"></button>
-  <button id="scale-dec" aria-label="Decrease UI size">-</button>
-  <button id="scale-inc" aria-label="Increase UI size">+</button>
+  <div class="settings-group">
+    <button id="settings-button" aria-label="Settings">
+      <svg viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="3" />
+        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9A1.65 1.65 0 0 0 10.51 3.09V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9A1.65 1.65 0 0 0 20.91 10.51H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+      </svg>
+    </button>
+    <div id="settings-panel">
+      <button id="theme-toggle" aria-label="Toggle theme"></button>
+      <button id="layout-toggle" aria-label="Toggle layout"></button>
+      <button id="scale-dec" aria-label="Decrease UI size">-</button>
+      <button id="scale-inc" aria-label="Increase UI size">+</button>
+    </div>
+  </div>
 </nav>
 
 <div id="dropdownMenu">
     <button data-action="character-select">Character Select</button>
     <button data-action="new-character">New Character</button>
     <button data-action="map">Map</button>
-    <button data-action="settings">Settings</button>
   </div>
 
 <div id="characterMenu">

--- a/script.js
+++ b/script.js
@@ -77,8 +77,9 @@ const defaultProficiencies = {
   axe: 0,
   greataxe: 0,
   staff: 0,
-  marksmanship: 0,
+  bow: 0,
   crossbow: 0,
+  martial: 0,
   wand: 0,
   dagger: 0,
   shield: 0,
@@ -92,6 +93,10 @@ function migrateProficiencies(character) {
   if ('mage' in character && !('wand' in character)) {
     character.wand = character.mage;
     delete character.mage;
+  }
+  if ('marksmanship' in character && !('bow' in character)) {
+    character.bow = character.marksmanship;
+    delete character.marksmanship;
   }
   return character;
 }
@@ -122,8 +127,9 @@ const proficiencyCategories = {
     'axe',
     'greataxe',
     'staff',
-    'marksmanship',
+    'bow',
     'crossbow',
+    'martial',
     'wand',
     'dagger',
     'shield',
@@ -406,15 +412,16 @@ function showCharacterUI() {
 function showProficienciesUI() {
   if (!currentCharacter) return;
   showBackButton();
-  let html = '<div class="no-character"><h1>Proficiencies</h1>';
+  let html = '<div class="proficiencies-screen"><h1>Proficiencies</h1>';
   for (const [type, list] of Object.entries(proficiencyCategories)) {
-    html += `<h2>${type}</h2><ul>`;
+    html += `<h2>${type}</h2><div class="proficiency-grid">`;
     list.forEach(key => {
       const value = currentCharacter[key] ?? 0;
       const name = key.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase());
-      html += `<li>${name}: ${value}</li>`;
+      const capped = value >= 100 ? ' capped' : '';
+      html += `<div class="proficiency-item"><span class="proficiency-name">${name}</span><span class="proficiency-value${capped}">${value}</span></div>`;
     });
-    html += '</ul>';
+    html += '</div>';
   }
   html += '</div>';
   main.innerHTML = html;
@@ -685,6 +692,12 @@ function loadPreferences() {
   updateScale();
   setLayout(currentLayoutIndex);
 }
+
+const settingsButton = document.getElementById('settings-button');
+const settingsPanel = document.getElementById('settings-panel');
+settingsButton.addEventListener('click', () => {
+  settingsPanel.classList.toggle('active');
+});
 
 // Theme toggle
 const themeToggle = document.getElementById('theme-toggle');

--- a/style.css
+++ b/style.css
@@ -6,6 +6,7 @@
   --menu-color-dark: #333333;
   --menu-color-light: #333333;
   --range-color: #555555;
+  --capped-color: #2e8b57;
 }
 
 html {
@@ -54,6 +55,40 @@ body {
   stroke: currentColor;
   fill: none;
   stroke-width: 2;
+}
+
+.settings-group {
+  display: flex;
+  gap: 0.5rem;
+}
+
+#settings-panel {
+  display: flex;
+  gap: 0.5rem;
+  overflow: hidden;
+  max-width: 0;
+  max-height: 0;
+  transition: max-width 0.3s ease, max-height 0.3s ease;
+}
+
+body.layout-landscape #settings-panel,
+body.layout-auto #settings-panel {
+  flex-direction: row;
+}
+
+body.layout-portrait #settings-panel {
+  flex-direction: column;
+}
+
+body.layout-landscape #settings-panel.active,
+body.layout-auto #settings-panel.active {
+  max-width: 12rem;
+  max-height: 3rem;
+}
+
+body.layout-portrait #settings-panel.active {
+  max-width: 3rem;
+  max-height: 12rem;
 }
 
 #dropdownMenu {
@@ -236,6 +271,7 @@ body.theme-light {
   --menu-color-dark: #333333;
   --menu-color-light: #333333;
   --range-color: #555555;
+  --capped-color: #2e8b57;
 }
 
 body.theme-sepia {
@@ -244,6 +280,7 @@ body.theme-sepia {
   --menu-color-dark: #4a3b2d;
   --menu-color-light: #4a3b2d;
   --range-color: #4a3b2d;
+  --capped-color: #1e90ff;
 }
 
 body.theme-dark {
@@ -252,6 +289,7 @@ body.theme-dark {
   --menu-color-dark: #cccccc;
   --menu-color-light: #cccccc;
   --range-color: #aaaaaa;
+  --capped-color: #9370db;
 }
 
 .progress {
@@ -438,6 +476,31 @@ body.theme-dark {
     accent-color: var(--range-color);
   }
 
+.proficiency-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 0.5rem 1rem;
+  width: 100%;
+}
+
+.proficiency-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.proficiency-name {
+  text-align: left;
+}
+
+.proficiency-value {
+  text-align: right;
+}
+
+.proficiency-value.capped {
+  color: var(--capped-color);
+}
+
 /* Orientation layouts */
 body.layout-landscape .top-menu {
   flex-direction: row;
@@ -471,6 +534,13 @@ body.layout-portrait main {
     margin-top: 0;
     margin-left: 3.5rem;
   }
+  body.layout-auto #settings-panel {
+    flex-direction: column;
+  }
+  body.layout-auto #settings-panel.active {
+    max-width: 3rem;
+    max-height: 12rem;
+  }
 }
 
 @media (orientation: landscape) {
@@ -482,5 +552,12 @@ body.layout-portrait main {
   body.layout-auto main {
     margin-top: 4rem;
     margin-left: 0;
+  }
+  body.layout-auto #settings-panel {
+    flex-direction: row;
+  }
+  body.layout-auto #settings-panel.active {
+    max-width: 12rem;
+    max-height: 3rem;
   }
 }


### PR DESCRIPTION
## Summary
- Replace marksmanship with bow proficiency and add martial proficiency
- Introduce settings gear in persistent menu to reveal theme, layout and scale controls
- Revamp proficiency screen with responsive two-column layout and highlight capped values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a77b291be48325a85e31d05ac47b4e