### PR TITLE
refactor: centralize equipment slot definitions

### DIFF
--- a/core.js
+++ b/core.js
@@ -1,5 +1,7 @@
 // Core game constants, enums, templates and helper functions
 
+import { createEmptyEquipment } from "./equipment.js";
+
 // ---- Global Tunables & Tables ----
 export const PROF_MILESTONES = [10,20,30,40,50,60,70,80,90,100];
 export const RACIAL_START_MULTIPLIER = {};
@@ -200,14 +202,7 @@ export const characterTemplate = {
     unlockHistory: {},
     varietyBuffer: {}
   },
-  equipment: {
-    mainHand: null,
-    offHand: null,
-    ranged: null,
-    ammo: null,
-    armor: null,
-    trinkets: []
-  },
+  equipment: createEmptyEquipment(),
   status: {
     activeEffects: [],
     cooldowns: {},

--- a/equipment.d.ts
+++ b/equipment.d.ts
@@ -1,0 +1,35 @@
+export type WeaponSlot =
+  | "mainHand"
+  | "offHand"
+  | "ranged"
+  | "instrument"
+  | "ammo";
+
+export type ArmorSlot =
+  | "head"
+  | "body"
+  | "back"
+  | "hands"
+  | "waist"
+  | "legs"
+  | "feet";
+
+export type TrinketSlot =
+  | "lEar"
+  | "rEar"
+  | "neck"
+  | "lRing"
+  | "rRing"
+  | "pouch";
+
+export interface Equipment {
+  weapons: Record<WeaponSlot, string | null>;
+  armor: Record<ArmorSlot, string | null>;
+  trinkets: Record<TrinketSlot, string | null>;
+}
+
+export const WEAPON_SLOTS: WeaponSlot[];
+export const ARMOR_SLOTS: ArmorSlot[];
+export const TRINKET_SLOTS: TrinketSlot[];
+
+export function createEmptyEquipment(): Equipment;

--- a/equipment.js
+++ b/equipment.js
@@ -1,0 +1,55 @@
+export const WEAPON_SLOTS = [
+  "mainHand",
+  "offHand",
+  "ranged",
+  "instrument",
+  "ammo"
+];
+
+export const ARMOR_SLOTS = [
+  "head",
+  "body",
+  "back",
+  "hands",
+  "waist",
+  "legs",
+  "feet"
+];
+
+export const TRINKET_SLOTS = [
+  "lEar",
+  "rEar",
+  "neck",
+  "lRing",
+  "rRing",
+  "pouch"
+];
+
+export function createEmptyEquipment() {
+  return {
+    weapons: {
+      mainHand: null,
+      offHand: null,
+      ranged: null,
+      instrument: null,
+      ammo: null
+    },
+    armor: {
+      head: null,
+      body: null,
+      back: null,
+      hands: null,
+      waist: null,
+      legs: null,
+      feet: null
+    },
+    trinkets: {
+      lEar: null,
+      rEar: null,
+      neck: null,
+      lRing: null,
+      rRing: null,
+      pouch: null
+    }
+  };
+}

--- a/party.ts
+++ b/party.ts
@@ -1,6 +1,8 @@
 // party.ts — party structs (up to 8), resources, effects, and NPC proficiency policy
 
 import { initGrowth, onLevelUp } from "./attr_growth.js";
+import type { Equipment } from "./equipment.js";
+import { createEmptyEquipment } from "./equipment.js";
 
 /* ========================= Core Types ========================= */
 
@@ -71,13 +73,6 @@ export interface MaintainedChannel {
   effectIds: string[];
   /** true while the performer is actively maintaining */
   active: boolean;
-}
-
-export interface Equipment {
-  mainHand?: string;
-  offHand?: string;
-  armor?: string;
-  trinkets?: string[];
 }
 
 export interface Member {
@@ -333,7 +328,7 @@ export function makeMember(params: {
     growth: { state: growthInit.state, rates: growthInit.perLevel.rates, choicePerLevel: growthInit.perLevel.choicePerLevel },
     resources: { HP:0, MP:0, Stamina:0, HPMax:0, MPMax:0, StaminaMax:0 },
     proficiencies: params.proficiencies ?? {},
-    equipment: params.equipment,
+    equipment: params.equipment ?? createEmptyEquipment(),
     alive: true,
     status: [],
     channels: [],


### PR DESCRIPTION
## Summary
- centralize weapon, armor, and trinket slots in a shared module
- default characters to a full empty equipment loadout
- expose equipment slot types for consistency across systems

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68a89910c90883259887aac96d7bdf34