### PR TITLE
Add Timber Grove location and navigation

### DIFF
--- a/assets/data/city_nav.js
+++ b/assets/data/city_nav.js
@@ -89,5 +89,89 @@ export const CITY_NAV = {
         interactions: []
       }
     }
+  },
+  "Timber Grove": {
+    districts: {
+      "Central Plaza": {
+        travelPrompt: "Walk to",
+        points: [
+          { name: "Fishing Bridges", type: "district", target: "Fishing Bridges" },
+          { name: "The Lumberworks", type: "district", target: "The Lumberworks" },
+          { name: "Fields & Orchards", type: "district", target: "Fields & Orchards" },
+          { name: "Shrine of the Forest Father", type: "building", target: "Shrine of the Forest Father" },
+          { name: "The Timberhall", type: "building", target: "The Timberhall" },
+          { name: "Forest Rest Inn", type: "building", target: "Forest Rest Inn" },
+          { name: "The Riverhouse", type: "building", target: "The Riverhouse" }
+        ]
+      },
+      "Fishing Bridges": {
+        travelPrompt: "Walk to",
+        points: [
+          { name: "Central Plaza", type: "district", target: "Central Plaza" },
+          { name: "The Mine", type: "district", target: "The Mine" },
+          { name: "Wayside Shrine of the River-Mother", type: "building", target: "Wayside Shrine of the River-Mother" }
+        ]
+      },
+      "The Lumberworks": {
+        travelPrompt: "Walk to",
+        points: [
+          { name: "Central Plaza", type: "district", target: "Central Plaza" },
+          { name: "Fields & Orchards", type: "district", target: "Fields & Orchards" },
+          { name: "Logger's Flask Tavern", type: "building", target: "Logger's Flask Tavern" }
+        ]
+      },
+      "Fields & Orchards": {
+        travelPrompt: "Walk to",
+        points: [
+          { name: "The Lumberworks", type: "district", target: "The Lumberworks" },
+          { name: "The Mine", type: "district", target: "The Mine" }
+        ]
+      },
+      "The Mine": {
+        travelPrompt: "Walk to",
+        points: [
+          { name: "Fields & Orchards", type: "district", target: "Fields & Orchards" },
+          { name: "Fishing Bridges", type: "district", target: "Fishing Bridges" },
+          { name: "Crystalsong Lodge", type: "building", target: "Crystalsong Lodge" }
+        ]
+      }
+    },
+    buildings: {
+      "Shrine of the Forest Father": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "Central Plaza", target: "Central Plaza" } ],
+        interactions: []
+      },
+      "The Timberhall": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "Central Plaza", target: "Central Plaza" } ],
+        interactions: []
+      },
+      "Forest Rest Inn": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "Central Plaza", target: "Central Plaza" } ],
+        interactions: [ { name: "Rest", action: "rest" } ]
+      },
+      "The Riverhouse": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "Central Plaza", target: "Central Plaza" } ],
+        interactions: []
+      },
+      "Wayside Shrine of the River-Mother": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "Fishing Bridges", target: "Fishing Bridges" } ],
+        interactions: []
+      },
+      "Logger's Flask Tavern": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "The Lumberworks", target: "The Lumberworks" } ],
+        interactions: []
+      },
+      "Crystalsong Lodge": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "The Mine", target: "The Mine" } ],
+        interactions: []
+      }
+    }
   }
 };

--- a/assets/data/locations.js
+++ b/assets/data/locations.js
@@ -258,11 +258,57 @@ Coral Keep is also a city of exchange. Caravans arrive from the lumber-rich high
             imports: ["timber", "spices", "silks", "gems"],
         },
     } });
