### PR TITLE
Display XP and handle magic aptitudes at creation

### DIFF
--- a/style.css
+++ b/style.css
@@ -342,15 +342,18 @@ body.theme-dark {
     background: var(--background);
     margin: 0.25rem 0;
     overflow: hidden;
+    position: relative;
   }
 
   .resource-bar .fill {
     height: 100%;
+    width: 0;
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 0.75rem;
     white-space: nowrap;
+    box-sizing: border-box;
   }
 
   .resource-bar.hp .fill {
@@ -366,6 +369,10 @@ body.theme-dark {
   .resource-bar.stamina .fill {
     background: #9acd32;
     color: #6532cd;
+  }
+
+  .xp-display {
+    margin-top: 0.25rem;
   }
 
   .character-creation {


### PR DESCRIPTION
## Summary
- show current and next-level XP on the profile screen
- fix resource bars so HP, MP and Stamina render correctly
- add random magic aptitude assignment during character creation

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68a81da163188325a96d01b42aa900b6