### PR TITLE
Add icons for hybrid elements in spellbook

### DIFF
--- a/script.js
+++ b/script.js
@@ -488,6 +488,19 @@ const elementIcons = {
   Light: '☀️'
 };
 
+// Add icons for hybrid elements by combining parent icons or using special symbols
+HYBRID_RELATIONS.forEach(rel => {
+  if (rel.name === 'Order') {
+    elementIcons[rel.name] = '⚖️';
+  } else if (rel.name === 'Chaos') {
+    elementIcons[rel.name] = '🌀';
+  } else {
+    const p1 = elementIcons[rel.parents[0]] || '';
+    const p2 = elementIcons[rel.parents[1]] || '';
+    elementIcons[rel.name] = `${p1}${p2}`;
+  }
+});
+
 const schoolIcons = {
   Destructive: '💥',
   Enfeebling:


### PR DESCRIPTION
## Summary
- Derive hybrid element icons from parent elements or special symbols
- Ensure hybrid elements display with icons in the spellbook

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0cd1410a08325b40928be228aced3