### PR TITLE
Organize city navigation and set default business hours

### DIFF
--- a/assets/data/city_nav.js
+++ b/assets/data/city_nav.js
@@ -1,3 +1,5 @@
+import { LOCATIONS } from "./locations.js";
+
 export const CITY_NAV = {
   "Wave's Break": {
     districts: {
@@ -696,3 +698,35 @@ export const CITY_NAV = {
     }
   }
 };
+
+function defaultBusinessHours(cityName, buildingName) {
+  const population = LOCATIONS[cityName]?.population?.estimate || 0;
+  const name = buildingName.toLowerCase();
+  if (/(inn|tavern)/.test(name)) {
+    return population >= 15000
+      ? { open: "00:00", close: "24:00" }
+      : { open: "06:00", close: "24:00" };
+  }
+  if (/(temple|shrine|church|monastery)/.test(name)) {
+    return { open: "06:00", close: "22:00" };
+  }
+  if (/(shop|market|exchange|wharf|pier|yard|bakery|granary)/.test(name)) {
+    return { open: "06:00", close: "18:00" };
+  }
+  if (/(forge|workshop|lodge|shed|lab|sanctum|guild|hall|keep)/.test(name)) {
+    return { open: "08:00", close: "20:00" };
+  }
+  return { open: "09:00", close: "17:00" };
+}
+
+function applyBusinessHours(nav) {
+  Object.entries(nav).forEach(([cityName, city]) => {
+    Object.entries(city.buildings).forEach(([buildingName, building]) => {
+      if (!building.hours) {
+        building.hours = defaultBusinessHours(cityName, buildingName);
+      }
+    });
+  });
+}
+
+applyBusinessHours(CITY_NAV);

--- a/style.css
+++ b/style.css
@@ -644,6 +644,17 @@ body.theme-dark {
     color: var(--background);
   }
 
+  .business-hours {
+    margin: 0 0 0.5rem 0;
+    text-align: center;
+    font-size: 0.9rem;
+  }
+
+  .option-grid .group-separator {
+    width: 100%;
+    height: 0.5rem;
+  }
+
   .navigation .city-name {
     margin: 0 0 0.5rem 0;
     text-align: center;


### PR DESCRIPTION
## Summary
- Group navigation options so city exits, districts, and local sites are separated with spacing
- Automatically generate business hours for all buildings based on type and city size
- Show open hours when entering a building

## Testing
- `node --check assets/data/city_nav.js`
- `node --check script.js`
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b33b7657c083258cdb0c965bb28a8f