### PR TITLE
feat: expand city navigation and show current city

### DIFF
--- a/assets/data/city_nav.js
+++ b/assets/data/city_nav.js
@@ -5,14 +5,55 @@ export const CITY_NAV = {
         travelPrompt: "Walk to",
         points: [
           { name: "Tideway Inn", type: "building", target: "Tideway Inn" },
-          { name: "Upper Ward", type: "district", target: "Upper Ward" }
+          { name: "Upper Ward", type: "district", target: "Upper Ward" },
+          { name: "Little Terns", type: "district", target: "Little Terns" }
         ]
       },
       "Upper Ward": {
         travelPrompt: "Walk to",
         points: [
           { name: "Governor's Keep", type: "building", target: "Governor's Keep" },
-          { name: "Port District", type: "district", target: "Port District" }
+          { name: "Crafting Quarter", type: "building", target: "Crafting Quarter" },
+          { name: "Mercantile Exchange", type: "building", target: "Mercantile Exchange" },
+          { name: "Temple of the Tides", type: "building", target: "Temple of the Tides" },
+          { name: "Hall of Records", type: "building", target: "Hall of Records" },
+          { name: "Port District", type: "district", target: "Port District" },
+          { name: "Greensoul Hill", type: "district", target: "Greensoul Hill" }
+        ]
+      },
+      "Little Terns": {
+        travelPrompt: "Walk to",
+        points: [
+          { name: "Port District", type: "district", target: "Port District" },
+          { name: "Greensoul Hill", type: "district", target: "Greensoul Hill" }
+        ]
+      },
+      "Greensoul Hill": {
+        travelPrompt: "Walk to",
+        points: [
+          { name: "Upper Ward", type: "district", target: "Upper Ward" },
+          { name: "Little Terns", type: "district", target: "Little Terns" },
+          { name: "The Lower Gardens", type: "district", target: "The Lower Gardens" }
+        ]
+      },
+      "The Lower Gardens": {
+        travelPrompt: "Walk to",
+        points: [
+          { name: "Greensoul Hill", type: "district", target: "Greensoul Hill" },
+          { name: "The High Road District", type: "district", target: "The High Road District" }
+        ]
+      },
+      "The High Road District": {
+        travelPrompt: "Walk to",
+        points: [
+          { name: "The Lower Gardens", type: "district", target: "The Lower Gardens" },
+          { name: "The Farmlands Beyond the Walls", type: "district", target: "The Farmlands Beyond the Walls" }
+        ]
+      },
+      "The Farmlands Beyond the Walls": {
+        travelPrompt: "Walk to",
+        points: [
+          { name: "The High Road District", type: "district", target: "The High Road District" }
         ]
       }
     },
@@ -23,6 +64,26 @@ export const CITY_NAV = {
         interactions: [ { name: "Rest", action: "rest" } ]
       },
       "Governor's Keep": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "Upper Ward", target: "Upper Ward" } ],
+        interactions: []
+      },
+      "Crafting Quarter": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "Upper Ward", target: "Upper Ward" } ],
+        interactions: []
+      },
+      "Mercantile Exchange": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "Upper Ward", target: "Upper Ward" } ],
+        interactions: []
+      },
+      "Temple of the Tides": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "Upper Ward", target: "Upper Ward" } ],
+        interactions: []
+      },
+      "Hall of Records": {
         travelPrompt: "Exit to",
         exits: [ { name: "Upper Ward", target: "Upper Ward" } ],
         interactions: []

--- a/script.js
+++ b/script.js
@@ -684,14 +684,18 @@ function showNavigation() {
     (building.interactions || []).forEach(i => {
       buttons.push(`<button data-type="interaction" data-action="${i.action}">${i.name}</button>`);
     });
-    setMainHTML(`<div class="navigation"><h2>${pos.building}</h2><div class="option-grid">${buttons.join('')}</div></div>`);
+    setMainHTML(
+      `<div class="navigation"><h1 class="city-name">${pos.city}</h1><h2>${pos.building}</h2><div class="option-grid">${buttons.join('')}</div></div>`
+    );
   } else {
     const district = cityData.districts[pos.district];
     const buttons = district.points.map(pt => {
       const prompt = pt.type === 'district' ? 'Travel to' : district.travelPrompt || 'Walk to';
       return `<button data-type="${pt.type}" data-target="${pt.target}">${prompt} ${pt.name}</button>`;
     });
-    setMainHTML(`<div class="navigation"><h2>${pos.district}</h2><div class="option-grid">${buttons.join('')}</div></div>`);
+    setMainHTML(
+      `<div class="navigation"><h1 class="city-name">${pos.city}</h1><h2>${pos.district}</h2><div class="option-grid">${buttons.join('')}</div></div>`
+    );
   }
   normalizeOptionButtonWidths();
   updateMenuHeight();

--- a/style.css
+++ b/style.css
@@ -642,6 +642,11 @@ body.theme-dark {
     color: var(--background);
   }
 
+  .navigation .city-name {
+    margin: 0 0 0.5rem 0;
+    text-align: center;
+  }
+
   .location-select,
   .race-select {
     display: flex;


### PR DESCRIPTION
## Summary
- display current city or zone name above district and travel options
- extend Wave's Break navigation with additional districts and key crafting, commercial, religious, and political buildings
- style navigation headings for the city name

## Testing
- `npm test` *(fails: missing package.json)*
- `node --check script.js`
- `node --check assets/data/city_nav.js`


------
https://chatgpt.com/codex/tasks/task_e_68b116e7f60c8325846494451d869f71