### PR TITLE
Add dual sorting options and grouping in spellbook

### DIFF
--- a/style.css
+++ b/style.css
@@ -876,6 +876,20 @@ body.theme-dark {
   cursor: pointer;
 }
 
+.sort-buttons {
+  display: inline-flex;
+  gap: 0.25rem;
+}
+
+.sort-button.active {
+  text-decoration: underline;
+}
+
+.spell-subheading {
+  margin: 0.5rem 0 0.25rem;
+  font-weight: bold;
+}
+
 .spell-list {
   list-style: none;
   padding: 0;


### PR DESCRIPTION
## Summary
- Add separate buttons for sorting spells by proficiency requirement or school type
- Group spells into sub-sections based on selected sort style
- Style sort controls and group headings for readability

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/RPG/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68ae1d042850832598a9365b5dcbc869