### PR TITLE
Add comprehensive combat calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ No build steps are required. After publishing the repository with GitHub Pages, 
   and core mechanics such as proficiency gain
 - `weapon_skills.js` – weapon skill data and effects
 - `resources.js` – dynamic HP/MP/Stamina calculations based on stats
+- `combat.ts` – single function to resolve combat, accounting for level, attributes, proficiencies and active skill effects
 - `party.ts` – party structs, resources, effects, and NPC proficiency policy
 - `assets/images/` – image assets
 - `assets/data/` – data assets

--- a/combat.ts
+++ b/combat.ts
@@ -1,0 +1,132 @@
+import { WEAPON_SKILLS } from "./weapon_skills.js";
+import { SPELLBOOK } from "./spells.js";
+
+export interface Actor {
+  level: number;
+  attributes: Record<string, number>; // STR, DEX, CON, VIT, AGI, INT, WIS, CHA
+  proficiencies: Record<string, number>; // weapon, magic, non-combat etc
+  defense?: number; // optional flat defense
+  resistances?: Record<string, number>; // element -> percent
+}
+
+export interface CombatResult {
+  damage: number;
+  hitChance: number;
+  evasionChance: number;
+  blockChance: number;
+  resistMultiplier: number;
+}
+
+export interface CombatOptions {
+  attackId: string; // id in WEAPON_SKILLS or SPELLBOOK
+  attackType: "weapon" | "spell";
+  attackerEffects?: Record<string, number>[]; // modifiers from songs/dances/instruments
+  defenderEffects?: Record<string, number>[];
+}
+
+const elementProfKey: Record<string, string> = {
+  Stone: "stoneMagic",
+  Water: "waterMagic",
+  Wind: "windMagic",
+  Fire: "fireMagic",
+  Ice: "iceMagic",
+  Thunder: "thunderMagic",
+  Dark: "darkMagic",
+  Light: "lightMagic",
+};
+
+function clamp(x: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, x));
+}
+
+function aggregateEffects(effects: Record<string, number>[] = []) {
+  const mods: Record<string, number> = {};
+  for (const e of effects) {
+    for (const k in e) {
+      if (Object.prototype.hasOwnProperty.call(e, k)) {
+        mods[k] = (mods[k] || 0) + (e as any)[k];
+      }
+    }
+  }
+  return mods;
+}
+
+
+function proficiencyForSkill(actor: Actor, skill: any, type: "weapon" | "spell") {
+  if (type === "weapon") {
+    const key = skill.weapon?.toLowerCase();
+    return actor.proficiencies[key] || 0;
+  }
+  const key = elementProfKey[skill.element] || "";
+  return actor.proficiencies[key] || 0;
+}
+
+function nonCombatBonus(actor: Actor, kind: "offense" | "defense" | "evasion") {
+  const { singing = 0, instrument = 0, dancing = 0 } = actor.proficiencies;
+  if (kind === "evasion") return 1 + dancing * 0.001;
+  const sum = singing + instrument + (kind === "offense" ? dancing : 0);
+  return 1 + sum * 0.001;
+}
+
+export function calculateCombat(attacker: Actor, defender: Actor, opts: CombatOptions): CombatResult {
+  const skillList = opts.attackType === "weapon" ? WEAPON_SKILLS : SPELLBOOK;
+  const skill = skillList.find((s: any) => s.id === opts.attackId);
+  if (!skill) throw new Error("Unknown attack id");
+
+  const atkProf = proficiencyForSkill(attacker, skill, opts.attackType);
+  const defEvasion = defender.proficiencies.evasion || 0;
+  const defBlock = defender.proficiencies.block || 0;
+
+  const atkMods = aggregateEffects(opts.attackerEffects);
+  const defMods = aggregateEffects(opts.defenderEffects);
+
+  const keyAttr = skill.keyAttribute || (opts.attackType === "spell" ? "INT" : "STR");
+  const secAttr = skill.secondaryAttribute;
+  const keyVal = attacker.attributes[keyAttr] || 0;
+  const secVal = secAttr ? attacker.attributes[secAttr] || 0 : 0;
+  const attrScale = keyVal + secVal * 0.5;
+
+  const levelFactor = clamp(1 + (attacker.level - defender.level) * 0.05, 0.5, 1.5);
+  const profFactor = 1 + atkProf / 100;
+  const offenseBonus = nonCombatBonus(attacker, "offense") * (1 + (atkMods.ATK_PCT || 0) / 100);
+  let baseDamage = skill.basePower * attrScale * profFactor * offenseBonus * levelFactor;
+
+  const defenseBase = defender.defense || (defender.attributes.CON + defender.attributes.VIT);
+  const defenseBonus = nonCombatBonus(defender, "defense") * (1 + (defMods.DEF_PCT || 0) / 100);
+  const damageAfterDefense = Math.max(0, baseDamage - defenseBase * defenseBonus);
+
+  const isMagic = opts.attackType === "spell" || skill.family === "control" || skill.element;
+  const resistAttr = isMagic ? defender.attributes.INT : (defender.attributes.CON + defender.attributes.VIT) / 2;
+  const attackerAttr = isMagic ? attacker.attributes.INT : attacker.attributes.STR;
+  const resistFromAttr = resistAttr / (resistAttr + attackerAttr + 1);
+  const elementResist = (defender.resistances?.[skill.element] || 0) / 100;
+  const dmgTakenMod = 1 + (defMods.DMG_TAKEN_PCT || 0) / 100;
+  const totalResist = clamp(resistFromAttr + elementResist, 0, 0.8);
+  const damageAfterResist = damageAfterDefense * (1 - totalResist) * dmgTakenMod;
+
+  const evasionChance = clamp(
+    (0.1 + (defender.attributes.AGI - attacker.attributes.DEX) * 0.005 +
+      (defEvasion - atkProf) * 0.002 + (defender.level - attacker.level) * 0.01) *
+      nonCombatBonus(defender, "evasion") * (1 + (defMods.EVADE_PCT || 0) / 100),
+    0,
+    0.95
+  );
+
+  const blockChance = clamp(
+    0.05 +
+      defBlock * 0.002 +
+      (defender.attributes.CON + defender.attributes.VIT - attacker.attributes.STR) * 0.002 +
+      (defender.level - attacker.level) * 0.01,
+    0,
+    0.8
+  );
+
+  const finalDamage = damageAfterResist * (1 - blockChance * 0.5);
+  return {
+    damage: Math.round(finalDamage * 100) / 100,
+    hitChance: Math.round((1 - evasionChance) * 1000) / 1000,
+    evasionChance: Math.round(evasionChance * 1000) / 1000,
+    blockChance: Math.round(blockChance * 1000) / 1000,
+    resistMultiplier: Math.round((1 - totalResist) * 1000) / 1000,
+  };
+}


### PR DESCRIPTION
## Summary
- introduce `calculateCombat` to compute damage, hit, evasion and block using level, attributes, proficiencies and active skill effects
- factor in resistances from key attributes and elemental resists
- document new combat resolver in README

## Testing
- `npx tsc --noEmit combat.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a7fff22d0c8325a168c5ea66f1abff