### PR TITLE
Add Wave's Break population data

### DIFF
--- a/assets/data/locations.js
+++ b/assets/data/locations.js
@@ -12,6 +12,7 @@ export function createLocation(name, mapFile, description = "") {
             tradeRoutes: [],
             resources: { domestic: [], exports: [], imports: [] },
         },
+        population: undefined,
     };
 }
 const WAVES_BREAK = Object.assign(Object.assign({}, createLocation("Wave's Break", "Wave's Break.png", `The City of Wave's Break
@@ -28,9 +29,42 @@ Its people are diverse: salt-stained sailors, silver-tongued merchants, hammer-a
         "Little Terns",
         "Greensoul Hill",
         "The Lower Gardens",
-        "The High Road District (East Gate Approach)",
-        "The Farmlands Beyond the Walls",
-    ], pointsOfInterest: {
+    "The High Road District (East Gate Approach)",
+    "The Farmlands Beyond the Walls",
+    ], population: {
+        estimate: 31500,
+        range: [28000, 34000],
+        districts: {
+            "Port District": {
+                estimate: 6000,
+                notes: "dockworkers, fishers, chandlers, coopers, ropewalkers, shipwright families",
+            },
+            "Little Terns": {
+                estimate: 9000,
+                notes: "artisans: smiths, carpenters and lumber yards, tailors, potters, tanners, cobblers, mills",
+            },
+            "Lower Gardens": {
+                estimate: 5500,
+                notes: "market gardeners, brewers, herbalists, arena staff, service trades",
+            },
+            "Upper Ward": {
+                estimate: 3000,
+                notes: "administration, noble households, guards, high-end merchants",
+            },
+            "Greensoul Hill": {
+                estimate: 3500,
+                notes: "clergy, healers, scribes, arcanists, students",
+            },
+            "High Road District": {
+                estimate: 4500,
+                notes: "caravan trades, armourers, wagonwrights, leatherworkers, teamsters",
+            },
+        },
+        hinterland: {
+            estimate: 7500,
+            notes: "farmsteads, mills, brickworks, and quarries outside the walls",
+        },
+    }, pointsOfInterest: {
         buildings: [
             "Dockmaster's Hall",
             "Warehouse Row",

--- a/assets/data/locations.ts
+++ b/assets/data/locations.ts
@@ -22,6 +22,12 @@ export interface Location {
       imports: string[];
     };
   };
+  population?: {
+    estimate: number;
+    range: [number, number];
+    districts: Record<string, { estimate: number; notes: string }>;
+    hinterland?: { estimate: number; notes: string };
+  };
 }
 
 export function createLocation(
@@ -41,6 +47,7 @@ export function createLocation(
       tradeRoutes: [],
       resources: { domestic: [], exports: [], imports: [] },
     },
+    population: undefined,
   };
 }
 
@@ -67,6 +74,46 @@ Its people are diverse: salt-stained sailors, silver-tongued merchants, hammer-a
     "The High Road District (East Gate Approach)",
     "The Farmlands Beyond the Walls",
   ],
+  population: {
+    estimate: 31500,
+    range: [28000, 34000],
+    districts: {
+      "Port District": {
+        estimate: 6000,
+        notes:
+          "dockworkers, fishers, chandlers, coopers, ropewalkers, shipwright families",
+      },
+      "Little Terns": {
+        estimate: 9000,
+        notes:
+          "artisans: smiths, carpenters and lumber yards, tailors, potters, tanners, cobblers, mills",
+      },
+      "Lower Gardens": {
+        estimate: 5500,
+        notes:
+          "market gardeners, brewers, herbalists, arena staff, service trades",
+      },
+      "Upper Ward": {
+        estimate: 3000,
+        notes:
+          "administration, noble households, guards, high-end merchants",
+      },
+      "Greensoul Hill": {
+        estimate: 3500,
+        notes: "clergy, healers, scribes, arcanists, students",
+      },
+      "High Road District": {
+        estimate: 4500,
+        notes:
+          "caravan trades, armourers, wagonwrights, leatherworkers, teamsters",
+      },
+    },
+    hinterland: {
+      estimate: 7500,
+      notes:
+        "farmsteads, mills, brickworks, and quarries outside the walls",
+    },
+  },
   pointsOfInterest: {
     buildings: [
       "Dockmaster's Hall",


### PR DESCRIPTION
## Summary
- Track population details for locations
- Include Wave's Break resident and district populations

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b1b62e3ab8832596b9267b780b3270