### PR TITLE
Improve layout scaling and orientation behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -42,11 +42,8 @@ function updateLayoutSize() {
     height = width / aspect;
   } else if (body.classList.contains('layout-portrait')) {
     const aspect = 9 / 16;
-    width = Math.min(vw, vh * aspect);
-    height = width / aspect;
-  } else {
-    width = vw;
     height = vh;
+    width = Math.min(vw, vh * aspect);
   }
   app.style.width = `${width}px`;
   app.style.height = `${height}px`;
@@ -1202,7 +1199,6 @@ function loadPreferences() {
     currentLayoutIndex = layouts.indexOf(prefs.layout);
   }
   setTheme(currentThemeIndex);
-  updateScale();
   setLayout(currentLayoutIndex);
 }
 
@@ -1242,9 +1238,12 @@ themeToggle.addEventListener('click', () => {
 let uiScale = 1;
 let creationScaleOffset = 0;
 const updateScale = () => {
+  const baseScale = body.classList.contains('layout-landscape')
+    ? uiScale * 1.25
+    : uiScale;
   document.documentElement.style.setProperty(
     '--ui-scale',
-    uiScale + creationScaleOffset
+    baseScale + creationScaleOffset
   );
   savePreference('uiScale', uiScale);
   updateMenuHeight();
@@ -1278,7 +1277,7 @@ const setLayout = index => {
   body.classList.add(`layout-${layout}`);
   layoutToggle.innerHTML = layoutIcons[layout];
   savePreference('layout', layout);
-  updateMenuHeight();
+  updateScale();
   if (screen.orientation) {
     if (layout === 'landscape') {
       screen.orientation.lock('landscape').catch(() => {});

--- a/style.css
+++ b/style.css
@@ -32,9 +32,9 @@ body.layout-landscape,
 body.layout-portrait {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   min-height: 100vh;
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 body.layout-auto {
@@ -47,14 +47,6 @@ body.layout-auto {
   flex-direction: column;
   width: 100%;
   height: 100vh;
-}
-
-body.layout-portrait #app {
-  aspect-ratio: 9 / 16;
-}
-
-body.layout-landscape #app {
-  aspect-ratio: 16 / 9;
 }
 
 main {


### PR DESCRIPTION
## Summary
- Align wrapper to top of screen for portrait and landscape layouts
- Scale UI 25% larger in landscape and resize wrapper to window dimensions

## Testing
- `node --check script.js`
- `npm test` *(fails: no such file or directory '/workspace/RPG/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68adb9d773448325a0d431da8a312420