### PR TITLE
Keep stats beside progress in character creation

### DIFF
--- a/script.js
+++ b/script.js
@@ -1155,28 +1155,9 @@ function startCharacterCreation() {
         )}</span>`;
       }
 
-      const portrait = isPortraitLayout();
-      if (field.key === 'location') {
-        if (portrait) {
-          setMainHTML(
-            `<div class="character-creation"><div class="progress-container">${progressHTML}</div><div class="cc-column"><div class="cc-top"><div class="cc-options">${inputHTML}</div></div></div><div class="cc-info">${descHTML}${imageHTML}</div></div>`
-          );
-        } else {
-          setMainHTML(
-            `<div class="character-creation"><div class="progress-container">${progressHTML}</div><div class="cc-column"><div class="cc-top"><div class="cc-options">${inputHTML}</div>${descHTML}</div>${imageHTML}</div></div>`
-          );
-        }
-      } else {
-        if (portrait) {
-          setMainHTML(
-            `<div class="character-creation"><div class="progress-container">${progressHTML}</div><div class="cc-column"><div class="cc-top">${statsHTML}<div class="cc-options">${inputHTML}</div></div></div><div class="cc-info">${descHTML}${imageHTML}</div></div>`
-          );
-        } else {
-          setMainHTML(
-            `<div class="character-creation"><div class="progress-container">${progressHTML}</div><div class="cc-column"><div class="cc-top">${statsHTML}<div class="cc-options">${inputHTML}</div>${descHTML}</div>${imageHTML}</div></div>`
-          );
-        }
-      }
+      setMainHTML(
+        `<div class="character-creation"><div class="cc-top-row"><div class="progress-container">${progressHTML}</div>${statsHTML}</div><div class="cc-options">${inputHTML}</div><div class="cc-info">${descHTML}${imageHTML}</div></div>`
+      );
       normalizeOptionButtonWidths();
 
       const currentStepEl = document.querySelector('.progress-step.current');
@@ -1276,12 +1257,9 @@ function startCharacterCreation() {
       }
     } else {
       const nameVal = character.name || '';
-      const portrait = isPortraitLayout();
-      if (portrait) {
-        setMainHTML(`<div class="character-creation"><div class="progress-container">${progressHTML}</div><div class="cc-column"><div class="cc-top">${statsHTML}<div class="cc-options"><input type="text" id="name-input" value="${nameVal}" placeholder="Name"></div></div></div><div class="cc-info">${descHTML}${imageHTML}</div></div>`);
-      } else {
-        setMainHTML(`<div class="character-creation"><div class="progress-container">${progressHTML}</div><div class="cc-column"><div class="cc-top">${statsHTML}<div class="cc-options"><input type="text" id="name-input" value="${nameVal}" placeholder="Name"></div>${descHTML}</div>${imageHTML}</div></div>`);
-      }
+      setMainHTML(
+        `<div class="character-creation"><div class="cc-top-row"><div class="progress-container">${progressHTML}</div>${statsHTML}</div><div class="cc-options"><input type="text" id="name-input" value="${nameVal}" placeholder="Name"></div><div class="cc-info">${descHTML}${imageHTML}</div></div>`
+      );
       normalizeOptionButtonWidths();
       const currentStepEl = document.querySelector('.progress-step.current');
       const optionsEl = document.querySelector('.cc-options');

--- a/style.css
+++ b/style.css
@@ -470,12 +470,21 @@ body.theme-dark {
 
   .character-creation {
     display: flex;
+    flex-direction: column;
     align-items: flex-start;
   }
 
   body.layout-portrait .character-creation {
-    flex-direction: column;
     align-items: stretch;
+  }
+
+  .cc-top-row {
+    display: flex;
+    align-items: flex-start;
+  }
+
+  body.layout-portrait .cc-top-row {
+    flex-direction: column;
   }
 
   .progress-container {
@@ -488,16 +497,6 @@ body.theme-dark {
   body.layout-portrait .progress-container {
     margin-right: 0;
     margin-bottom: 0.5rem;
-    order: 0;
-  }
-
-  body.layout-portrait .cc-column {
-    order: 1;
-  }
-
-  body.layout-portrait .cc-info {
-    order: 2;
-    margin-top: 0.5rem;
   }
 
   .progress-step {
@@ -541,24 +540,11 @@ body.theme-dark {
     margin-left: 0.5rem;
   }
 
-  .cc-column {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    width: 100%;
-  }
-
   .cc-info {
     display: flex;
     flex-direction: column;
     align-items: center;
-  }
-
-  .cc-top {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.125rem;
-    width: 100%;
+    margin-top: 0.5rem;
   }
 
   .race-stats {
@@ -591,11 +577,6 @@ body.theme-dark {
 
   .race-description {
     margin-top: 0;
-  }
-
-  body.layout-portrait .cc-top {
-    flex-direction: column;
-    align-items: center;
   }
 
 


### PR DESCRIPTION
## Summary
- Keep starting stats in a column next to character creation steps
- Move description and portrait to a dedicated section below the steps
- Simplify layout CSS with new `cc-top-row` container

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68b0477af11c8325b6a0bf3d05dfe28d