### PR TITLE
Fix dark summon visibility at low proficiency

### DIFF
--- a/assets/data/summons.ts
+++ b/assets/data/summons.ts
@@ -613,11 +613,31 @@ export function resolveSummon(def: SummonDef, input: SummonResolveInput): Summon
 
 /* ========================= Convenience ========================= */
 
+const ELEMENT_PROF_KEY: Record<Element, string> = {
+  Stone: "stoneMagic",
+  Water: "waterMagic",
+  Wind: "windMagic",
+  Fire: "fireMagic",
+  Ice: "iceMagic",
+  Thunder: "thunderMagic",
+  Dark: "darkMagic",
+  Light: "lightMagic",
+};
+
 export function summonsForElement(el: Element): SummonDef[] {
   return SUMMONS.filter(s => s.element === el);
 }
 
-export function summonsAvailable(summoningP: number, elementP: number): SummonDef[] {
-  return SUMMONS.filter(s => isUnlocked(s, summoningP, elementP));
+export function summonsAvailable(
+  summoningP: number,
+  elementP: number | Record<string, number>
+): SummonDef[] {
+  return SUMMONS.filter(s => {
+    const p =
+      typeof elementP === "number"
+        ? elementP
+        : elementP[ELEMENT_PROF_KEY[s.element]] || 0;
+    return isUnlocked(s, summoningP, p);
+  });
 }
 


### PR DESCRIPTION
## Summary
- Handle per-element proficiencies when listing available summons
- Map element names to proficiency keys to surface Dark Elemental at proficiency 1

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab782705d88325be44059279aaea47