### PR TITLE
Add cantrip spells and refine school unlock logic

### DIFF
--- a/assets/data/spells.js
+++ b/assets/data/spells.js
@@ -191,8 +191,104 @@ function buildSupportEffect(element, spellName, target, basePower, idx /*0..4*/)
   }
 }
 
-/** Build one element's 20-spell kit */
+/** Build one element's spell kit including level 1 cantrips */
 function buildElement(elementName, names) {
+  const baseAtk = 0.25; // quarter of tier-1 power
+  const baseCtrl = 0.05;
+  const baseSupp = 0.25;
+
+  const cantrips = [
+    {
+      id: `${elementName}:CAN:DES`,
+      name: `${elementName} Spark`,
+      element: elementName,
+      school: "Destructive",
+      family: "attack",
+      type: "Attack",
+      subtype: "Single",
+      proficiency: 1,
+      target: "ST",
+      basePower: baseAtk,
+      proficiencyFactor: 1.0,
+      unlockTierId: "CANTRIP",
+      mpCost: 1,
+      ultimate: false,
+      starter: true,
+    },
+    {
+      id: `${elementName}:CAN:ENF`,
+      name: `${elementName} Jinx`,
+      element: elementName,
+      school: "Enfeebling",
+      family: "control",
+      type: "Control",
+      subtype: null,
+      proficiency: 1,
+      target: "ST",
+      basePower: baseCtrl,
+      proficiencyFactor: 1.0,
+      unlockTierId: "CANTRIP",
+      mpCost: 1,
+      ultimate: false,
+      starter: true,
+      effect: buildControlEffect(`${elementName} Jinx`, "ST", baseCtrl, 0),
+    },
+    {
+      id: `${elementName}:CAN:REIN`,
+      name: `${elementName} Ward`,
+      element: elementName,
+      school: "Reinforcement",
+      family: "support",
+      type: "Buff",
+      subtype: "Buff",
+      proficiency: 1,
+      target: "ST",
+      basePower: baseSupp,
+      proficiencyFactor: 1.0,
+      unlockTierId: "CANTRIP",
+      mpCost: 1,
+      ultimate: false,
+      starter: true,
+      effect: buildSupportEffect(elementName, `${elementName} Ward`, "ST", baseSupp, 0),
+    },
+    {
+      id: `${elementName}:CAN:HEAL`,
+      name: `${elementName} Heal`,
+      element: elementName,
+      school: "Healing",
+      family: "support",
+      type: "Heal",
+      subtype: "Heal",
+      proficiency: 1,
+      target: "ST",
+      basePower: baseSupp,
+      proficiencyFactor: 1.0,
+      unlockTierId: "CANTRIP",
+      mpCost: 1,
+      ultimate: false,
+      starter: true,
+      effect: buildSupportEffect(elementName, `${elementName} Heal`, "ST", baseSupp, 2),
+    },
+    {
+      id: `${elementName}:CAN:SUM`,
+      name: `Summon ${elementName} Sprite`,
+      element: elementName,
+      school: "Summoning",
+      family: "summon",
+      type: "Summon",
+      subtype: null,
+      proficiency: 1,
+      target: "Self",
+      basePower: 0,
+      proficiencyFactor: 1.0,
+      unlockTierId: "CANTRIP",
+      mpCost: 1,
+      ultimate: false,
+      starter: true,
+      effect: { kind: "summon", summonId: `${elementName}:Elemental` },
+    },
+  ];
+
   // Families: Attack(10 tiers), Control(5), Support(5)
   const atk = buildBasePowers(10, mpCost, 1.00);
   const ctrl = buildBasePowers(5, mpCost, 0.20);
@@ -299,10 +395,10 @@ function buildElement(elementName, names) {
   [...attack, ...control, ...support].forEach(spell => {
     byMilestone.get(spell.proficiency).push(spell);
   });
-  return MILESTONES.flatMap(m => byMilestone.get(m));
+  return [...cantrips, ...MILESTONES.flatMap(m => byMilestone.get(m))];
 }
 
-/** Build the full 8-element spellbook (160 spells total) */
+/** Build the full 8-element spellbook (200 spells total) */
 function generateSpellbook() {
   const elements = Object.keys(NAMES);
   const all = [];

--- a/script.js
+++ b/script.js
@@ -298,7 +298,6 @@ const defaultProficiencies = {
 function assignMagicAptitudes(character) {
   const aptitude = character.magicAptitude || 'low';
   const elemChance = aptitude === 'high' ? 0.3 : aptitude === 'med' ? 0.2 : 0.1;
-  const nonElemChance = aptitude === 'high' ? 0.9 : aptitude === 'med' ? 0.6 : 0.3;
   const elemental = [
     'stone',
     'water',
@@ -309,24 +308,37 @@ function assignMagicAptitudes(character) {
     'dark',
     'light'
   ];
-  const nonElemental = [
-    'destructive',
-    'healing',
-    'reinforcement',
-    'enfeebling',
-    'summoning'
-  ];
-  let anyElement = false;
-  for (const key of elemental) {
-    if (Math.random() < elemChance) {
-      character[key] = 1;
-      anyElement = true;
+  const schoolChances = {
+    destructive: 0.33,
+    reinforcement: 0.33,
+    enfeebling: 0.33,
+    healing: 0.2,
+    summoning: 0.1,
+  };
+
+  // Determine if the character already has an elemental proficiency
+  let hasElement = elemental.some(k => character[k] > 0);
+
+  // Roll for elemental proficiencies if none are present
+  if (!hasElement) {
+    for (const key of elemental) {
+      if (Math.random() < elemChance) {
+        character[key] = 1;
+        hasElement = true;
+      }
     }
   }
-  if (anyElement) {
-    for (const key of nonElemental) {
-      if (Math.random() < nonElemChance) {
-        character[key] = 1;
+
+  // Ensure at least one school is unlocked when any element is present
+  if (hasElement) {
+    const schoolKeys = Object.keys(schoolChances);
+    let hasSchool = schoolKeys.some(k => character[k] > 0);
+    while (!hasSchool) {
+      for (const key of schoolKeys) {
+        if (Math.random() < schoolChances[key]) {
+          character[key] = 1;
+          hasSchool = true;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Merge level 1 cantrips into each element's spell kit for a unified 200-spell book
- Remove retroactive school assignment on character load
- Spellbook view now checks both elemental and school proficiencies when listing spells

## Testing
- `node --check assets/data/spells.js`
- `node --check script.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ade9cff3f4832587aa3351c260d8bd