### PR TITLE
Fix top menu background height

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@
   --hp-color: #ff0000;
   --mp-color: #0000ff;
   --stamina-color: #00ff00;
-  --menu-height: 3.5rem;
+  --menu-height: 2.5rem;
 }
 
 html {
@@ -68,7 +68,9 @@ main {
   display: flex;
   flex-direction: row;
   gap: 0.5rem;
-  padding: 0.5rem;
+  padding: 0 0.5rem;
+  height: var(--menu-height);
+  align-items: center;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   z-index: 300;
 }


### PR DESCRIPTION
## Summary
- set top menu height from CSS variable and center controls
- adjust default menu height for consistent layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa07de52908325a959420cdb5e1cea