### PR TITLE
Reorder race selection columns

### DIFF
--- a/script.js
+++ b/script.js
@@ -847,7 +847,7 @@ function startCharacterCreation() {
         );
       } else {
         setMainHTML(
-          `<div class="character-creation"><div class="progress-container">${progressHTML}</div><div class="cc-column"><div class="cc-top"><div class="cc-options">${inputHTML}</div>${statsHTML}${descHTML}</div>${imageHTML}</div></div>`
+          `<div class="character-creation"><div class="progress-container">${progressHTML}</div><div class="cc-column"><div class="cc-top">${statsHTML}<div class="cc-options">${inputHTML}</div>${descHTML}</div>${imageHTML}</div></div>`
         );
         normalizeOptionButtonWidths();
       }
@@ -903,7 +903,7 @@ function startCharacterCreation() {
       }
     } else {
       const nameVal = character.name || '';
-      setMainHTML(`<div class="character-creation"><div class="progress-container">${progressHTML}</div><div class="cc-column"><div class="cc-top"><div class="cc-options"><input type="text" id="name-input" value="${nameVal}" placeholder="Name"></div>${statsHTML}${descHTML}</div>${imageHTML}</div></div>`);
+      setMainHTML(`<div class="character-creation"><div class="progress-container">${progressHTML}</div><div class="cc-column"><div class="cc-top">${statsHTML}<div class="cc-options"><input type="text" id="name-input" value="${nameVal}" placeholder="Name"></div>${descHTML}</div>${imageHTML}</div></div>`);
       normalizeOptionButtonWidths();
       const nameInput = document.getElementById('name-input');
       const updateName = () => {

--- a/style.css
+++ b/style.css
@@ -523,12 +523,15 @@ body.theme-dark {
   .cc-top {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.25rem;
+    gap: 0.125rem;
     width: 100%;
   }
 
   .cc-options,
-  .race-stats,
+  .race-stats {
+    flex: 0 0 12rem;
+  }
+
   .race-description {
     flex: 1 1 12rem;
   }


### PR DESCRIPTION
## Summary
- Swap race selector and starting stats positions so selector sits between stats and description
- Shrink spacing and allow race description column to stretch on wide layouts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a902d49d6883258a06674ac4b7103d