### PR TITLE
feat: add location selection and map toggle

### DIFF
--- a/assets/data/core.js
+++ b/assets/data/core.js
@@ -155,6 +155,8 @@ export const characterTemplate = {
   name: "",
   race: "",
   class: "",
+  homeTown: "",
+  location: "",
   level: 1,
   xp: 0,
   attributes: {

--- a/assets/data/locations.js
+++ b/assets/data/locations.js
@@ -1,0 +1,80 @@
+const MAP_BASE_PATH = "assets/images/Maps";
+
+function createLocation(name, mapFile, description = "") {
+  return {
+    name,
+    description,
+    map: `${MAP_BASE_PATH}/${mapFile}`,
+    subdivisions: [],
+    position: {},
+    travel: { routes: [], connections: [] },
+    pointsOfInterest: {
+      buildings: [],
+      tradeRoutes: [],
+      resources: { domestic: [], exports: [], imports: [] },
+    },
+  };
+}
+
+export const LOCATIONS = {
+  "Duvilia Kingdom": createLocation(
+    "Duvilia Kingdom",
+    "Duvilia Kingdom.png"
+  ),
+  "Wave's Break": createLocation(
+    "Wave's Break",
+    "Wave's Break.png",
+    "Main hub for trade between east and west; major supplier of fish, ocean goods, and western-bound produce."
+  ),
+  "Coral Keep": createLocation(
+    "Coral Keep",
+    "Coral Keep.png",
+    "Source of coral, pearls, and glass; western trade point exporting large lumber from Timber Grove with major guild halls."
+  ),
+  "Timber Grove": createLocation(
+    "Timber Grove",
+    "Timber Grove.png",
+    "Primary harvester of large lumber, plus rare freshwater fauna, crystals, mushrooms, and orchard fruits."
+  ),
+  "Creekside": createLocation(
+    "Creekside",
+    "Creekside.png",
+    "Militarized former Wetlands Pass waypoint providing freshwater catch, cattle, dairy, leather, and sugar."
+  ),
+  "Warm Springs": createLocation(
+    "Warm Springs",
+    "Warm Springs.png",
+    "Mining town exporting metals, reagents, and coveted hot spring mineral water with an alchemy guild branch."
+  ),
+  "Dancing Pines": createLocation(
+    "Dancing Pines",
+    "Dancing Pines.png",
+    "Supplies small timber, metals, gemstones, game, and pelts; home to a renowned light-armor leatherworker."
+  ),
+  "Mountain Top": createLocation(
+    "Mountain Top",
+    "Mountain Top.png",
+    "Trade hub between Corona and Wave's Break growing flax and cotton while guarding the Wetlands choke point."
+  ),
+  "Corona": createLocation(
+    "Corona",
+    "Corona.png",
+    "Capital producing eastern crops, cattle, dairy, and basic goods; seat of human power hosting major guilds."
+  ),
+  "Corner Stone": createLocation(
+    "Corner Stone",
+    "Corner Stone.png",
+    "Premier crafting city rich in crystal, quartz, stone, and rare metals like mithril and adamantine; home to master artisans and the Commerce Guild."
+  ),
+  "Dragon's Reach Road": createLocation(
+    "Dragon's Reach Road",
+    "Dragon's Reach Road.png",
+    "Northern frontier stop before the dragon plateaus, yielding fruit, game, lumber, pelts, and scarce dragon materials."
+  ),
+  "Whiteheart": createLocation(
+    "Whiteheart",
+    "Whiteheart.png",
+    "Guild-founded outpost for lumber and exploration, serving as midpoint between Corona and Corner Stone to expand eastern agriculture and curb bandits."
+  ),
+};
+

--- a/index.html
+++ b/index.html
@@ -17,6 +17,13 @@
       <path d="M4 20c0-4 4-6 8-6s8 2 8 6" />
     </svg>
   </button>
+  <button id="map-button" aria-label="Map" style="display:none;">
+    <svg viewBox="0 0 24 24">
+      <path d="M3 6l6-3 6 3 6-3v15l-6 3-6-3-6 3z" />
+      <path d="M9 3v15" />
+      <path d="M15 6v15" />
+    </svg>
+  </button>
   <div class="settings-group">
     <button id="settings-button" aria-label="Settings">
       <svg viewBox="0 0 24 24">

--- a/style.css
+++ b/style.css
@@ -700,8 +700,34 @@ body.theme-dark {
    flex: 0 0 6rem;
  }
 
- .slot-item {
-   flex: 1;
- }
+.slot-item {
+  flex: 1;
+}
 
 /* Orientation layouts removed: top menu remains horizontal for all layouts */
+
+#map-container {
+  position: fixed;
+  top: var(--menu-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--background);
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 250;
+}
+
+#map-container img {
+  max-width: 100%;
+  max-height: 80%;
+  object-fit: contain;
+}
+
+#map-container .map-description {
+  margin-top: 1rem;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- introduce location data and character template fields for hometown and current location
- add location step in character creation with map/description and spawn text on load
- include persistent map button that toggles area or kingdom map

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check assets/data/locations.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8ed9b09a08325a26736e65693f4f3