+
+const TIMBER_GROVE = Object.assign(Object.assign({}, createLocation("Timber Grove", "Timber Grove.png", `Timber Grove – The Mountain Lumberstead
+
+Nestled along a bend in the mountain river, Timber Grove is a modest but vital settlement, its small wooden homes clustered beside water and forest alike. Known primarily as the chief harvester of great timbers in the western range, the town supplies the beams, masts, and keels shipped downriver to Coral Keep, fueling both construction and shipbuilding across the kingdom. The air is rich with the scent of pine and cedar, while the rhythmic thud of axes and saws blends with the chatter of the river.
+
+Though small, Timber Grove is also known for its secondary trades. Its forests yield luxury mushrooms, nuts, and tree saps, which are carefully harvested and sold as delicacies or ingredients for medicines and enchantments. The river provides rare freshwater fish, crawfish, and amphibians valued by herbalists and alchemists. From the nearby highland mine, the town occasionally turns up raw crystal and ore, some of which are rare enough to serve as material for magical enchantments. With its small population, Timber Grove relies on outside labor—many hands come seasonally from Creekside or Coral Keep, often through contracts or adventuring guild requests. For travelers, the town also serves as a waystop on the road between Creekside and Coral Keep, where one can rest, resupply, and find work before continuing on.`)), { subdivisions: [
+        "Central Plaza",
+        "Fishing Bridges",
+        "The Lumberworks",
+        "Fields & Orchards",
+        "The Mine",
+        "Farms & Homesteads",
+    ], position: {
+        general: "western mountain river bend",
+        relative: "between Creekside and Coral Keep",
+    }, travel: { routes: ["road to Creekside", "river to Coral Keep"], connections: ["Creekside", "Coral Keep"] }, population: {
+        estimate: 210,
+        range: [210, 400],
+        districts: {
+            "Town Proper": { estimate: 210, notes: "families of loggers, millers, fishermen, and farmers" },
+            "Seasonal Camps": { estimate: 75, notes: "outside laborers from Creekside and Coral Keep" },
+            "Waystop Travelers": { estimate: 45, notes: "daily adventurers, traders, and pilgrims" },
+        },
+        hinterland: { estimate: 60, notes: "scattered farms and homesteads around the town" },
+    }, pointsOfInterest: {
+        buildings: [
+            "Central Plaza",
+            "Fishing Bridges",
+            "The Lumberworks",
+            "Fields & Orchards",
+            "The Mine",
+            "Shrine of the Forest Father",
+            "Wayside Shrine of the River-Mother",
+            "The Timberhall",
+            "The Crystalsong Lodge",
+            "The Forest Rest Inn",
+            "The Logger's Flask Tavern",
+            "The Riverhouse",
+        ],
+        tradeRoutes: ["river barge to Coral Keep", "road caravans to Creekside"],
+        resources: {
+            domestic: ["timber", "grain", "nuts", "mushrooms", "tree sap", "freshwater fish", "crystals"],
+            exports: ["timber", "mushrooms", "saps", "crystals", "freshwater fish"],
+            imports: ["labor", "finished goods"],
+        },
+    } });
 export const LOCATIONS = {
     "Duvilia Kingdom": createLocation("Duvilia Kingdom", "Duvilia Kingdom.png"),
     "Wave's Break": WAVES_BREAK,
     "Coral Keep": CORAL_KEEP,
-    "Timber Grove": createLocation("Timber Grove", "Timber Grove.png", "Primary harvester of large lumber, plus rare freshwater fauna, crystals, mushrooms, and orchard fruits."),
+    "Timber Grove": TIMBER_GROVE,
     "Creekside": createLocation("Creekside", "Creekside.png", "Militarized former Wetlands Pass waypoint providing freshwater catch, cattle, dairy, leather, and sugar."),
     "Warm Springs": createLocation("Warm Springs", "Warm Springs.png", "Mining town exporting metals, reagents, and coveted hot spring mineral water with an alchemy guild branch."),
     "Dancing Pines": createLocation("Dancing Pines", "Dancing Pines.png", "Supplies small timber, metals, gemstones, game, and pelts; home to a renowned light-armor leatherworker."),

--- a/assets/data/locations.ts
+++ b/assets/data/locations.ts
@@ -329,6 +329,86 @@ Coral Keep is also a city of exchange. Caravans arrive from the lumber-rich high
   },
 };
 
