### PR TITLE
Standardize spellbook icons and sorting visuals

### DIFF
--- a/script.js
+++ b/script.js
@@ -587,7 +587,7 @@ const schoolIcons = {
   Enfeebling:
     '<span class="icon enfeeble"><span class="arrow">⬇</span></span>',
   Reinforcement:
-    '<span class="icon reinforce"><span class="arrow">⬆</span></span>',
+    '<span class="icon reinforce"><svg viewBox="0 0 24 24"><path d="M12 3l7 4v5c0 5-3.5 8.5-7 9-3.5-.5-7-4-7-9V7l7-4z"/></svg></span>',
   Healing:
     '<span class="icon heal"><span class="arrow">+</span></span>',
   Summoning: '<span class="icon slime"></span>'
@@ -597,7 +597,10 @@ let spellSort = { mode: 'prof', dir: 'asc' };
 
 function getProficiencySortIcon(dir) {
   const arrow = dir === 'desc' ? '↓' : '↑';
-  return `#${arrow}`;
+  return (
+    `<span class="prof-icon">` +
+    `<svg viewBox="0 0 24 24"><path d="M10 3v18M14 3v18M3 10h18M3 14h18"/></svg>${arrow}</span>`
+  );
 }
 
 function getTypeSortIcon(dir) {

--- a/style.css
+++ b/style.css
@@ -999,8 +999,20 @@ body.theme-dark {
   align-items: center;
 }
 
-.element-icon {
+
+.element-icon,
+.school-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1em;
+  height: 1em;
+  font-size: 1em;
+  line-height: 1;
   margin-right: 0.25rem;
+}
+
+.element-icon {
   filter: brightness(0) saturate(100%) invert(1);
 }
 
@@ -1023,9 +1035,7 @@ body.theme-dark .element-icon {
   gap: 0.25rem;
 }
 
-.sort-button.active {
-  text-decoration: underline;
-}
+
 
 .spell-subheading {
   margin: 0.5rem 0 0.25rem;
@@ -1053,10 +1063,6 @@ body.theme-dark .element-icon {
   background: linear-gradient(to right, var(--background), var(--foreground), var(--background));
 }
 
-.school-icon {
-  margin-right: 0.25rem;
-}
-
 .spellbook-icon {
   margin-right: 0.25rem;
 }
@@ -1064,20 +1070,26 @@ body.theme-dark .element-icon {
 .icon {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  width: 1em;
+  height: 1em;
 }
 
-.type-icon {
+.type-icon,
+.prof-icon {
   display: inline-flex;
   align-items: center;
 }
 
-.type-icon svg {
+.type-icon svg,
+.prof-icon svg {
   width: 1em;
   height: 1em;
   fill: none;
   stroke-width: 2;
   stroke-linecap: round;
   stroke-linejoin: round;
+  stroke: currentColor;
 }
 
 .type-icon .cw {
@@ -1092,8 +1104,9 @@ body.theme-dark .element-icon {
   color: red;
 }
 
-.icon.reinforce .arrow {
-  color: blue;
+.icon.reinforce svg {
+  fill: #3b82f6;
+  stroke: #2563eb;
 }
 
 .icon.heal .arrow {
@@ -1103,7 +1116,7 @@ body.theme-dark .element-icon {
 .icon.slime {
   display: inline-block;
   width: 1em;
-  height: 0.8em;
+  height: 1em;
   background: #6f6;
   border-radius: 50% 50% 40% 40%;
   position: relative;


### PR DESCRIPTION
## Summary
- Remove underline styling from active spellbook sort buttons
- Standardize sort icons using SVGs and equal sizing
- Normalize magic school and element icon sizes and switch Reinforcement to a blue shield

## Testing
- `node --check script.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3293ddce88325969fcef943f39c21