### PR TITLE
Fix menu height duplication and improve orientation layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -28,11 +28,35 @@ const body = document.body;
 const main = document.querySelector('main');
 const backButton = document.getElementById('back-button');
 const topMenu = document.querySelector('.top-menu');
+const app = document.getElementById('app');
+
+function updateLayoutSize() {
+  if (!app) return;
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  let width = vw;
+  let height = vh;
+  if (body.classList.contains('layout-landscape')) {
+    const aspect = 16 / 9;
+    width = Math.min(vw, vh * aspect);
+    height = width / aspect;
+  } else if (body.classList.contains('layout-portrait')) {
+    const aspect = 9 / 16;
+    width = Math.min(vw, vh * aspect);
+    height = width / aspect;
+  } else {
+    width = vw;
+    height = vh;
+  }
+  app.style.width = `${width}px`;
+  app.style.height = `${height}px`;
+}
 
 function updateMenuHeight() {
   if (!topMenu) return;
   const height = topMenu.offsetHeight;
   document.documentElement.style.setProperty('--menu-height', `${height}px`);
+  updateLayoutSize();
 }
 window.addEventListener('resize', updateMenuHeight);
 updateMenuHeight();
@@ -483,6 +507,7 @@ function showNoCharacterUI() {
   updateMapButton();
   setMainHTML(`<div class="no-character"><h1>Start your journey...</h1><button id="new-character">New Character</button></div>`);
   document.getElementById('new-character').addEventListener('click', startCharacterCreation);
+  updateMenuHeight();
 }
 
 function showCharacterSelectUI() {

--- a/style.css
+++ b/style.css
@@ -32,6 +32,7 @@ body.layout-portrait {
   justify-content: center;
   align-items: center;
   min-height: 100vh;
+  overflow: hidden;
 }
 
 body.layout-auto {
@@ -48,14 +49,10 @@ body.layout-auto {
 
 body.layout-portrait #app {
   aspect-ratio: 9 / 16;
-  width: min(100vw, calc(100vh * 9 / 16));
-  height: min(100vh, calc(100vw * 16 / 9));
 }
 
 body.layout-landscape #app {
   aspect-ratio: 16 / 9;
-  width: min(100vw, calc(100vh * 16 / 9));
-  height: min(100vh, calc(100vw * 9 / 16));
 }
 
 main {
@@ -286,7 +283,7 @@ button:not(:disabled):hover,
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: calc(100vh - 4rem);
+  min-height: calc(100vh - var(--menu-height) - 2rem);
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- ensure no-character welcome screen updates menu height correctly
- dynamically size app wrapper to maintain orientation aspect ratios without scrollbars
- use CSS variables for menu height and orientation overflow handling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d9d42478832593ed16baafd0538a