### PR TITLE
Reorder location step and refine location styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -596,7 +596,8 @@ body.theme-dark {
   .location-button {
     position: relative;
     padding: 0.5rem 1rem;
-    background: var(--background);
+    background: transparent;
+    border: none;
     color: var(--foreground);
     cursor: pointer;
   }


### PR DESCRIPTION
## Summary
- Move location selection to occur after entering a character's name
- Adjust completion logic and progress bar to include location
- Remove background from location selection button, leaving only gradient lines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fa6aa6188325af4cdd7366a3d671