### PR TITLE
Remove redundant spell proficiency labels

### DIFF
--- a/script.js
+++ b/script.js
@@ -829,8 +829,7 @@ function showSpellbookUI() {
           const sIcon = schoolIcons[key] || '';
           html += `<h3 class="spell-subheading"><span class="school-icon">${sIcon}</span>${key}</h3><ul class="spell-list">`;
           grouped[key].forEach(spell => {
-            const reqLabel = proficiencyToTierLabel(spell.proficiency);
-            html += `<li class="spell-item"><button class="spell-name" data-spell-id="${spell.id}">${spell.name}</button> <span class="spell-req">(${reqLabel})</span></li>`;
+            html += `<li class="spell-item"><button class="spell-name" data-spell-id="${spell.id}">${spell.name}</button></li>`;
           });
           html += '</ul>';
         });
@@ -846,8 +845,7 @@ function showSpellbookUI() {
           const label = proficiencyToTierLabel(key);
           html += `<h3 class="spell-subheading">${label}</h3><ul class="spell-list">`;
           grouped[key].forEach(spell => {
-            const reqLabel = proficiencyToTierLabel(spell.proficiency);
-            html += `<li class="spell-item"><button class="spell-name" data-spell-id="${spell.id}">${spell.name}</button> <span class="spell-req">(${reqLabel})</span></li>`;
+            html += `<li class="spell-item"><button class="spell-name" data-spell-id="${spell.id}">${spell.name}</button></li>`;
           });
           html += '</ul>';
         });


### PR DESCRIPTION
## Summary
- Remove tier labels like "(Cantrips)" from spell list entries
- Spell proficiency tiers now indicated solely by list subheaders

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/RPG/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b0e24b46908325af73249a5d93c5f4