### PR TITLE
Refine proficiency categories and layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -378,7 +378,7 @@ function migrateProficiencies(character) {
 }
 
 const proficiencyCategories = {
-  Magical: [
+  'Elemental Magic': [
     'stone',
     'water',
     'wind',
@@ -386,7 +386,9 @@ const proficiencyCategories = {
     'ice',
     'thunder',
     'dark',
-    'light',
+    'light'
+  ],
+  'Magical Schools': [
     'destructive',
     'healing',
     'reinforcement',
@@ -798,37 +800,18 @@ function showProficienciesUI() {
   const profCap = proficiencyCap(currentCharacter.level);
   let html = '<div class="proficiencies-screen">';
   for (const [type, list] of Object.entries(proficiencyCategories)) {
+    const items = list.filter(key => (currentCharacter[key] ?? 0) > 0);
+    if (!items.length) continue;
     html += '<section class="proficiency-section">';
     html += `<h2>${type}</h2>`;
-    if (type === 'Magical') {
-      const elemental = list.filter(k => ELEMENTAL_MAGIC_KEYS.includes(k));
-      const other = list.filter(k => !ELEMENTAL_MAGIC_KEYS.includes(k));
-      html += '<ul class="proficiency-list">';
-      elemental.forEach(key => {
-        const value = currentCharacter[key] ?? 0;
-        const name = key.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase());
-        const capped = value >= 100 ? ' capped' : '';
-        html += `<li class="proficiency-item"><span class="proficiency-name">${name}</span><span class="proficiency-value${capped}" data-cap="${profCap}">${value}</span></li>`;
-      });
-      html += '</ul><ul class="proficiency-list">';
-      other.forEach(key => {
-        const value = currentCharacter[key] ?? 0;
-        const name = key.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase());
-        const capped = value >= 100 ? ' capped' : '';
-        html += `<li class="proficiency-item"><span class="proficiency-name">${name}</span><span class="proficiency-value${capped}" data-cap="${profCap}">${value}</span></li>`;
-      });
-      html += '</ul>';
-    } else {
-      html += '<ul class="proficiency-list">';
-      list.forEach(key => {
-        const value = currentCharacter[key] ?? 0;
-        const name = key.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase());
-        const capped = value >= 100 ? ' capped' : '';
-        html += `<li class="proficiency-item"><span class="proficiency-name">${name}</span><span class="proficiency-value${capped}" data-cap="${profCap}">${value}</span></li>`;
-      });
-      html += '</ul>';
-    }
-    html += '</section>';
+    html += '<ul class="proficiency-list">';
+    items.forEach(key => {
+      const value = currentCharacter[key] ?? 0;
+      const name = key.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase());
+      const capped = value >= 100 ? ' capped' : '';
+      html += `<li class="proficiency-item"><span class="proficiency-name">${name}</span><span class="proficiency-value${capped}" data-cap="${profCap}">${value}</span></li>`;
+    });
+    html += '</ul></section>';
   }
   html += '</div>';
   setMainHTML(html);

--- a/style.css
+++ b/style.css
@@ -773,6 +773,7 @@ body.theme-dark {
 .proficiency-item {
   display: flex;
   align-items: center;
+  gap: 0.5rem;
   position: relative;
   padding: 0.25rem 0;
 }
@@ -788,13 +789,13 @@ body.theme-dark {
 }
 
 .proficiency-name {
-  flex: 1;
+  flex: 0 0 auto;
+  max-width: 12rem;
   text-align: left;
   padding-right: 0.5rem;
 }
 
 .proficiency-value {
-  margin-left: auto;
   width: 3ch;
   text-align: right;
 }


### PR DESCRIPTION
## Summary
- Split magic proficiencies into Elemental Magic and Magical Schools
- Hide zero-valued proficiencies
- Constrain proficiency name width for tighter value spacing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af5d95c4bc8325be7789dc856c17ec