### PR TITLE
Unify wheel selector options and remove stats header

### DIFF
--- a/script.js
+++ b/script.js
@@ -1036,7 +1036,7 @@ function startCharacterCreation() {
       const resList = Object.entries(resources)
         .map(([k, v]) => `<li>${k}: ${v}</li>`)
         .join('');
-      const statsHTML = `<div class="race-stats"><h3>Starting Stats</h3><ul>${attrList}</ul><ul>${resList}</ul></div>`;
+      const statsHTML = `<div class="race-stats"><ul>${attrList}</ul><ul>${resList}</ul></div>`;
       const imageSrc = RACE_IMAGES[character.race];
       const imageHTML = imageSrc ? `<img class="race-image" src="${imageSrc}" alt="${character.race}">` : '';
       const descHTML = `<div class="race-description">${RACE_DESCRIPTIONS[character.race] || ''}</div>`;

--- a/style.css
+++ b/style.css
@@ -580,14 +580,23 @@ body.theme-dark {
     align-items: flex-start;
   }
 
-  .option-grid button {
+  .option-button {
+    width: 8rem;
+    height: 2rem;
     padding: 0.5rem;
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  .option-grid button {
     border: 2px solid var(--foreground);
     background: var(--background);
     color: var(--foreground);
     cursor: pointer;
-    box-sizing: border-box;
-    white-space: nowrap;
   }
 
   .option-grid button:hover {
@@ -615,14 +624,13 @@ body.theme-dark {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 1rem;
+    gap: 0;
   }
 
   .location-button,
   .race-button,
   .sex-button {
     position: relative;
-    padding: 0.5rem 1rem;
     background: transparent;
     border: none;
     color: var(--foreground);
@@ -664,7 +672,12 @@ body.theme-dark {
     color: var(--foreground);
     font-size: 2rem;
     line-height: 1;
-    padding: 0 0.5rem;
+    padding: 0;
+    width: 2rem;
+    height: 2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     cursor: pointer;
   }
 
@@ -705,6 +718,7 @@ body.theme-dark {
     cursor: pointer;
     font-size: 1.5rem;
     line-height: 1;
+    margin-left: 0.5rem;
   }
 
   .complete-button {


### PR DESCRIPTION
## Summary
- Remove "Starting Stats" header from character creation preview
- Make wheel selector and option buttons a consistent size
- Eliminate spacing between wheel arrows and selection option

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af85705b8c83259bb6dd63854e4203