### PR TITLE
feat: update type selector icon

### DIFF
--- a/script.js
+++ b/script.js
@@ -468,7 +468,13 @@ function getProficiencySortIcon(dir) {
 
 function getTypeSortIcon(dir) {
   const arrow = dir === 'desc' ? '↓' : '↑';
-  return `<span class="type-icon"><span class="cw">↻</span><span class="ccw">↺</span>${arrow}</span>`;
+  return (
+    `<span class="type-icon">` +
+    `<svg viewBox="0 0 24 24">` +
+    `<g class="cw"><polyline points="23 4 23 10 17 10"/><path d="M3.51 9a9 9 0 0 1 14.13-5.36L23 10"/></g>` +
+    `<g class="ccw"><polyline points="1 20 1 14 7 14"/><path d="M20.49 15a9 9 0 0 1-14.13 5.36L1 14"/></g>` +
+    `</svg>${arrow}</span>`
+  );
 }
 
 function applySpellProficiencyGain(character, spell, params) {

--- a/style.css
+++ b/style.css
@@ -923,12 +923,26 @@ body.theme-dark {
   align-items: center;
 }
 
+.type-icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.type-icon svg {
+  width: 1em;
+  height: 1em;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .type-icon .cw {
-  color: #3c8;
+  stroke: #3c8;
 }
 
 .type-icon .ccw {
-  color: #c83;
+  stroke: #c83;
 }
 
 .icon.enfeeble .arrow {


### PR DESCRIPTION
## Summary
- replace type selector icon with two-color circular arrows
- style icon using SVG and stroke colors

## Testing
- `node --check script.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae47dbf1a08325bd37047c8812a2b4