### PR TITLE
Implement party growth and enemy template

### DIFF
--- a/enemy.ts
+++ b/enemy.ts
@@ -1,0 +1,30 @@
+import { AttrBlock, Member, maxHP, maxMP, maxStamina, recomputeResources, makeMember } from "./party";
+
+export interface Enemy extends Member {
+  xpYield?: number;
+}
+
+export function makeEnemy(params: {
+  id: string; name: string; level: number; race?: string;
+  startingAttributes: AttrBlock; currentAttributes?: Partial<AttrBlock>;
+  role?: Member["role"]; xpYield?: number;
+}): Enemy {
+  const enemy = makeMember({
+    ...params,
+    isPlayer: false,
+    isNPC: true,
+    controllable: false,
+  }) as Enemy;
+  enemy.faction = "enemy";
+  enemy.xpYield = params.xpYield;
+  return enemy;
+}
+
+/** Recalculate enemy resource maximums and clamp current values. */
+export function recomputeEnemyResources(e: Enemy): void {
+  recomputeResources(e);
+}
+
+export const enemyMaxHP = (vit: number, level: number) => maxHP(vit, level);
+export const enemyMaxMP = (wis: number, level: number) => maxMP(wis, level);
+export const enemyMaxStamina = (con: number, level: number) => maxStamina(con, level);


### PR DESCRIPTION
## Summary
- track automatic attribute growth for party members and apply it on level-up
- add reusable enemy template with resource calculation helpers

## Testing
- `npx tsc --allowJs --noEmit --lib es2016,dom party.ts enemy.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a7fdc66dbc8325933c77b924e205a4