### PR TITLE
Rename Sunfire to Sacred Flame

### DIFF
--- a/assets/data/hybrid_relations.js
+++ b/assets/data/hybrid_relations.js
@@ -17,7 +17,7 @@ export const HYBRID_RELATIONS = [
   { name:"Wildfire", parents:["Fire","Wind"], strong:["Wood"], weak:["Water"] },
   { name:"Ash", parents:["Fire","Ice"], strong:["Light"], weak:["Wind"] },
   { name:"Plasma", parents:["Fire","Thunder"], strong:["Metal"], weak:["Water"] },
-  { name:"Sunfire", parents:["Fire","Light"], strong:["Dark"], weak:["Water"] },
+  { name:"Sacred Flame", parents:["Fire","Light"], strong:["Dark"], weak:["Water"] },
   { name:"Hellfire", parents:["Fire","Dark"], strong:["Light"], weak:["Ice"] },
 
   { name:"Blizzard", parents:["Wind","Ice"], strong:["Fire"], weak:["Stone"] },


### PR DESCRIPTION
## Summary
- Rename the Fire+Light hybrid element from Sunfire to Sacred Flame
- Validated existing spell names avoid magic school terms and bland element-only names

## Testing
- `node --input-type=module -e "import('./assets/data/spells.js').then(()=>{const schools=['Destructive','Enfeebling','Reinforcement','Healing','Summoning']; const bad=[]; const N=globalThis.NAMES; for (const elem in N){const families=N[elem]; const collect=(names)=>{for(const n of names){for(const s of schools){if(n.includes(s)) bad.push(n);}}}; for(const key in families){const val=families[key]; if(Array.isArray(val)) collect(val); else if(typeof val==='object'){collect(Object.values(val));} else if(typeof val==='string'){collect([val]);}}} console.log('bad names', bad);})"`
- `node --input-type=module -e "import('./assets/data/spells.js').then(()=>{const N=globalThis.NAMES; const bland=[]; for(const elem in N){const families=N[elem]; const collect=(names)=>{for(const n of names){if(n.toLowerCase()===elem.toLowerCase()) bland.push(n);}}; for(const key in families){const val=families[key]; if(Array.isArray(val)) collect(val); else if(typeof val==='object'){collect(Object.values(val));} else if(typeof val==='string'){collect([val]);}}} console.log('bland names', bland);})"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d0d24c4c8325b49bc72515dfc52c