### PR TITLE
Use ST abbreviation and improve resource bar visibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -583,10 +583,13 @@ function showCharacterUI() {
     const mpPct = c.maxMP ? (c.mp / c.maxMP) * 100 : 0;
     const staPct = c.maxStamina ? (c.stamina / c.maxStamina) * 100 : 0;
     const xpNeed = xpForNextLevel(c.level);
+    const hpColor = hpPct > 0 ? '#fff' : '#000';
+    const mpColor = mpPct > 0 ? '#fff' : '#000';
+    const stColor = staPct > 0 ? '#fff' : '#000';
     return `
-      <div class="resource-bar hp"><div class="fill" style="width:${hpPct}%"><span>${c.hp} / ${c.maxHP}</span></div></div>
-      <div class="resource-bar mp"><div class="fill" style="width:${mpPct}%"><span>${c.mp} / ${c.maxMP}</span></div></div>
-      <div class="resource-bar stamina"><div class="fill" style="width:${staPct}%"><span>${c.stamina} / ${c.maxStamina}</span></div></div>
+      <div class="resource-bar hp"><div class="fill" style="width:${hpPct}%"></div><span class="value" style="color:${hpColor}">HP: ${c.hp} / ${c.maxHP}</span></div>
+      <div class="resource-bar mp"><div class="fill" style="width:${mpPct}%"></div><span class="value" style="color:${mpColor}">MP: ${c.mp} / ${c.maxMP}</span></div>
+      <div class="resource-bar stamina"><div class="fill" style="width:${staPct}%"></div><span class="value" style="color:${stColor}">ST: ${c.stamina} / ${c.maxStamina}</span></div>
       <p class="xp-display">XP: ${c.xp} / ${xpNeed}</p>
     `;
   })();
@@ -787,7 +790,7 @@ function startCharacterCreation() {
       const resources = {
         HP: maxHP(attrs.VIT, 1),
         MP: maxMP(attrs.WIS, 1),
-        Stamina: maxStamina(attrs.CON, 1)
+        ST: maxStamina(attrs.CON, 1)
       };
       const attrList = Object.entries({ ...attrs, LCK: 10 })
         .map(([k, v]) => `<li>${k}: ${v}</li>`)

--- a/style.css
+++ b/style.css
@@ -385,29 +385,40 @@ body.theme-dark {
   }
 
   .resource-bar .fill {
+    position: absolute;
+    top: 0;
+    left: 0;
     height: 100%;
     width: 0;
+    z-index: 1;
+  }
+
+  .resource-bar .value {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 0.75rem;
     white-space: nowrap;
     box-sizing: border-box;
+    color: #000;
+    z-index: 2;
   }
 
   .resource-bar.hp .fill {
     background: var(--hp-color);
-    color: #000;
   }
 
   .resource-bar.mp .fill {
     background: var(--mp-color);
-    color: #000;
   }
 
   .resource-bar.stamina .fill {
     background: var(--stamina-color);
-    color: #000;
   }
 
   .xp-display {
@@ -558,6 +569,20 @@ body.theme-dark {
 
   .race-description {
     margin-top: 0;
+  }
+
+  body.layout-portrait .cc-top {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  body.layout-portrait .cc-options {
+    order: -1;
+    align-self: center;
+  }
+
+  body.layout-portrait .cc-options .option-grid {
+    align-items: center;
   }
 
   .option-grid {


### PR DESCRIPTION
## Summary
- Abbreviate stamina to ST on character screens
- Make resource bar text legible by swapping color based on fill
- Center option selector in portrait layout and move it above other dynamic elements

## Testing
- `node --check script.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab372d06d48325b7fe1c7273f02d36