### PR TITLE
Add default character names with randomizer

### DIFF
--- a/assets/data/names.js
+++ b/assets/data/names.js
@@ -1,0 +1,98 @@
+export const DEFAULT_NAMES = {
+  Human: {
+    male: [
+      'Aldric', 'Bartram', 'Cedric', 'Dorian', 'Emeric', 'Fendrel', 'Garrick', 'Hadrian', 'Ivor', 'Jareth',
+      'Kaelen', 'Leofric', 'Merrick', 'Nolan', 'Oswin', 'Percival', 'Quinlan', 'Roderic', 'Stefan', 'Talan',
+      'Ulric', 'Varron', 'Wystan', 'Yorick', 'Alaric', 'Benedict', 'Corvin', 'Damion', 'Edmund', 'Godric'
+    ],
+    female: [
+      'Adelina', 'Beatrix', 'Catrin', 'Delphine', 'Elswyth', 'Ffion', 'Giselle', 'Helene', 'Isolde', 'Jessamine',
+      'Katryn', 'Liora', 'Meliora', 'Norwynne', 'Odette', 'Petronilla', 'Rosamund', 'Seraphine', 'Tanith', 'Ursula',
+      'Verena', 'Winifred', 'Ysoria', 'Ameline', 'Brienne', 'Clarisse', 'Delyth', 'Eveline', 'Gwenneth', 'Honoria'
+    ]
+  },
+  Elf: {
+    male: [
+      'Aelar', 'Belanor', 'Caelthas', 'Daerion', 'Elrandir', 'Faelar', 'Galathil', 'Haemir', 'Ilyas', 'Jhaelian',
+      'Kaelenir', 'Laeroth', 'Morthil', 'Nydorin', 'Orophir', 'Phalaris', 'Quarion', 'Rhalion', 'Saelindor', 'Thaelion',
+      'Uloris', 'Vaelion', 'Wyndrel', 'Xilthar', 'Yelion', 'Arannis', 'Cyrandir', 'Eryndor', 'Fanelar', 'Sylthas'
+    ],
+    female: [
+      'Aelene', 'Belwyn', 'Caerith', 'Daelyra', 'Elenya', 'Faelwen', 'Galadriel', 'Helyra', 'Ilythia', 'Jhaenya',
+      'Kaelira', 'Laewen', 'Myriele', 'Nytheris', 'Orlith', 'Phyrelle', 'Quenaya', 'Rhaelynn', 'Saelith', 'Thaelira',
+      'Ulinya', 'Vaenya', 'Wynriel', 'Xilwen', 'Yselith', 'Aeryn', 'Ciryelle', 'Elariel', 'Fynwen', 'Sylthiel'
+    ]
+  },
+  'Dark Elf': {
+    male: [
+      'Zarathis', 'Malrik', 'Draven', 'Veynor', 'Xorath', 'Kelthir', 'Drazhan', 'Morvane', 'Lareth', 'Zyvran',
+      'Khaelith', 'Thoren', 'Valrik', 'Soryn', 'Kaevros', 'Nytheron', 'Rhazek', 'Vorath', 'Zorlan', 'Droveth',
+      'Maelith', 'Zevrin', 'Kytheris', 'Onareth', 'Thalrik', 'Vaedros', 'Syvran', 'Rhaziel', 'Koryth', 'Dymar'
+    ],
+    female: [
+      'Zyrelle', 'Maevira', 'Drosyne', 'Velyth', 'Xyra', 'Khyrith', 'Drelyss', 'Morwenne', 'Liraeth', 'Zynestra',
+      'Khaerys', 'Thalyss', 'Veyra', 'Sorveth', 'Kaelira', 'Nyssara', 'Rhaezra', 'Vorlyth', 'Zorvanna', 'Draelith',
+      'Maeryth', 'Zyvira', 'Kyrisse', 'Onaerys', 'Thalyn', 'Veythra', 'Syrrith', 'Rhazira', 'Koryssa', 'Dymira'
+    ]
+  },
+  Dwarf: {
+    male: [
+      'Bromir', 'Dain', 'Edrik', 'Fargrim', 'Gundrik', 'Hrothgar', 'Ivarn', 'Jorik', 'Kazmir', 'Logain',
+      'Morgrin', 'Norik', 'Orvik', 'Padrig', 'Quorim', 'Rurik', 'Stenvar', 'Thrain', 'Uldor', 'Varrim',
+      'Wulfram', 'Yorin', 'Algrim', 'Borik', 'Dolvar', 'Emerik', 'Faldor', 'Garvik', 'Helmar', 'Kordrim'
+    ],
+    female: [
+      'Brunhild', 'Dagna', 'Edris', 'Freyda', 'Gudrun', 'Helga', 'Ingith', 'Jorhild', 'Katla', 'Lofwyn',
+      'Morhild', 'Nessa', 'Orla', 'Petra', 'Quilda', 'Ragna', 'Sigrid', 'Thora', 'Uldra', 'Veyra',
+      'Wyrdis', 'Ysolde', 'Astrid', 'Brynja', 'Doreth', 'Eydis', 'Frida', 'Gertha', 'Hulda', 'Katra'
+    ]
+  },
+  Gnome: {
+    male: [
+      'Boddynock', 'Carlin', 'Dimble', 'Eldrin', 'Fizzlewick', 'Gimble', 'Hoddin', 'Jerrick', 'Korrin', 'Loddin',
+      'Murnig', 'Nodwick', 'Orbin', 'Pindle', 'Quibble', 'Roddin', 'Sprocket', 'Tovin', 'Uldin', 'Vindle',
+      'Wobbin', 'Yorrick', 'Alfin', 'Bramble', 'Dipple', 'Erbin', 'Filwick', 'Grindle', 'Hoddle', 'Klemper'
+    ],
+    female: [
+      'Bimpnottin', 'Carissa', 'Dabble', 'Ellywick', 'Fizzelle', 'Glintra', 'Heddra', 'Jilpin', 'Kendra', 'Lollin',
+      'Myrla', 'Nissa', 'Orphelia', 'Poppet', 'Quivella', 'Rilla', 'Saphra', 'Tinkra', 'Ullia', 'Vindlewyn',
+      'Wobblette', 'Yezra', 'Alira', 'Brina', 'Drenna', 'Eryssa', 'Fenla', 'Grizelle', 'Hoppin', 'Krella'
+    ]
+  },
+  Halfling: {
+    male: [
+      'Andric', 'Berrin', 'Cottar', 'Darrin', 'Eldon', 'Finnan', 'Garret', 'Hobb', 'Ivran', 'Jory',
+      'Kipwick', 'Lyle', 'Merroc', 'Nedrin', 'Ollo', 'Paddock', 'Quenlin', 'Rollo', 'Samric', 'Tobin',
+      'Ulwick', 'Varrin', 'Willet', 'Yorrin', 'Ander', 'Brannoc', 'Corbin', 'Darrick', 'Eldric', 'Fennor'
+    ],
+    female: [
+      'Amary', 'Belka', 'Cora', 'Della', 'Esme', 'Fennie', 'Gilda', 'Hattie', 'Ivyra', 'Jilly',
+      'Kendra', 'Lyria', 'Maribell', 'Nolly', 'Orla', 'Poppy', 'Quenna', 'Rosie', 'Sylvie', 'Tilda',
+      'Una', 'Verra', 'Willa', 'Ysme', 'Avena', 'Bree', 'Cindel', 'Dora', 'Elira', 'Fayra'
+    ]
+  },
+  'Cait Sith': {
+    male: [
+      'Aelric', 'Branth', 'Caedros', 'Dathren', 'Felmar', 'Grimnar', 'Harth', 'Ivenn', 'Jareth', 'Kaelor',
+      'Luthar', 'Myrron', 'Nyvel', 'Odris', 'Phaeron', 'Quarris', 'Rynar', 'Sylth', 'Tovren', 'Uryss',
+      'Veynar', 'Werrick', 'Xyras', 'Ydrin', 'Zalthor', 'Arven', 'Corvath', 'Drelis', 'Fenrik', 'Korrath'
+    ],
+    female: [
+      'Aenya', 'Brynn', 'Celira', 'Delyth', 'Felira', 'Gryssa', 'Helynn', 'Iryss', 'Jhala', 'Kaeryn',
+      'Lirra', 'Myssan', 'Nyvra', 'Olyss', 'Phyra', 'Quenya', 'Ryselle', 'Syrrin', 'Thalira', 'Ulynn',
+      'Veyra', 'Wynne', 'Xyrelle', 'Ysanna', 'Zhyrra', 'Aeryss', 'Cyrra', 'Deyra', 'Felynn', 'Kyrris'
+    ]
+  },
+  Salamander: {
+    male: [
+      'Ashar', 'Bronzar', 'Cindral', 'Deyric', 'Emberon', 'Faryx', 'Galdros', 'Hestrel', 'Ignar', 'Jorveth',
+      'Kaedros', 'Luthros', 'Magryn', 'Nyrvos', 'Ozaric', 'Pyrrhus', 'Quarn', 'Rhovan', 'Sazrik', 'Tharos',
+      'Urvos', 'Veyric', 'Wyranth', 'Xandros', 'Yvarn', 'Zorric', 'Arveth', 'Calros', 'Drakar', 'Fyrion'
+    ],
+    female: [
+      'Ashira', 'Bronyra', 'Cindrae', 'Deyra', 'Emberlyn', 'Farynna', 'Galrissa', 'Hestara', 'Ignysa', 'Jorra',
+      'Kaelyn', 'Luthira', 'Magrynn', 'Nyssra', 'Ozara', 'Pyrrha', 'Quenya', 'Rhava', 'Sazira', 'Thalyn',
+      'Uryssa', 'Veyra', 'Wyrren', 'Xyra', 'Ysola', 'Zynra', 'Arinya', 'Calira', 'Dravessa', 'Fyrra'
+    ]
+  }
+};

