### PR TITLE
fix: hide horizontal overflow in UI

### DIFF
--- a/style.css
+++ b/style.css
@@ -25,6 +25,7 @@ body {
   font-family: sans-serif;
   background: var(--background);
   color: var(--foreground);
+  overflow-x: hidden;
 }
 
 body.layout-landscape,


### PR DESCRIPTION
## Summary
- prevent UI from exceeding viewport width by hiding horizontal overflow on the body

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab542264a88325853085d869ae01d2