### PR TITLE
Display resource stats on character pages

### DIFF
--- a/style.css
+++ b/style.css
@@ -335,6 +335,39 @@ body.theme-dark {
     stroke-width: 2;
   }
 
+  .resource-bar {
+    width: 10rem;
+    height: 1rem;
+    border: 1px solid var(--foreground);
+    background: var(--background);
+    margin: 0.25rem 0;
+    overflow: hidden;
+  }
+
+  .resource-bar .fill {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    white-space: nowrap;
+  }
+
+  .resource-bar.hp .fill {
+    background: #e74c3c;
+    color: #00ffff;
+  }
+
+  .resource-bar.mp .fill {
+    background: #3498db;
+    color: #ffff00;
+  }
+
+  .resource-bar.stamina .fill {
+    background: #9acd32;
+    color: #6532cd;
+  }
+
   .character-creation {
     display: flex;
     align-items: flex-start;


### PR DESCRIPTION
## Summary
- show starting HP/MP/Stamina during character creation
- initialize HP/MP/Stamina for new characters
- add colored resource bars to character profile

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a7d6f5b204832584050b29e1992789