### PR TITLE
Add bakery and granary navigation points

### DIFF
--- a/assets/data/city_nav.js
+++ b/assets/data/city_nav.js
@@ -43,6 +43,8 @@ export const CITY_NAV = {
       "The Lower Gardens": {
         travelPrompt: "Walk to",
         points: [
+          { name: "City Bakery", type: "building", target: "City Bakery" },
+          { name: "Central Granary", type: "building", target: "Central Granary" },
           { name: "Greensoul Hill", type: "district", target: "Greensoul Hill" },
           { name: "The High Road District", type: "district", target: "The High Road District" }
         ]
@@ -123,6 +125,16 @@ export const CITY_NAV = {
           { name: "Coral Keep", target: "Coral Keep", type: "location", prompt: "Sail to" }
         ],
         interactions: []
+      },
+      "City Bakery": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "The Lower Gardens", target: "The Lower Gardens" } ],
+        interactions: [ { name: "Trade", action: "trade" } ]
+      },
+      "Central Granary": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "The Lower Gardens", target: "The Lower Gardens" } ],
+        interactions: [ { name: "Trade", action: "trade" } ]
       }
     }
   },
@@ -276,7 +288,9 @@ export const CITY_NAV = {
           { name: "The Creamery Hall", type: "building", target: "The Creamery Hall" },
           { name: "Leatherworkers' Guildhouse", type: "building", target: "Leatherworkers' Guildhouse" },
           { name: "Shrine of the Harvestmother", type: "building", target: "Shrine of the Harvestmother" },
-          { name: "The Plowman's Rest Tavern", type: "building", target: "The Plowman's Rest Tavern" }
+          { name: "The Plowman's Rest Tavern", type: "building", target: "The Plowman's Rest Tavern" },
+          { name: "City Bakery", type: "building", target: "City Bakery" },
+          { name: "Central Granary", type: "building", target: "Central Granary" }
         ]
       },
       "Everrise Bridge": {
@@ -353,6 +367,16 @@ export const CITY_NAV = {
         travelPrompt: "Exit to",
         exits: [ { name: "Greenford", target: "Greenford" } ],
         interactions: [ { name: "Rest", action: "rest" } ]
+      },
+      "City Bakery": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "Greenford", target: "Greenford" } ],
+        interactions: [ { name: "Trade", action: "trade" } ]
+      },
+      "Central Granary": {
+        travelPrompt: "Exit to",
+        exits: [ { name: "Greenford", target: "Greenford" } ],
+        interactions: [ { name: "Trade", action: "trade" } ]
       },
       "The Everrise Bridge": {
         travelPrompt: "Exit to",

--- a/assets/data/locations.js
+++ b/assets/data/locations.js
@@ -140,6 +140,8 @@ Its people are diverse: salt-stained sailors, silver-tongued merchants, hammer-a
             "Stone Quarries",
             "Outer Watchtowers",
             "Wayside Shrines",
+            "City Bakery",
+            "Central Granary",
         ],
         tradeRoutes: [],
         resources: {
@@ -401,6 +403,8 @@ The city thrives on industry, practicality, and defense. Its dense, stone-and-wo
             "Goat and Sheep Farms",
             "Outlying Watchtowers",
             "Roadside Shrine of the Forest Father",
+            "City Bakery",
+            "Central Granary",
         ],
         tradeRoutes: ["caravans to Timber Grove", "flatboats to Coral Keep"],
         resources: {

--- a/assets/data/locations.ts
+++ b/assets/data/locations.ts
@@ -191,6 +191,8 @@ Its people are diverse: salt-stained sailors, silver-tongued merchants, hammer-a
       "Stone Quarries",
       "Outer Watchtowers",
       "Wayside Shrines",
+      "City Bakery",
+      "Central Granary",
     ],
     tradeRoutes: [],
     resources: {
@@ -496,6 +498,8 @@ The city thrives on industry, practicality, and defense. Its dense, stone-and-wo
       "Goat and Sheep Farms",
       "Outlying Watchtowers",
       "Roadside Shrine of the Forest Father",
+      "City Bakery",
+      "Central Granary",
     ],
     tradeRoutes: ["caravans to Timber Grove", "flatboats to Coral Keep"],
     resources: {


### PR DESCRIPTION
## Summary
- add City Bakery and Central Granary to Wave's Break and Creekside locations
- connect City Bakery and Central Granary to city navigation with trade hooks

## Testing
- `npx tsc assets/data/locations.ts --target ES2017 --module ESNext --lib ES2017,DOM --moduleResolution node --esModuleInterop`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b257f0c3448325995646f0271bc0f8