### PR TITLE
Ensure content sits below persistent menu

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,6 +25,15 @@ window.fromIron = fromIron;
 const body = document.body;
 const main = document.querySelector('main');
 const backButton = document.getElementById('back-button');
+const topMenu = document.querySelector('.top-menu');
+
+function updateMenuHeight() {
+  if (!topMenu) return;
+  const height = topMenu.offsetHeight;
+  document.documentElement.style.setProperty('--menu-height', `${height}px`);
+}
+window.addEventListener('resize', updateMenuHeight);
+updateMenuHeight();
 
 function setMainHTML(html) {
   if (main) main.innerHTML = html;
@@ -890,6 +899,7 @@ let uiScale = 1;
 const updateScale = () => {
   document.documentElement.style.setProperty('--ui-scale', uiScale);
   savePreference('uiScale', uiScale);
+  updateMenuHeight();
 };
 document.getElementById('scale-dec').addEventListener('click', () => {
   uiScale = Math.max(0.5, uiScale - 0.1);
@@ -920,6 +930,7 @@ const setLayout = index => {
   body.classList.add(`layout-${layout}`);
   layoutToggle.innerHTML = layoutIcons[layout];
   savePreference('layout', layout);
+  updateMenuHeight();
   if (screen.orientation) {
     if (layout === 'landscape') {
       screen.orientation.lock('landscape').catch(() => {});

--- a/style.css
+++ b/style.css
@@ -9,6 +9,7 @@
   --capped-color: #2e8b57;
   --new-char-bg: #333333;
   --new-char-color: #f0f0f0;
+  --menu-height: 3.5rem;
 }
 
 html {
@@ -125,7 +126,7 @@ main {
 
 #dropdownMenu {
   position: absolute;
-  top: 3.5rem;
+  top: var(--menu-height);
   left: 0;
   width: 14rem;
   background: var(--background);
@@ -156,7 +157,7 @@ main {
 
 #characterMenu {
   position: absolute;
-  top: 3.5rem;
+  top: var(--menu-height);
   left: 0;
   width: 14rem;
   background: var(--background);
@@ -238,9 +239,9 @@ main {
 /* Positions for slide-out menus */
 #dropdownMenu,
 #characterMenu {
-  top: 3.5rem;
+  top: var(--menu-height);
   left: 0;
-  height: calc(100vh - 3.5rem);
+  height: calc(100vh - var(--menu-height));
 }
 
 .portrait-grid {


### PR DESCRIPTION
## Summary
- Add CSS `--menu-height` variable and apply it to dropdown and character menus so they start below the top navigation
- Introduce `updateMenuHeight` helper that updates the CSS variable on resize, UI scale, and layout changes to keep content clear of the persistent menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b9d6d7a483258c95a67fa02b7bf3