--- a/script.js
+++ b/script.js
@@ -8,6 +8,7 @@ import { WEAPON_SLOTS, ARMOR_SLOTS, TRINKET_SLOTS } from "./assets/data/equipmen
 import { LOCATIONS } from "./assets/data/locations.js";
 import { HYBRID_RELATIONS } from "./assets/data/hybrid_relations.js";
 import { CITY_NAV } from "./assets/data/city_nav.js";
+import { DEFAULT_NAMES } from "./assets/data/names.js";
 
 function totalXpForLevel(level) {
   return Math.floor((4 * Math.pow(level, 3)) / 5);
@@ -1565,8 +1566,13 @@ function startCharacterCreation() {
       }
     } else {
       const nameVal = character.name || '';
+      const nameList =
+        DEFAULT_NAMES[character.race]?.[
+          character.sex === 'Male' ? 'male' : 'female'
+        ] || [];
+      const placeholderName = nameList[0] || 'Name';
       setMainHTML(
-        `<div class="character-creation"><div class="cc-top-row"><div class="progress-container">${progressHTML}</div>${statsHTML}</div><div class="cc-options"><input type="text" id="name-input" value="${nameVal}" placeholder="Name"></div><div class="cc-info">${descHTML}${imageHTML}</div></div>`
+        `<div class="character-creation"><div class="cc-top-row"><div class="progress-container">${progressHTML}</div>${statsHTML}</div><div class="cc-options name-entry"><input type="text" id="name-input" value="${nameVal}" placeholder="${placeholderName}"><button id="name-random" class="dice-button" aria-label="Randomize Name">🎲</button></div><div class="cc-info">${descHTML}${imageHTML}</div></div>`
       );
       normalizeOptionButtonWidths();
       const currentStepEl = document.querySelector('.progress-step.current');
@@ -1578,6 +1584,7 @@ function startCharacterCreation() {
         detailEl.appendChild(optionsEl);
       }
       const nameInput = document.getElementById('name-input');
+      const randomBtn = document.getElementById('name-random');
       const updateName = () => {
         character.name = nameInput.value.trim();
         localStorage.setItem(TEMP_CHARACTER_KEY, JSON.stringify({ step, character }));
@@ -1591,6 +1598,13 @@ function startCharacterCreation() {
         if (isComplete()) completeBtn.removeAttribute('disabled');
         else completeBtn.setAttribute('disabled', '');
       };
+      const randomizeName = () => {
+        if (!nameList.length) return;
+        const newName = nameList[Math.floor(Math.random() * nameList.length)];
+        nameInput.value = newName;
+        updateName();
+      };
+      randomBtn.addEventListener('click', randomizeName);
       nameInput.addEventListener('input', updateName);
       updateName();
     }

--- a/style.css
+++ b/style.css
@@ -1193,3 +1193,21 @@ body.theme-dark .element-icon {
   border: 1px solid var(--foreground);
   max-width: 90%;
 }
+
+.name-entry {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.name-entry input {
+  flex: 1;
+}
+
+.dice-button {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--foreground);
+  font-size: 1.25rem;
+}


### PR DESCRIPTION
## Summary
- add extensive default name lists for each race and sex
- enable dice button to randomize character names based on race and sex
- style name entry and dice button for character creation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3186f1c44832598333ae7344ed13d