### PR TITLE
feat: add race carousel and hover glow

### DIFF
--- a/script.js
+++ b/script.js
@@ -738,6 +738,10 @@ function startCharacterCreation() {
     let field;
     if (step < fields.length) field = fields[step];
     else if (step === fields.length + 1) field = locationField;
+    if (field && field.key === 'race' && !character.race) {
+      character.race = field.options[0];
+      localStorage.setItem(TEMP_CHARACTER_KEY, JSON.stringify({ step, character }));
+    }
     if (step === fields.length + 1 && !character.location) {
       character.location = locationField.options[0];
     }
@@ -787,6 +791,20 @@ function startCharacterCreation() {
               <button class="loc-arrow right" aria-label="Next">&#x203A;</button>
             </div>
             <div class="location-indicator">${index + 1} / ${options.length}</div>`;
+        } else if (field.key === 'race') {
+          const options = field.options;
+          let index = options.indexOf(character.race);
+          if (index === -1) {
+            index = 0;
+            character.race = options[0];
+          }
+          inputHTML = `
+            <div class="race-carousel">
+              <button class="race-arrow left" aria-label="Previous">&#x2039;</button>
+              <button class="option-button race-button">${character.race}</button>
+              <button class="race-arrow right" aria-label="Next">&#x203A;</button>
+            </div>
+            <div class="race-indicator">${index + 1} / ${options.length}</div>`;
         } else {
           inputHTML = `<div class="option-grid">${field.options
             .map(
@@ -841,6 +859,17 @@ function startCharacterCreation() {
         };
         document.querySelector('.loc-arrow.left').addEventListener('click', () => change(-1));
         document.querySelector('.loc-arrow.right').addEventListener('click', () => change(1));
+      } else if (field.key === 'race') {
+        const options = field.options;
+        let index = options.indexOf(character.race);
+        const change = dir => {
+          index = (index + dir + options.length) % options.length;
+          character.race = options[index];
+          localStorage.setItem(TEMP_CHARACTER_KEY, JSON.stringify({ step, character }));
+          renderStep();
+        };
+        document.querySelector('.race-arrow.left').addEventListener('click', () => change(-1));
+        document.querySelector('.race-arrow.right').addEventListener('click', () => change(1));
       } else if (field.type === 'select') {
         document.querySelectorAll('.option-button').forEach(btn => {
           btn.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -204,6 +204,11 @@ main {
   color: var(--background);
 }
 
+button:not(:disabled):hover,
+.clickable:hover {
+  filter: drop-shadow(0 0 0.5rem currentColor);
+}
+
 #dropdownMenu button:not(:last-child)::after,
 #characterMenu button:not(:last-child)::after {
   content: "";
@@ -579,21 +584,24 @@ body.theme-dark {
     color: var(--background);
   }
 
-  .location-select {
+  .location-select,
+  .race-select {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 0.5rem;
   }
 
-  .location-carousel {
+  .location-carousel,
+  .race-carousel {
     display: flex;
     align-items: center;
     justify-content: center;
     gap: 1rem;
   }
 
-  .location-button {
+  .location-button,
+  .race-button {
     position: relative;
     padding: 0.5rem 1rem;
     background: transparent;
@@ -603,7 +611,9 @@ body.theme-dark {
   }
 
   .location-button::before,
-  .location-button::after {
+  .location-button::after,
+  .race-button::before,
+  .race-button::after {
     content: '';
     position: absolute;
     left: 0;
@@ -612,15 +622,18 @@ body.theme-dark {
     background: linear-gradient(to right, var(--background), var(--foreground), var(--background));
   }
 
-  .location-button::before {
+  .location-button::before,
+  .race-button::before {
     top: 0;
   }
 
-  .location-button::after {
+  .location-button::after,
+  .race-button::after {
     bottom: 0;
   }
 
-  .loc-arrow {
+  .loc-arrow,
+  .race-arrow {
     background: transparent;
     border: none;
     color: var(--foreground);
@@ -630,11 +643,13 @@ body.theme-dark {
     cursor: pointer;
   }
 
-  .loc-arrow:hover {
+  .loc-arrow:hover,
+  .race-arrow:hover {
     filter: drop-shadow(0 0 0.5rem currentColor);
   }
 
-  .location-indicator {
+  .location-indicator,
+  .race-indicator {
     text-align: center;
   }
 


### PR DESCRIPTION
## Summary
- add global hover glow for clickable text and buttons
- switch race selection to horizontal carousel with arrow navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fda6031c8325bf4c82564ed813a0