### PR TITLE
feat(nav): add icon imagery for location buttons

### DIFF
--- a/assets/data/city_nav.js
+++ b/assets/data/city_nav.js
@@ -9,7 +9,7 @@ export const CITY_NAV = {
           { name: "Harbor Guard Naval Yard", type: "building", target: "Harbor Guard Naval Yard" },
           { name: "Nobles' Quay", type: "building", target: "Nobles' Quay" },
           { name: "Merchants' Wharf", type: "building", target: "Merchants' Wharf" },
-          { name: "Fisherman's Pier", type: "building", target: "Fisherman's Pier" },
+          { name: "Fisherman's Pier", type: "building", target: "Fisherman's Pier", icon: "assets/images/icons/pier.svg" },
           { name: "Tideway Inn", type: "building", target: "Tideway Inn" },
           { name: "Upper Ward", type: "district", target: "Upper Ward" },
           { name: "Little Terns", type: "district", target: "Little Terns" }
@@ -31,7 +31,7 @@ export const CITY_NAV = {
         travelPrompt: "Walk to",
         points: [
           { name: "Glassblowing Trainer's Workshop", type: "building", target: "Glassblowing Trainer's Workshop" },
-          { name: "Smithing Trainer's Forge", type: "building", target: "Smithing Trainer's Forge" },
+          { name: "Smithing Trainer's Forge", type: "building", target: "Smithing Trainer's Forge", icon: "assets/images/icons/blacksmith.svg" },
           { name: "Carpentry Trainer's Lodge", type: "building", target: "Carpentry Trainer's Lodge" },
           { name: "Tailoring Trainer's Shop", type: "building", target: "Tailoring Trainer's Shop" },
           { name: "Leatherworking Trainer's Shed", type: "building", target: "Leatherworking Trainer's Shed" },

--- a/assets/images/icons/blacksmith.svg
+++ b/assets/images/icons/blacksmith.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor">
+    <path d="M8 40h48v-4l-12-8h-8l-4-4H20l-8 4v12z"/>
+    <rect x="20" y="40" width="24" height="8"/>
+    <rect x="36" y="8" width="20" height="8" transform="rotate(45 46 12)"/>
+    <rect x="30" y="20" width="8" height="20" transform="rotate(45 34 30)"/>
+  </g>
+</svg>

--- a/assets/images/icons/pier.svg
+++ b/assets/images/icons/pier.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor">
+    <rect x="4" y="40" width="56" height="6"/>
+    <rect x="8" y="46" width="4" height="10"/>
+    <rect x="20" y="46" width="4" height="10"/>
+    <rect x="32" y="46" width="4" height="10"/>
+    <rect x="44" y="46" width="4" height="10"/>
+    <rect x="56" y="46" width="4" height="10"/>
+    <path d="M16 34l8 6h16l8-6-8-14H24z"/>
+    <rect x="30" y="14" width="4" height="10"/>
+  </g>
+</svg>

--- a/script.js
+++ b/script.js
@@ -723,11 +723,14 @@ function showNavigation() {
     setMainHTML(`<div class="no-character"><h1>Welcome, ${currentCharacter.name}</h1><p>You are in ${pos.city}.</p></div>`);
     return;
   }
-  const createNavItem = ({ type, target, name, action, prompt }) => {
-    const icon = NAV_ICONS[type] || '📍';
+  const createNavItem = ({ type, target, name, action, prompt, icon }) => {
+    const defaultIcon = NAV_ICONS[type] || '📍';
+    const iconHTML = icon
+      ? `<img src="${icon}" alt="" class="nav-icon">`
+      : `<span class="nav-icon">${defaultIcon}</span>`;
     const attrs = action ? `data-action="${action}"` : `data-target="${target}"`;
     const aria = prompt ? `${prompt} ${name}` : name;
-    return `<div class="nav-item"><button data-type="${type}" ${attrs} aria-label="${aria}"><span class="nav-icon">${icon}</span></button><span class="street-sign">${name}</span></div>`;
+    return `<div class="nav-item"><button data-type="${type}" ${attrs} aria-label="${aria}">${iconHTML}</button><span class="street-sign">${name}</span></div>`;
   };
   if (pos.building) {
     const building = cityData.buildings[pos.building];
@@ -736,7 +739,7 @@ function showNavigation() {
       const prompt = e.prompt || building.travelPrompt || 'Exit to';
       const type = e.type || 'exit';
       buttons.push(
-        createNavItem({ type, target: e.target, name: e.name, prompt })
+        createNavItem({ type, target: e.target, name: e.name, prompt, icon: e.icon })
       );
     });
     if (building.exits.length && (building.interactions || []).length) {
@@ -744,7 +747,7 @@ function showNavigation() {
     }
     (building.interactions || []).forEach(i => {
       buttons.push(
-        createNavItem({ type: 'interaction', action: i.action, name: i.name })
+        createNavItem({ type: 'interaction', action: i.action, name: i.name, icon: i.icon })
       );
     });
     const hours = building.hours;
@@ -773,6 +776,7 @@ function showNavigation() {
         target: pt.target,
         name: pt.name,
         prompt,
+        icon: pt.icon,
       });
     };
     const buttons = [

--- a/style.css
+++ b/style.css
@@ -680,7 +680,6 @@ body.theme-dark {
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 2rem;
   }
 
   .navigation .nav-item button:hover {
@@ -688,8 +687,20 @@ body.theme-dark {
     color: var(--background);
   }
 
-  .navigation .nav-icon {
+  .navigation .nav-item button .nav-icon {
+    width: 3rem;
+    height: 3rem;
+  }
+
+  .navigation .nav-item button span.nav-icon {
     font-size: 2.5rem;
+    line-height: 3rem;
+  }
+
+  .navigation .nav-item button img.nav-icon {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
   }
 
   .navigation .street-sign {


### PR DESCRIPTION
## Summary
- Show street-sign labels beside navigation buttons
- Support custom icons per location
- Add blacksmith forge and pier image assets

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b37cd8c10c8325b63b3cca7f2c97b6