### PR TITLE
feat: add equipment item template

### DIFF
--- a/assets/data/equipment.d.ts
+++ b/assets/data/equipment.d.ts
@@ -33,3 +33,43 @@ export const ARMOR_SLOTS: ArmorSlot[];
 export const TRINKET_SLOTS: TrinketSlot[];
 
 export function createEmptyEquipment(): Equipment;
+
+export interface EquipmentItemStats {
+  damage: number;
+  defense: number;
+}
+
+export interface EquipmentItem {
+  id?: string;
+  name?: string;
+  slot: WeaponSlot | ArmorSlot | TrinketSlot | string;
+  type: string;
+  baseStats: EquipmentItemStats;
+  abilities: string[];
+  effects: string[];
+  marketPrice: number;
+  condition: number;
+  weight: number;
+  rarity?: string;
+  attributes: Record<string, number>;
+  meta: Record<string, any>;
+}
+
+export interface EquipmentItemParams {
+  id?: string;
+  name?: string;
+  slot: WeaponSlot | ArmorSlot | TrinketSlot | string;
+  type: string;
+  damage?: number;
+  defense?: number;
+  abilities?: string[];
+  effects?: string[];
+  marketPrice?: number;
+  condition?: number;
+  weight?: number;
+  rarity?: string;
+  attributes?: Record<string, number>;
+  meta?: Record<string, any>;
+}
+
+export function createEquipmentItem(params: EquipmentItemParams): EquipmentItem;

--- a/assets/data/equipment.js
+++ b/assets/data/equipment.js
@@ -53,3 +53,36 @@ export function createEmptyEquipment() {
     }
   };
 }
+
+export function createEquipmentItem({
+  id = "",
+  name = "",
+  slot,
+  type,
+  damage = 0,
+  defense = 0,
+  abilities = [],
+  effects = [],
+  marketPrice = 0,
+  condition = 100,
+  weight = 0,
+  rarity = "common",
+  attributes = {},
+  meta = {},
+} = {}) {
+  return {
+    id,
+    name,
+    slot,
+    type,
+    baseStats: { damage, defense },
+    abilities,
+    effects,
+    marketPrice,
+    condition,
+    weight,
+    rarity,
+    attributes,
+    meta,
+  };
+}


### PR DESCRIPTION
## Summary
- add createEquipmentItem for reusable gear definitions
- define EquipmentItem types for stats, abilities, and price

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae082c2748832595da233456097dda