### PR TITLE
Adjust character creation layout and enforce orientation

### DIFF
--- a/script.js
+++ b/script.js
@@ -843,6 +843,15 @@ const setLayout = index => {
   body.classList.add(`layout-${layout}`);
   layoutToggle.innerHTML = layoutIcons[layout];
   savePreference('layout', layout);
+  if (screen.orientation) {
+    if (layout === 'landscape') {
+      screen.orientation.lock('landscape').catch(() => {});
+    } else if (layout === 'portrait') {
+      screen.orientation.lock('portrait').catch(() => {});
+    } else if (screen.orientation.unlock) {
+      screen.orientation.unlock();
+    }
+  }
 };
 layoutToggle.addEventListener('click', () => {
   currentLayoutIndex = (currentLayoutIndex + 1) % layouts.length;

--- a/style.css
+++ b/style.css
@@ -428,25 +428,30 @@ body.theme-dark {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    width: 100%;
+    width: fit-content;
   }
 
   .cc-top {
     display: flex;
     flex-wrap: wrap;
-    gap: 1rem;
-    width: 100%;
+    gap: 0.5rem;
+    width: fit-content;
   }
 
   .cc-options,
   .race-stats {
-    flex: 1 1 15rem;
+    flex: 0 0 auto;
+    width: fit-content;
   }
 
   .race-stats ul {
     list-style: none;
     padding: 0;
     margin: 0;
+  }
+
+  .race-stats li {
+    white-space: nowrap;
   }
 
   .race-stats ul + ul {


### PR DESCRIPTION
## Summary
- Resize character creation columns to fit content with no wrapping and minimal margins while images scale accordingly.
- Lock screen orientation when toggling layout between landscape, portrait, and auto modes.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8973d7b28832589016831c1f76cfb