### PR TITLE
Adjust creation progress layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -1146,7 +1146,12 @@ function startCharacterCreation() {
 
       const currentStepEl = document.querySelector('.progress-step.current');
       const optionsEl = document.querySelector('.cc-options');
-      if (currentStepEl && optionsEl) currentStepEl.appendChild(optionsEl);
+      if (currentStepEl && optionsEl) {
+        const detailEl = document.createElement('div');
+        detailEl.className = 'progress-current-detail';
+        currentStepEl.after(detailEl);
+        detailEl.appendChild(optionsEl);
+      }
 
       if (field.key === 'location') {
         const options = field.options;
@@ -1240,7 +1245,12 @@ function startCharacterCreation() {
       normalizeOptionButtonWidths();
       const currentStepEl = document.querySelector('.progress-step.current');
       const optionsEl = document.querySelector('.cc-options');
-      if (currentStepEl && optionsEl) currentStepEl.appendChild(optionsEl);
+      if (currentStepEl && optionsEl) {
+        const detailEl = document.createElement('div');
+        detailEl.className = 'progress-current-detail';
+        currentStepEl.after(detailEl);
+        detailEl.appendChild(optionsEl);
+      }
       const nameInput = document.getElementById('name-input');
       const updateName = () => {
         character.name = nameInput.value.trim();

--- a/style.css
+++ b/style.css
@@ -676,13 +676,19 @@ body.theme-dark {
   }
 
   .wheel-selector {
-    margin-left: 0.5rem;
+    margin-left: 0;
     display: flex;
     align-items: center;
   }
 
-  .progress-step input {
-    margin-left: 0.5rem;
+  .progress-current-detail {
+    display: flex;
+    flex-direction: column;
+    margin: 0.5rem 0 0.5rem 1.5rem;
+  }
+
+  .progress-current-detail input {
+    margin-left: 0;
   }
 
   .color-button {


### PR DESCRIPTION
## Summary
- Move current step wheel selector into a detail row below the indicator
- Add styles to indent the detail row and remove extra margin

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68af7396ab9083259d9b649c9bbf723d