### PR TITLE
Expand spell schools with full elemental coverage

### DIFF
--- a/script.js
+++ b/script.js
@@ -725,7 +725,7 @@ function showSpellDetails(spell) {
   const content = document.createElement('div');
   content.className = 'spell-detail-content';
   const desc = `${spell.type} - ${spell.target}`;
-  content.innerHTML = `<h3>${spell.name}</h3><p>${desc}</p><p>Element: ${spell.element}</p><p>School: ${spell.school}</p><p>Base Power: ${spell.basePower}</p><p>MP Cost: ${spell.mpCost}</p>`;
+  content.innerHTML = `<h3>${spell.name}</h3><p>${desc}</p><p>${spell.description}</p><p>Element: ${spell.element}</p><p>School: ${spell.school}</p><p>Base Power: ${spell.basePower}</p><p>MP Cost: ${spell.mpCost}</p>`;
   const close = document.createElement('button');
   close.textContent = 'Close';
   close.addEventListener('click', () => overlay.remove());


### PR DESCRIPTION
## Summary
- Added helpers to expand spell names and generate narrative descriptions
- Created tiered spell lists for all schools across every element, including magnetism-inspired thunder magic
- Display spell descriptions in the spell detail modal

## Testing
- `node -e "import('./assets/data/spells.js').then(m=>console.log('count', m.SPELLBOOK.length))"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0af2040c08325bf96687bb986d89d