### PR TITLE
Add quest board quest listings

### DIFF
--- a/assets/data/locations.js
+++ b/assets/data/locations.js
@@ -13,7 +13,67 @@ export function createLocation(name, mapFile, description = "") {
             resources: { domestic: [], exports: [], imports: [] },
         },
         population: undefined,
+        questBoards: {},
     };
+}
+function createQuest(title, description, opts = {}) {
+    return Object.assign({ title, description }, opts);
+}
+function addQuestBoards(loc) {
+    const boards = {};
+    const banditPatrol = createQuest("Patrol the main road", "Help the guards keep bandits away.", { repeatable: true, highPriority: true });
+    const prototypeBlade = createQuest("Test prototype blade", "Check with Master Smith before testing.", { requiresCheckIn: true });
+    var _a;
+    if ((_a = loc.population) === null || _a === void 0 ? void 0 : _a.districts) {
+        Object.keys(loc.population.districts).forEach((d) => {
+            boards[`${d} Quest Board`] = [
+                createQuest(`Assist ${d} locals`, `Handle tasks for residents of ${d}.`),
+            ];
+        });
+    }
+    boards["Town Plaza Quest Board"] = [
+        createQuest("Help set up market stalls", "Assist merchants in preparing stalls."),
+        banditPatrol,
+        prototypeBlade,
+    ];
+    boards["Church Quest Board"] = [
+        createQuest("Collect healing herbs", "Gather herbs requested by the clergy."),
+    ];
+    boards["City Gate Quest Board"] = [
+        createQuest("Escort departing caravan", "Guard caravan until next waypoint."),
+        banditPatrol,
+    ];
+    loc.pointsOfInterest.buildings.forEach((b) => {
+        const lower = b.toLowerCase();
+        if (lower.indexOf("smith") !== -1) {
+            boards[`${b} Quest Board`] = [
+                createQuest("Gather iron ore", "Bring quality ore for smelting."),
+                prototypeBlade,
+            ];
+        }
+        else if (lower.indexOf("carpenter") !== -1 || lower.indexOf("carver") !== -1 || lower.indexOf("fletcher") !== -1) {
+            boards[`${b} Quest Board`] = [
+                createQuest("Harvest fine timber", "Collect seasoned wood from nearby forest."),
+            ];
+        }
+        else if (lower.indexOf("alchemist") !== -1) {
+            boards[`${b} Quest Board`] = [
+                createQuest("Collect rare herbs", "Fetch ingredients for experimental potion."),
+            ];
+        }
+        else if (lower.indexOf("enchant") !== -1) {
+            boards[`${b} Quest Board`] = [
+                createQuest("Gather arcane crystals", "Acquire crystals from old ruins."),
+            ];
+        }
+        else if (lower.indexOf("guild") !== -1) {
+            boards[`${b} Quest Board`] = [
+                createQuest(`Assist ${b}`, `Help with tasks at ${b}.`),
+            ];
+        }
+    });
+    loc.questBoards = boards;
+    loc.pointsOfInterest.buildings.push(...Object.keys(boards));
 }
 const WAVES_BREAK = Object.assign(Object.assign({}, createLocation("Wave's Break", "Wave's Break.png", `The City of Wave's Break
 
@@ -1135,3 +1195,5 @@ export const LOCATIONS = {
     "Dragon's Reach Road": DRAGONS_REACH_ROAD,
     "Whiteheart": WHITEHEART,
 };
+
+Object.keys(LOCATIONS).forEach((name) => addQuestBoards(LOCATIONS[name]));

--- a/assets/data/locations.ts
+++ b/assets/data/locations.ts
@@ -28,6 +28,15 @@ export interface Location {
     districts: Record<string, { estimate: number; notes: string }>;
     hinterland?: { estimate: number; notes: string };
   };
+  questBoards: Record<string, Quest[]>;
+}
+
+export interface Quest {
+  title: string;
+  description: string;
+  repeatable?: boolean;
+  highPriority?: boolean;
+  requiresCheckIn?: boolean;
 }
 
 export function createLocation(
@@ -48,7 +57,112 @@ export function createLocation(
       resources: { domestic: [], exports: [], imports: [] },
     },
     population: undefined,
+    questBoards: {},
   };
+}
+
+function createQuest(
+  title: string,
+  description: string,
+  opts: Partial<Quest> = {},
+): Quest {
+  return { title, description, ...opts };
+}
+
+function addQuestBoards(loc: Location) {
+  const boards: Record<string, Quest[]> = {};
+
+  const banditPatrol = createQuest(
+    "Patrol the main road",
+    "Help the guards keep bandits away.",
+    { repeatable: true, highPriority: true },
+  );
+
+  const prototypeBlade = createQuest(
+    "Test prototype blade",
+    "Check with Master Smith before testing.",
+    { requiresCheckIn: true },
+  );
+
+  if (loc.population?.districts) {
+    Object.keys(loc.population.districts).forEach((d) => {
+      boards[`${d} Quest Board`] = [
+        createQuest(
+          `Assist ${d} locals`,
+          `Handle tasks for residents of ${d}.`,
+        ),
+      ];
+    });
+  }
+
+  boards["Town Plaza Quest Board"] = [
+    createQuest(
+      "Help set up market stalls",
+      "Assist merchants in preparing stalls.",
+    ),
+    banditPatrol,
+    prototypeBlade,
+  ];
+
+  boards["Church Quest Board"] = [
+    createQuest(
+      "Collect healing herbs",
+      "Gather herbs requested by the clergy.",
+    ),
+  ];
+
+  boards["City Gate Quest Board"] = [
+    createQuest(
+      "Escort departing caravan",
+      "Guard caravan until next waypoint.",
+    ),
+    banditPatrol,
+  ];
+
+  loc.pointsOfInterest.buildings.forEach((b) => {
+    const lower = b.toLowerCase();
+    if (lower.indexOf("smith") !== -1) {
+      boards[`${b} Quest Board`] = [
+        createQuest("Gather iron ore", "Bring quality ore for smelting."),
+        prototypeBlade,
+      ];
+    } else if (
+      lower.indexOf("carpenter") !== -1 ||
+      lower.indexOf("carver") !== -1 ||
+      lower.indexOf("fletcher") !== -1
+    ) {
+      boards[`${b} Quest Board`] = [
+        createQuest(
+          "Harvest fine timber",
+          "Collect seasoned wood from nearby forest.",
+        ),
+      ];
+    } else if (lower.indexOf("alchemist") !== -1) {
+      boards[`${b} Quest Board`] = [
+        createQuest(
+          "Collect rare herbs",
+          "Fetch ingredients for experimental potion.",
+        ),
+      ];
+    } else if (lower.indexOf("enchant") !== -1) {
+      boards[`${b} Quest Board`] = [
+        createQuest(
+          "Gather arcane crystals",
+          "Acquire crystals from old ruins.",
+        ),
+      ];
+    } else if (lower.indexOf("guild") !== -1) {
+      boards[`${b} Quest Board`] = [
+        createQuest(
+          `Assist ${b}`,
+          `Help with tasks at ${b}.`,
+        ),
+      ];
+    }
+  });
+
+  loc.questBoards = boards;
+  loc.pointsOfInterest.buildings.push(...Object.keys(boards));
 }
 
 const WAVES_BREAK: Location = {
@@ -1329,4 +1443,6 @@ export const LOCATIONS: Record<string, Location> = {
     "Dragon's Reach Road": DRAGONS_REACH_ROAD,
     "Whiteheart": WHITEHEART,
   };
+
+Object.keys(LOCATIONS).forEach((name) => addQuestBoards(LOCATIONS[name]));
 


### PR DESCRIPTION
## Summary
- convert quest board storage into named boards with quest details
- auto-populate plazas, churches, city gates, and guilds with relevant unique quests
- support cross-posted high-priority or check-in quests across boards

## Testing
- `node --check assets/data/locations.js`
- `npx tsc --noEmit assets/data/locations.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b36bb503f08325b1b0f09a0182d313