### PR TITLE
Align proficiency list values by normalizing name widths

### DIFF
--- a/script.js
+++ b/script.js
@@ -77,6 +77,20 @@ function normalizeOptionButtonWidths() {
   });
 }
 
+function normalizeProficiencyNameWidths() {
+  const names = Array.from(document.querySelectorAll('.proficiency-name'));
+  if (!names.length) return;
+  let maxWidth = 0;
+  names.forEach(n => {
+    n.style.width = 'auto';
+    const w = n.getBoundingClientRect().width;
+    if (w > maxWidth) maxWidth = w;
+  });
+  names.forEach(n => {
+    n.style.width = `${maxWidth}px`;
+  });
+}
+
 // --- Profile and save management ---
 const STORAGE_KEY = 'rpgProfiles';
 const LAST_PROFILE_KEY = 'rpgLastProfile';
@@ -815,6 +829,7 @@ function showProficienciesUI() {
   }
   html += '</div>';
   setMainHTML(html);
+  normalizeProficiencyNameWidths();
   setupProficiencyTooltips();
 }
 

--- a/style.css
+++ b/style.css
@@ -793,6 +793,7 @@ body.theme-dark {
   max-width: 12rem;
   text-align: left;
   padding-right: 0.5rem;
+  box-sizing: border-box;
 }
 
 .proficiency-value {


### PR DESCRIPTION
## Summary
- ensure proficiency values align by sizing all names to match the longest
- set proficiency name spans to border-box for accurate width measurement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af6701d970832599edfed07a73ff15