+const TIMBER_GROVE: Location = {
+  ...createLocation(
+    "Timber Grove",
+    "Timber Grove.png",
+    `Timber Grove – The Mountain Lumberstead
+
+Nestled along a bend in the mountain river, Timber Grove is a modest but vital settlement, its small wooden homes clustered beside water and forest alike. Known primarily as the chief harvester of great timbers in the western range, the town supplies the beams, masts, and keels shipped downriver to Coral Keep, fueling both construction and shipbuilding across the kingdom. The air is rich with the scent of pine and cedar, while the rhythmic thud of axes and saws blends with the chatter of the river.
+
+Though small, Timber Grove is also known for its secondary trades. Its forests yield luxury mushrooms, nuts, and tree saps, which are carefully harvested and sold as delicacies or ingredients for medicines and enchantments. The river provides rare freshwater fish, crawfish, and amphibians valued by herbalists and alchemists. From the nearby highland mine, the town occasionally turns up raw crystal and ore, some of which are rare enough to serve as material for magical enchantments. With its small population, Timber Grove relies on outside labor—many hands come seasonally from Creekside or Coral Keep, often through contracts or adventuring guild requests. For travelers, the town also serves as a waystop on the road between Creekside and Coral Keep, where one can rest, resupply, and find work before continuing on.`
+  ),
+  subdivisions: [
+    "Central Plaza",
+    "Fishing Bridges",
+    "The Lumberworks",
+    "Fields & Orchards",
+    "The Mine",
+    "Farms & Homesteads",
+  ],
+  position: {
+    general: "western mountain river bend",
+    relative: "between Creekside and Coral Keep",
+  },
+  travel: {
+    routes: ["road to Creekside", "river to Coral Keep"],
+    connections: ["Creekside", "Coral Keep"],
+  },
+  population: {
+    estimate: 210,
+    range: [210, 400],
+    districts: {
+      "Town Proper": {
+        estimate: 210,
+        notes: "families of loggers, millers, fishermen, and farmers",
+      },
+      "Seasonal Camps": {
+        estimate: 75,
+        notes: "outside laborers from Creekside and Coral Keep",
+      },
+      "Waystop Travelers": {
+        estimate: 45,
+        notes: "daily adventurers, traders, and pilgrims",
+      },
+    },
+    hinterland: {
+      estimate: 60,
+      notes: "scattered farms and homesteads around the town",
+    },
+  },
+  pointsOfInterest: {
+    buildings: [
+      "Central Plaza",
+      "Fishing Bridges",
+      "The Lumberworks",
+      "Fields & Orchards",
+      "The Mine",
+      "Shrine of the Forest Father",
+      "Wayside Shrine of the River-Mother",
+      "The Timberhall",
+      "The Crystalsong Lodge",
+      "The Forest Rest Inn",
+      "The Logger's Flask Tavern",
+      "The Riverhouse",
+    ],
+    tradeRoutes: ["river barge to Coral Keep", "road caravans to Creekside"],
+    resources: {
+      domestic: [
+        "timber",
+        "grain",
+        "nuts",
+        "mushrooms",
+        "tree sap",
+        "freshwater fish",
+        "crystals",
+      ],
+      exports: ["timber", "mushrooms", "saps", "crystals", "freshwater fish"],
+      imports: ["labor", "finished goods"],
+    },
+  },
+};
+
 export const LOCATIONS: Record<string, Location> = {
   "Duvilia Kingdom": createLocation(
     "Duvilia Kingdom",
@@ -336,11 +416,7 @@ export const LOCATIONS: Record<string, Location> = {
   ),
   "Wave's Break": WAVES_BREAK,
   "Coral Keep": CORAL_KEEP,
-  "Timber Grove": createLocation(
-    "Timber Grove",
-    "Timber Grove.png",
-    "Primary harvester of large lumber, plus rare freshwater fauna, crystals, mushrooms, and orchard fruits."
-  ),
+  "Timber Grove": TIMBER_GROVE,
   "Creekside": createLocation(
     "Creekside",
     "Creekside.png",


### PR DESCRIPTION
## Summary
- add detailed Timber Grove location data with resources, population and points of interest
- wire up UI navigation for Timber Grove districts and buildings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b205c6be0483258ae884467dee193b