### PR TITLE
Standardize UI line styles and boost character creation scale

### DIFF
--- a/script.js
+++ b/script.js
@@ -519,6 +519,8 @@ function showCharacterSelectUI() {
 }
 
 function showMainUI() {
+  creationScaleOffset = 0;
+  updateScale();
   if (currentCharacter) {
     showCharacter();
   } else {
@@ -667,6 +669,8 @@ function showEquipmentUI() {
 }
 
 function startCharacterCreation() {
+  creationScaleOffset = 0.1;
+  updateScale();
   showBackButton();
   mapButton.style.display = 'none';
   mapContainer.style.display = 'none';
@@ -1025,6 +1029,8 @@ function finalizeCharacter(character) {
   currentProfile.lastCharacter = id;
   currentCharacter = newChar;
   saveProfiles();
+  creationScaleOffset = 0;
+  updateScale();
   showCharacter();
   localStorage.removeItem(TEMP_CHARACTER_KEY);
 }
@@ -1095,8 +1101,12 @@ themeToggle.addEventListener('click', () => {
 
 // UI scale buttons
 let uiScale = 1;
+let creationScaleOffset = 0;
 const updateScale = () => {
-  document.documentElement.style.setProperty('--ui-scale', uiScale);
+  document.documentElement.style.setProperty(
+    '--ui-scale',
+    uiScale + creationScaleOffset
+  );
   savePreference('uiScale', uiScale);
   updateMenuHeight();
 };

--- a/style.css
+++ b/style.css
@@ -150,7 +150,7 @@ main {
 }
 
 #dropdownMenu button {
-  margin: 0.25rem;
+  margin: 0;
   padding: 0.5rem 1rem;
   text-align: left;
   border: none;
@@ -183,7 +183,7 @@ main {
 }
 
 #characterMenu button {
-  margin: 0.25rem;
+  margin: 0;
   padding: 0.5rem 1rem;
   display: flex;
   align-items: center;
@@ -215,9 +215,9 @@ button:not(:disabled):hover,
   position: absolute;
   left: 0;
   right: 0;
-  bottom: -0.25rem;
-  height: 1px;
-  background: linear-gradient(to right, var(--background), var(--foreground) 50%, var(--background));
+  bottom: 0;
+  height: 2px;
+  background: linear-gradient(to right, var(--background), var(--foreground), var(--background));
 }
 
 #dropdownMenu button[data-action="new-character"],
@@ -758,8 +758,8 @@ body.theme-dark {
    left: 0;
    right: 0;
    bottom: 0;
-   height: 1px;
-   background: linear-gradient(to right, var(--background), var(--foreground) 50%, var(--background));
+   height: 2px;
+   background: linear-gradient(to right, var(--background), var(--foreground), var(--background));
  }
 
  .equipment-slot svg {


### PR DESCRIPTION
## Summary
- Make menu and equipment divider lines a uniform 2px and remove button margins for consistent selection backgrounds across pages
- Add character creation UI scale offset so creation screens render one step larger and reset when exiting

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a900c04ef883258c082c041b75a84a