### PR TITLE
Fix menu height doubling on portrait orientation

### DIFF
--- a/style.css
+++ b/style.css
@@ -69,7 +69,7 @@ main {
   flex-direction: row;
   gap: 0.5rem;
   padding: 0 0.5rem;
-  height: var(--menu-height);
+  height: 2.5rem;
   align-items: center;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   z-index: 300;


### PR DESCRIPTION
## Summary
- Prevent persistent top menu from expanding when orientation is forced to portrait

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa69530dfc8325a7142c0c293daad7