### PR TITLE
Improve character creation layout and race visuals

### DIFF
--- a/style.css
+++ b/style.css
@@ -428,23 +428,56 @@ body.theme-dark {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-  }
-
-.option-grid {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
     width: 100%;
   }
 
+  .cc-top {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    width: 100%;
+  }
+
+  .cc-options,
+  .race-stats {
+    flex: 1 1 15rem;
+  }
+
+  .race-stats ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .race-stats ul + ul {
+    margin-top: 0.5rem;
+  }
+
+  .race-image {
+    width: 100%;
+    height: auto;
+    margin-top: 1rem;
+  }
+
+  .race-description {
+    margin-top: 0.5rem;
+  }
+
+  .option-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: flex-start;
+  }
+
   .option-grid button {
-    padding: 0.5rem 1rem;
+    padding: 0.5rem;
     border: 2px solid var(--foreground);
     background: var(--background);
     color: var(--foreground);
     cursor: pointer;
-    width: 100%;
     box-sizing: border-box;
+    white-space: nowrap;
   }
 
   .option-grid button:hover {


### PR DESCRIPTION
## Summary
- Split character creation into responsive columns for options and stats
- Add race images and move descriptions below them
- Normalize option button widths and separate resource stats

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx tsc --noEmit`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8925765d88325ad71c90a3d33526e