### PR TITLE
Add magic school gating for spells

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Additional functionality will be added over time.
 
 ### Magical Proficiencies
 
-Characters now track separate proficiencies for Stone, Water, Wind, Fire, Ice, Thunder, Dark, Light, Destructive, Healing, Reinforcement, Enfeebling and Summoning magic. The `gainProficiencyWithChance` function in `script.js` calculates how these values increase when spells are cast.
+Characters now track separate proficiencies for Stone, Water, Wind, Fire, Ice, Thunder, Dark, Light, Destructive, Healing, Reinforcement, Enfeebling and Summoning magic. The `gainProficiencyWithChance` function in `script.js` calculates how these values increase when spells are cast. The spellbook requires a character to meet the proficiency threshold in both a spell's element and its school before it can be used.
 
 ### Weapon Skills
 

--- a/assets/data/combat.ts
+++ b/assets/data/combat.ts
@@ -34,6 +34,13 @@ const elementProfKey: Record<string, string> = {
   Dark: "darkMagic",
   Light: "lightMagic",
 };
+const schoolProfKey: Record<string, string> = {
+  Destructive: "destructiveMagic",
+  Healing: "healingMagic",
+  Reinforcement: "reinforcementMagic",
+  Enfeebling: "enfeeblingMagic",
+  Summoning: "summoningMagic",
+};
 
 function clamp(x: number, min: number, max: number) {
   return Math.max(min, Math.min(max, x));
@@ -57,8 +64,11 @@ function proficiencyForSkill(actor: Actor, skill: any, type: "weapon" | "spell")
     const key = skill.weapon?.toLowerCase();
     return actor.proficiencies[key] || 0;
   }
-  const key = elementProfKey[skill.element] || "";
-  return actor.proficiencies[key] || 0;
+  const elemKey = elementProfKey[skill.element] || "";
+  const schoolKey = schoolProfKey[skill.school] || "";
+  const elemP = actor.proficiencies[elemKey] || 0;
+  const schoolP = actor.proficiencies[schoolKey] || 0;
+  return Math.min(elemP, schoolP);
 }
 
 function nonCombatBonus(actor: Actor, kind: "offense" | "defense" | "evasion") {

--- a/assets/data/spells.js
+++ b/assets/data/spells.js
@@ -221,6 +221,7 @@ function buildElement(elementName, names) {
       id: `${elementName}:ATK:${tier}`,
       name,
       element: elementName,
+      school: "Destructive",
       family: "attack",
       type: "Attack",
       subtype: ultimate ? "Ultimate" : (target === "AoE" ? "AoE" : "Single"),
@@ -247,6 +248,7 @@ function buildElement(elementName, names) {
       id: `${elementName}:CTRL:${tier}`,
       name,
       element: elementName,
+      school: "Enfeebling",
       family: "control",
       type: (i === 1 ? "DoT" : "Control"),
       subtype: null,
@@ -271,12 +273,14 @@ function buildElement(elementName, names) {
     const basePower = r4(supp.bp[i]);
     // Subtype hint (optional)
     const subtypeMap = ["Buff","Shield","Regen/Heal","Resist","Shield"];
+    const isHeal = /heal|grace|recovery|cauterize|cleansing/i.test(name);
     return {
       id: `${elementName}:SUP:${tier}`,
       name,
       element: elementName,
+      school: isHeal ? "Healing" : "Reinforcement",
       family: "support",
-      type: (/heal|grace/i.test(name) ? "Heal" : "Buff"),
+      type: (isHeal ? "Heal" : "Buff"),
       subtype: subtypeMap[i] || null,
       proficiency: prof,
       target,

--- a/script.js
+++ b/script.js
@@ -398,6 +398,14 @@ const elementalProficiencyMap = {
   light: 'lightMagic'
 };
 const ELEMENTAL_MAGIC_KEYS = Object.values(elementalProficiencyMap);
+const schoolProficiencyMap = {
+  Destructive: 'destructiveMagic',
+  Healing: 'healingMagic',
+  Reinforcement: 'reinforcementMagic',
+  Enfeebling: 'enfeeblingMagic',
+  Summoning: 'summoningMagic'
+};
+const SCHOOL_MAGIC_KEYS = Object.values(schoolProficiencyMap);
 
 function applySpellProficiencyGain(character, spell, params) {
   if (!character || !spell) return;
@@ -408,28 +416,10 @@ function applySpellProficiencyGain(character, spell, params) {
       ...params,
     });
   }
-
-  if (spell.isDamage) {
-    character.destructiveMagic = gainProficiency({
-      P: character.destructiveMagic,
-      ...params,
-    });
-  }
-  if (spell.isBuff) {
-    character.reinforcementMagic = gainProficiency({
-      P: character.reinforcementMagic,
-      ...params,
-    });
-  }
-  if (spell.isHeal) {
-    character.healingMagic = gainProficiency({
-      P: character.healingMagic,
-      ...params,
-    });
-  }
-  if (spell.isControl) {
-    character.enfeeblingMagic = gainProficiency({
-      P: character.enfeeblingMagic,
+  const schoolKey = schoolProficiencyMap[spell.school];
+  if (schoolKey) {
+    character[schoolKey] = gainProficiency({
+      P: character[schoolKey],
       ...params,
     });
   }
@@ -625,8 +615,10 @@ function showSpellbookUI() {
   const elements = ['Stone','Water','Wind','Fire','Ice','Thunder','Dark','Light'];
   for (const spell of SPELLBOOK) {
     const profKey = elementalProficiencyMap[spell.element.toLowerCase()];
-    const profValue = currentCharacter[profKey] ?? 0;
-    if (profValue >= spell.proficiency) {
+    const schoolKey = schoolProficiencyMap[spell.school];
+    const elemValue = currentCharacter[profKey] ?? 0;
+    const schoolValue = currentCharacter[schoolKey] ?? 0;
+    if (elemValue >= spell.proficiency && schoolValue >= spell.proficiency) {
       (spellsByElement[spell.element] ||= []).push(spell);
     }
   }


### PR DESCRIPTION
## Summary
- classify every spell by magic school
- gate spell usage by both elemental and school proficiencies
- track proficiency gains for magic schools

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7f71f27083259f3e0bfc3a877694