### PR TITLE
feat: orientation modes and compact profile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="theme-light layout-auto">
-
+  <div id="app">
 <nav class="top-menu">
   <button id="menu-button" aria-label="Menu">☰</button>
   <button id="back-button" aria-label="Back" style="display:none;">←</button>
@@ -31,7 +31,7 @@
       <button id="scale-inc" aria-label="Increase UI size">+</button>
     </div>
   </div>
-</nav>
+  </nav>
 
 <div id="dropdownMenu">
     <button data-action="character-select">Character Select</button>
@@ -85,9 +85,10 @@
     </svg>
     Quests
   </button>
-</div>
+  </div>
 
-<main style="margin-top:4rem; padding:1rem;"></main>
+<main style="padding:1rem;"></main>
+  </div>
 
 <script type="module" src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -399,7 +399,16 @@ function showCharacterUI() {
   showBackButton();
   const c = currentCharacter;
   const portrait = `<img src="${c.image || ''}" alt="portrait" style="width:10rem;height:10rem;${c.image ? '' : 'display:none;'}">`;
-  const info = `<p>Race: ${c.race}</p><p>Sex: ${c.sex}</p><p>Skin Color: <span class=\"color-box\" style=\"background:${c.skinColor}\"></span></p><p>Hair Color: <span class=\"color-box\" style=\"background:${c.hairColor}\"></span></p><p>Eye Color: <span class=\"color-box\" style=\"background:${c.eyeColor}\"></span></p><p>Height: ${formatHeight(c.height)}</p>`;
+  const info = `
+    <div class="info-grid">
+      <div>Race: ${c.race}</div>
+      <div>Sex: ${c.sex}</div>
+      <div>Skin Color: <span class="color-box" style="background:${c.skinColor}"></span></div>
+      <div>Hair Color: <span class="color-box" style="background:${c.hairColor}"></span></div>
+      <div>Eye Color: <span class="color-box" style="background:${c.eyeColor}"></span></div>
+      <div>Height: ${formatHeight(c.height)}</div>
+    </div>
+  `;
   const stats = c.attributes?.current || {};
   const statsList = ['STR','DEX','CON','VIT','AGI','INT','WIS','CHA','LCK']
     .map(attr => `<li>${attr}: ${stats[attr] ?? 0}</li>`)

--- a/style.css
+++ b/style.css
@@ -22,10 +22,46 @@ body {
   color: var(--foreground);
 }
 
+body.layout-landscape,
+body.layout-portrait {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+body.layout-auto {
+  display: block;
+}
+
+#app {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh;
+}
+
+body.layout-portrait #app {
+  aspect-ratio: 9 / 16;
+  width: min(100vw, calc(100vh * 9 / 16));
+  height: min(100vh, calc(100vw * 16 / 9));
+}
+
+body.layout-landscape #app {
+  aspect-ratio: 16 / 9;
+  width: min(100vw, calc(100vh * 16 / 9));
+  height: min(100vh, calc(100vw * 9 / 16));
+}
+
+main {
+  flex: 1;
+  overflow: auto;
+}
+
 .top-menu {
-  position: fixed;
+  position: sticky;
   top: 0;
-  left: 0;
   width: 100%;
   background: var(--background);
   display: flex;
@@ -88,7 +124,9 @@ body {
 }
 
 #dropdownMenu {
-  position: fixed;
+  position: absolute;
+  top: 3.5rem;
+  left: 0;
   width: 14rem;
   background: var(--background);
   box-shadow: 2px 0 4px rgba(0, 0, 0, 0.2);
@@ -117,7 +155,9 @@ body {
 }
 
 #characterMenu {
-  position: fixed;
+  position: absolute;
+  top: 3.5rem;
+  left: 0;
   width: 14rem;
   background: var(--background);
   box-shadow: 2px 0 4px rgba(0, 0, 0, 0.2);
@@ -373,6 +413,21 @@ body.theme-dark {
 
   .xp-display {
     margin-top: 0.25rem;
+  }
+
+  .info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+    gap: 0.25rem 1rem;
+  }
+
+  .stats-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(4rem, 1fr));
+    gap: 0.25rem 1rem;
   }
 
   .character-creation {


### PR DESCRIPTION
## Summary
- enforce portrait/landscape layouts with centered aspect-ratio container
- make character profile use grid layout with multiple columns

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx -y -p typescript tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a8b608e5108325ac723aba8ac000c7