### PR TITLE
Refine element icons and colors

### DIFF
--- a/script.js
+++ b/script.js
@@ -511,8 +511,8 @@ const elementIcons = {
   Fire: '🔥',
   Ice: '❄️',
   Thunder: '⚡',
-  Dark: '🌑',
-  Light: '☀️',
+  Dark: '☁️',
+  Light: '✦',
   Wood: '🌲',
   Magma: '🌋',
   Sand: '🏜️',
@@ -529,8 +529,8 @@ const elementIcons = {
   Wildfire: '🔥',
   Ash: '🌫️',
   Plasma: '🧪',
-  'Sacred Flame': '🔥',
-  Hellfire: '😈',
+  'Sacred Flame': '<span class="icon sacred-flame"></span>',
+  Hellfire: '<span class="icon hellfire"></span>',
   Blizzard: '🌨️',
   Cyclone: '🌪️',
   Skyfire: '☄️',
@@ -551,8 +551,8 @@ const elementColors = {
   Fire: '#ef4444',
   Ice: '#60a5fa',
   Thunder: '#eab308',
-  Dark: '#4b5563',
-  Light: '#facc15'
+  Dark: '#1e1b4b',
+  Light: '#e5e4e2'
 };
 
 function getElementBackground(el) {

--- a/style.css
+++ b/style.css
@@ -1126,6 +1126,43 @@ body.theme-dark .element-icon {
   right: 0.3em;
 }
 
+.icon.sacred-flame {
+  position: relative;
+  display: inline-block;
+}
+
+.icon.sacred-flame::before {
+  content: '🔥';
+}
+
+.icon.sacred-flame::after {
+  content: '⭕';
+  position: absolute;
+  top: -0.35em;
+  left: 50%;
+  transform: translateX(-50%) scale(0.6);
+}
+
+.icon.hellfire {
+  position: relative;
+  display: inline-block;
+}
+
+.icon.hellfire::before {
+  content: '🔱';
+  position: absolute;
+  top: -0.2em;
+  left: -0.15em;
+  transform: rotate(-45deg);
+  z-index: 0;
+}
+
+.icon.hellfire::after {
+  content: '🔥';
+  position: relative;
+  z-index: 1;
+}
+
 .spell-name {
   background: none;
   border: none;


### PR DESCRIPTION
## Summary
- Update Light and Dark element icons and colors
- Add themed icons for Sacred Flame and Hellfire

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/RPG/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b2181f7a0083259af6e6506341cfc8