### PR TITLE
Revamp proficiency layout and icons

### DIFF
--- a/script.js
+++ b/script.js
@@ -451,11 +451,11 @@ const elementIcons = {
 const schoolIcons = {
   Destructive: '💥',
   Enfeebling:
-    '<span class="icon enfeeble"><span class="arrow">⬇</span><span class="humanoid">👤</span></span>',
+    '<span class="icon enfeeble"><span class="arrow">⬇</span></span>',
   Reinforcement:
-    '<span class="icon reinforce"><span class="arrow">⬆</span><span class="humanoid">👤</span></span>',
+    '<span class="icon reinforce"><span class="arrow">⬆</span></span>',
   Healing:
-    '<span class="icon heal"><span class="arrow">+</span><span class="humanoid">👤</span></span>',
+    '<span class="icon heal"><span class="arrow">+</span></span>',
   Summoning: '<span class="icon slime"></span>'
 };
 
@@ -796,37 +796,39 @@ function showProficienciesUI() {
   if (!currentCharacter) return;
   showBackButton();
   const profCap = proficiencyCap(currentCharacter.level);
-  let html = '<div class="proficiencies-screen"><h1>Proficiencies</h1>';
+  let html = '<div class="proficiencies-screen">';
   for (const [type, list] of Object.entries(proficiencyCategories)) {
+    html += '<section class="proficiency-section">';
     html += `<h2>${type}</h2>`;
     if (type === 'Magical') {
       const elemental = list.filter(k => ELEMENTAL_MAGIC_KEYS.includes(k));
       const other = list.filter(k => !ELEMENTAL_MAGIC_KEYS.includes(k));
-      html += '<div class="proficiency-grid">';
+      html += '<ul class="proficiency-list">';
       elemental.forEach(key => {
         const value = currentCharacter[key] ?? 0;
         const name = key.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase());
         const capped = value >= 100 ? ' capped' : '';
-        html += `<div class="proficiency-item"><span class="proficiency-name">${name}</span><span class="proficiency-value${capped}" data-cap="${profCap}">${value}</span></div>`;
+        html += `<li class="proficiency-item"><span class="proficiency-name">${name}</span><span class="proficiency-value${capped}" data-cap="${profCap}">${value}</span></li>`;
       });
-      html += '</div><div class="proficiency-grid">';
+      html += '</ul><ul class="proficiency-list">';
       other.forEach(key => {
         const value = currentCharacter[key] ?? 0;
         const name = key.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase());
         const capped = value >= 100 ? ' capped' : '';
-        html += `<div class="proficiency-item"><span class="proficiency-name">${name}</span><span class="proficiency-value${capped}" data-cap="${profCap}">${value}</span></div>`;
+        html += `<li class="proficiency-item"><span class="proficiency-name">${name}</span><span class="proficiency-value${capped}" data-cap="${profCap}">${value}</span></li>`;
       });
-      html += '</div>';
+      html += '</ul>';
     } else {
-      html += '<div class="proficiency-grid">';
+      html += '<ul class="proficiency-list">';
       list.forEach(key => {
         const value = currentCharacter[key] ?? 0;
         const name = key.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase());
         const capped = value >= 100 ? ' capped' : '';
-        html += `<div class="proficiency-item"><span class="proficiency-name">${name}</span><span class="proficiency-value${capped}" data-cap="${profCap}">${value}</span></div>`;
+        html += `<li class="proficiency-item"><span class="proficiency-name">${name}</span><span class="proficiency-value${capped}" data-cap="${profCap}">${value}</span></li>`;
       });
-      html += '</div>';
+      html += '</ul>';
     }
+    html += '</section>';
   }
   html += '</div>';
   setMainHTML(html);

--- a/style.css
+++ b/style.css
@@ -746,21 +746,45 @@ body.theme-dark {
     accent-color: var(--range-color);
   }
 
-.proficiency-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.5rem 1rem;
+.proficiencies-screen {
   width: 100%;
 }
 
-.proficiency-grid + .proficiency-grid {
-  margin-top: 1rem;
+.proficiency-section {
+  margin-bottom: 1rem;
+}
+
+.proficiency-section h2 {
+  background: var(--foreground);
+  color: var(--background);
+  padding: 0.25rem 0.5rem;
+}
+
+.proficiency-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.proficiency-list + .proficiency-list {
+  margin-top: 0.5rem;
 }
 
 .proficiency-item {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  position: relative;
+  padding: 0.25rem 0;
+}
+
+.proficiency-item:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  background: linear-gradient(to right, var(--background), var(--foreground), var(--background));
 }
 
 .proficiency-name {
@@ -770,6 +794,7 @@ body.theme-dark {
 }
 
 .proficiency-value {
+  margin-left: auto;
   width: 3ch;
   text-align: right;
 }
@@ -982,11 +1007,6 @@ body.theme-dark {
 
 .icon.heal .arrow {
   color: green;
-}
-
-.icon .humanoid {
-  font-size: 0.8em;
-  margin-left: -0.1em;
 }
 
 .icon.slime {


### PR DESCRIPTION
## Summary
- Restyle Proficiencies screen to use single-column lists with separators and reversed headers
- Remove redundant page header and tighten spacing between proficiency labels and values
- Simplify magic school icons to only show arrows or symbols

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af5a77c22483259efd4e970109f041