### PR TITLE
feat: add icon-based city navigation

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,6 +27,14 @@ window.toIron = toIron;
 window.fromIron = fromIron;
 window.LOCATIONS = LOCATIONS;
 
+const NAV_ICONS = {
+  location: '🗺️',
+  district: '🏙️',
+  building: '🏠',
+  exit: '🚪',
+  interaction: '⚙️',
+};
+
 const body = document.body;
 const main = document.querySelector('main');
 const backButton = document.getElementById('back-button');
@@ -715,19 +723,29 @@ function showNavigation() {
     setMainHTML(`<div class="no-character"><h1>Welcome, ${currentCharacter.name}</h1><p>You are in ${pos.city}.</p></div>`);
     return;
   }
+  const createNavItem = ({ type, target, name, action, prompt }) => {
+    const icon = NAV_ICONS[type] || '📍';
+    const attrs = action ? `data-action="${action}"` : `data-target="${target}"`;
+    const aria = prompt ? `${prompt} ${name}` : name;
+    return `<div class="nav-item"><button data-type="${type}" ${attrs} aria-label="${aria}"><span class="nav-icon">${icon}</span></button><span class="street-sign">${name}</span></div>`;
+  };
   if (pos.building) {
     const building = cityData.buildings[pos.building];
     const buttons = [];
     building.exits.forEach(e => {
       const prompt = e.prompt || building.travelPrompt || 'Exit to';
       const type = e.type || 'exit';
-      buttons.push(`<button data-type="${type}" data-target="${e.target}">${prompt} ${e.name}</button>`);
+      buttons.push(
+        createNavItem({ type, target: e.target, name: e.name, prompt })
+      );
     });
     if (building.exits.length && (building.interactions || []).length) {
       buttons.push('<div class="group-separator"></div>');
     }
     (building.interactions || []).forEach(i => {
-      buttons.push(`<button data-type="interaction" data-action="${i.action}">${i.name}</button>`);
+      buttons.push(
+        createNavItem({ type: 'interaction', action: i.action, name: i.name })
+      );
     });
     const hours = building.hours;
     const hoursText = hours
@@ -750,7 +768,12 @@ function showNavigation() {
     });
     const makeButton = pt => {
       const prompt = pt.type === 'district' ? 'Travel to' : district.travelPrompt || 'Walk to';
-      return `<button data-type="${pt.type}" data-target="${pt.target}">${prompt} ${pt.name}</button>`;
+      return createNavItem({
+        type: pt.type,
+        target: pt.target,
+        name: pt.name,
+        prompt,
+      });
     };
     const buttons = [
       ...exits.map(makeButton),

--- a/style.css
+++ b/style.css
@@ -660,6 +660,49 @@ body.theme-dark {
     text-align: center;
   }
 
+  .navigation .option-grid {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  .navigation .nav-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .navigation .nav-item button {
+    width: 5rem;
+    height: 5rem;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+  }
+
+  .navigation .nav-item button:hover {
+    background: var(--foreground);
+    color: var(--background);
+  }
+
+  .navigation .nav-icon {
+    font-size: 2.5rem;
+  }
+
+  .navigation .street-sign {
+    background: #2e8b57;
+    color: #fff;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    font-weight: bold;
+    white-space: nowrap;
+    border: 2px solid #fff;
+    box-shadow: 0 0 0 2px #2e8b57;
+  }
+
   .location-select,
   .race-select {
     display: flex;


### PR DESCRIPTION
## Summary
- Show city navigation options as square buttons with large emoji-style icons and adjacent street-sign labels
- Style navigation grid to wrap items and display street-sign themed labels

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68b378b01d80832590e68e109ae00a94