### PR TITLE
Improve character profile readability

### DIFF
--- a/script.js
+++ b/script.js
@@ -403,13 +403,15 @@ function showCharacterUI() {
   const c = currentCharacter;
   const portrait = `<img src="${c.image || ''}" alt="portrait" style="width:10rem;height:10rem;${c.image ? '' : 'display:none;'}">`;
   const info = `
-    <div class="info-grid">
+    <div class="info-block">
       <div>Race: ${c.race}</div>
       <div>Sex: ${c.sex}</div>
-      <div>Skin Color: <span class="color-box" style="background:${c.skinColor}"></span></div>
-      <div>Hair Color: <span class="color-box" style="background:${c.hairColor}"></span></div>
-      <div>Eye Color: <span class="color-box" style="background:${c.eyeColor}"></span></div>
-      <div>Height: ${formatHeight(c.height)}</div>
+      <div class="physical-group">
+        <div>Skin Color: <span class="color-box" style="background:${c.skinColor}"></span></div>
+        <div>Hair Color: <span class="color-box" style="background:${c.hairColor}"></span></div>
+        <div>Eye Color: <span class="color-box" style="background:${c.eyeColor}"></span></div>
+        <div>Height: ${formatHeight(c.height)}</div>
+      </div>
     </div>
   `;
   const stats = c.attributes?.current || {};

--- a/style.css
+++ b/style.css
@@ -392,36 +392,45 @@ body.theme-dark {
 
   .resource-bar.hp .fill {
     background: var(--hp-color);
-    color: #00ffff;
+    color: #000;
   }
 
   .resource-bar.mp .fill {
     background: var(--mp-color);
-    color: #ffff00;
+    color: #000;
   }
 
   .resource-bar.stamina .fill {
     background: var(--stamina-color);
-    color: #6532cd;
+    color: #000;
   }
 
   .xp-display {
     margin-top: 0.25rem;
   }
 
-  .info-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
-    gap: 0.25rem 1rem;
+  .info-block {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .physical-group {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    margin-top: 0.5rem;
   }
 
   .stats-list {
     list-style: none;
     padding: 0;
     margin: 0;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(4rem, 1fr));
-    gap: 0.25rem 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    text-align: left;
   }
 
   .character-profile {


### PR DESCRIPTION
## Summary
- Render character attributes vertically in a single left-aligned block and group physical characteristics
- Set HP, MP, and Stamina bar text colors to black for better contrast

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a8e4009424832585f9e2f868e8047d