### PR TITLE
Add dance proficiency progression system

### DIFF
--- a/dance_proficiency.ts
+++ b/dance_proficiency.ts
@@ -1,0 +1,228 @@
+// dance_proficiency.ts — proficiency gains for Dances (TS/JS compatible)
+
+const r2 = (x: number) => Math.round(x * 100) / 100;
+
+export type Context = "practice" | "spar" | "battle";
+export type PerfOutcome = "success" | "partial" | "fail";
+
+/** One call per “dance tick” (e.g., every 3–5s of maintained dancing) or per finished dance. */
+export interface DanceGainInput {
+  P: number;                 // current proficiency (2-dec)
+  cap: number;               // current cap (rounded int elsewhere)
+  actorLevel: number;
+  enemyLevelAvg: number;     // avg enemy/instructor level in scene
+  context: Context;          // practice | spar | battle
+  outcome: PerfOutcome;      // success|partial|fail for this tick or end event
+  // Maintenance:
+  maintainedSec: number;     // seconds danced during this event (e.g., 3..10). If 0, treat as instant cast.
+  isStopEvent: boolean;      // true only on the frame the dancer stops; grants small consolidation bonus
+  // Anti-spam / variety:
+  N_same: number;            // consecutive uses of the same dance id
+  recentDanceIds: string[];  // last N dance ids used (most recent last)
+  // Scale with useful coverage:
+  alliesAffected: number;    // meaningful allies actually affected (AoE value)
+  enemiesPressuring: number; // number of hostile units pressuring the dancer (close or targeting)
+  // Unlock tiers for choke near thresholds:
+  thresholds: number[];      // e.g. [10,20,30,40,50,60,70,80,90,100]
+}
+
+export interface DanceProgressionConfig {
+  // Base scalar (dances are hard but a bit more generous than instrument per second of real uptime)
+  g0: number;                 // base gain per “normalized tick” before gates
+  // Context weights
+  contextWeight: Record<Context, number>;
+  // Level factor (equal-level gives small; higher-level ramps)
+  levelFloorEqual: number;    // at Δ=0
+  levelSlope: number;         // per level above actor
+  levelCap: number;
+  // Maintenance / uptime scaling
+  secNorm: number;            // seconds that count as one normalized “tick” of learning
+  uptimeK: number;            // diminishing return curve for very long uptime
+  // Crowd/pressure factors
+  crowdK: number;             // alliesAffected contribution
+  crowdMax: number;
+  pressureK: number;          // enemiesPressuring contribution
+  pressureMax: number;
+  // Repetition & variety
+  minRepeatFactor: number;    // floor for repetition decay
+  varietyMaxBonus: number;
+  varietyWindow: number;
+  varietyTargetDistinct: number;
+  // Unlock choke & cap taper
+  postUnlockChoke: number;
+  unlockWindow: number;
+  capSoftenerK: number;
+  // Outcome weights
+  outcomeWeight: Record<PerfOutcome, number>;
+  // Stop-event consolidation (tiny bonus at the moment dancing stops)
+  stopBonus: number;          // flat multiplier on raw delta if isStopEvent=true
+  // Chance gate (keep these the slowest to master)
+  tauLow: number;
+  tauHigh: number;
+  pSmallMin: number;
+  // RNG
+  rng: () => number;
+}
+
+export const DANCE_CFG: DanceProgressionConfig = {
+  g0: 0.075,
+  contextWeight: { practice: 0.25, spar: 0.75, battle: 1.0 },
+  levelFloorEqual: 0.30,
+  levelSlope: 0.11,
+  levelCap: 1.0,
+
+  secNorm: 4,         // every ~4s of real maintained dancing ≈ one learning unit
+  uptimeK: 0.6,       // diminishing returns exponent on uptime factor
+
+  crowdK: 0.08, crowdMax: 1.30,
+  pressureK: 0.10, pressureMax: 1.35,
+
+  minRepeatFactor: 0.45,
+  varietyMaxBonus: 0.25, varietyWindow: 10, varietyTargetDistinct: 4,
+
+  postUnlockChoke: 0.35, unlockWindow: 8.0,
+  capSoftenerK: 0.9,
+
+  outcomeWeight: { success: 1.0, partial: 0.35, fail: 0.0 },
+
+  stopBonus: 0.12,    // small extra nudge when the dancer ends a sequence cleanly
+
+  tauLow: 0.018, tauHigh: 0.055, pSmallMin: 0.12,
+  rng: () => Math.random(),
+};
+
+/* ========================= Internal helpers ========================= */
+
+function levelFactor(actorL: number, enemyL: number, cfg: DanceProgressionConfig): number {
+  const d = enemyL - actorL;
+  if (d < -1) return 0.05; // trivial content
+  if (d <= 0) return cfg.levelFloorEqual;
+  return Math.min(cfg.levelCap, cfg.levelFloorEqual + cfg.levelSlope * d);
+}
+
+function repeatFactor(N_same: number, cfg: DanceProgressionConfig): number {
+  if (N_same <= 0) return 1;
+  const f = 1 / (1 + Math.log(1 + N_same));
+  return Math.max(cfg.minRepeatFactor, f);
+}
+
+function varietyFactor(ids: string[], cfg: DanceProgressionConfig): number {
+  if (!ids?.length) return 1;
+  const slice = ids.slice(-cfg.varietyWindow);
+  const distinct = new Set(slice).size;
+  const t = Math.min(1, distinct / cfg.varietyTargetDistinct);
+  return 1 + cfg.varietyMaxBonus * t;
+}
+
+function thresholdChoke(P: number, thresholds: number[], cfg: DanceProgressionConfig): number {
+  for (const t of thresholds) if (P >= t && P <= t + cfg.unlockWindow) return cfg.postUnlockChoke;
+  return 1.0;
+}
+
+function capGapFactor(P: number, cap: number, cfg: DanceProgressionConfig): number {
+  if (cap <= 0) return 0;
+  const gap = Math.max(0, cap - P);
+  return Math.pow(gap / cap, cfg.capSoftenerK);
+}
+
+function crowdFactor(nAllies: number, cfg: DanceProgressionConfig): number {
+  return Math.min(cfg.crowdMax, 1 + cfg.crowdK * Math.max(0, nAllies - 1));
+}
+
+function pressureFactor(nEnemies: number, cfg: DanceProgressionConfig): number {
+  return Math.min(cfg.pressureMax, 1 + cfg.pressureK * Math.max(0, nEnemies - 0));
+}
+
+/** Convert uptime seconds into a normalized factor with diminishing returns. */
+function uptimeFactor(maintainedSec: number, cfg: DanceProgressionConfig): number {
+  if (maintainedSec <= 0) return 1; // instant pulse dances still give a tiny signal
+  const units = maintainedSec / cfg.secNorm;      // how many “ticks” worth of practice
+  return Math.pow(units, cfg.uptimeK);            // diminishing returns for very long holds
+}
+
+/* ========================= Main progression ========================= */
+
+/** Compute next Dance proficiency (2 decimals).
+ *  Call this:
+ *   - once per active “tick” while the dancer maintains (e.g., every 3–5s), OR
+ *   - once when they stop (isStopEvent=true) to apply a small consolidation bonus.
+ */
+export function gainDanceProficiency(input: DanceGainInput, cfg: DanceProgressionConfig = DANCE_CFG): number {
+  const {
+    P, cap, actorLevel, enemyLevelAvg, context, outcome,
+    maintainedSec, isStopEvent, N_same, recentDanceIds,
+    alliesAffected, enemiesPressuring, thresholds
+  } = input;
+
+  // Basic eligibility & outcome
+  const W_ctx = cfg.contextWeight[context];
+  if (W_ctx <= 0 || outcome === "fail") return r2(P);
+
+  // Build multipliers
+  const F_level    = levelFactor(actorLevel, enemyLevelAvg, cfg);
+  const F_repeat   = repeatFactor(N_same, cfg);
+  const F_variety  = varietyFactor(recentDanceIds, cfg);
+  const F_unlock   = thresholdChoke(P, thresholds, cfg);
+  const F_cap      = capGapFactor(P, cap, cfg);
+  const F_crowd    = crowdFactor(alliesAffected, cfg);
+  const F_pressure = pressureFactor(enemiesPressuring, cfg);
+  const F_uptime   = uptimeFactor(maintainedSec, cfg);
+  const W_outcome  = cfg.outcomeWeight[outcome];
+
+  // Raw deterministic delta (pre-gate)
+  let raw = cfg.g0
+          * W_ctx
+          * F_level
+          * F_repeat
+          * F_variety
+          * F_unlock
+          * F_cap
+          * F_crowd
+          * F_pressure
+          * F_uptime
+          * W_outcome;
+
+  // End-of-dance consolidation (very small nudge)
+  if (isStopEvent) raw *= (1 + cfg.stopBonus);
+
+  const Δ = Math.min(raw, Math.max(0, cap - P));
+  if (Δ <= 0) return r2(P);
+
+  // Strict chance gate — keeps progression slow & eventful
+  let pGain: number;
+  if (Δ >= cfg.tauHigh) pGain = 1.0;
+  else if (Δ <= cfg.tauLow) pGain = cfg.pSmallMin;
+  else {
+    const t = (Δ - cfg.tauLow) / (cfg.tauHigh - cfg.tauLow);
+    pGain = cfg.pSmallMin + (1 - cfg.pSmallMin) * t;
+  }
+
+  return (cfg.rng() < pGain) ? r2(P + Δ) : r2(P);
+}
+
+/* ========================= Example usage =========================
+import { gainDanceProficiency } from "./dance_proficiency";
+
+// Maintain a dance for ~6s during battle vs slightly higher-level enemies:
+let P = 24.17, cap = 54;
+P = gainDanceProficiency({
+  P, cap,
+  actorLevel: 12, enemyLevelAvg: 13,
+  context: "battle", outcome: "success",
+  maintainedSec: 6, isStopEvent: false,
+  N_same: 1, recentDanceIds: ["BUFF_DN:02","CTRL_DN:03"],
+  alliesAffected: 4, enemiesPressuring: 2,
+  thresholds: [10,20,30,40,50,60,70,80,90,100]
+});
+
+// When the dancer stops, call once more with a stop-event:
+P = gainDanceProficiency({
+  P, cap,
+  actorLevel: 12, enemyLevelAvg: 13,
+  context: "battle", outcome: "success",
+  maintainedSec: 0, isStopEvent: true,
+  N_same: 1, recentDanceIds: ["BUFF_DN:02","CTRL_DN:03"],
+  alliesAffected: 4, enemiesPressuring: 2,
+  thresholds: [10,20,30,40,50,60,70,80,90,100]
+});
+------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- add dance proficiency progression with configurable multipliers and chance gating

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ed92a03883259ec9c906a1981989