### PR TITLE
Add port district icons and update navigation

### DIFF
--- a/assets/data/city_nav.js
+++ b/assets/data/city_nav.js
@@ -6,10 +6,30 @@ export const CITY_NAV = {
       "Port District": {
         travelPrompt: "Walk to",
         points: [
-          { name: "Harbor Guard Naval Yard", type: "building", target: "Harbor Guard Naval Yard" },
-          { name: "Nobles' Quay", type: "building", target: "Nobles' Quay" },
-          { name: "Merchants' Wharf", type: "building", target: "Merchants' Wharf" },
-          { name: "Fisherman's Pier", type: "building", target: "Fisherman's Pier", icon: "assets/images/icons/pier.svg" },
+          {
+            name: "Harbor Guard Naval Yard",
+            type: "building",
+            target: "Harbor Guard Naval Yard",
+            icon: "assets/images/icons/naval-yard.svg",
+          },
+          {
+            name: "Nobles' Quay",
+            type: "building",
+            target: "Nobles' Quay",
+            icon: "assets/images/icons/nobles-quay.svg",
+          },
+          {
+            name: "Merchants' Wharf",
+            type: "building",
+            target: "Merchants' Wharf",
+            icon: "assets/images/icons/merchants-wharf.svg",
+          },
+          {
+            name: "Fisherman's Pier",
+            type: "building",
+            target: "Fisherman's Pier",
+            icon: "assets/images/icons/fishing-pier.svg",
+          },
           { name: "Tideway Inn", type: "building", target: "Tideway Inn" },
           { name: "Upper Ward", type: "district", target: "Upper Ward" },
           { name: "Little Terns", type: "district", target: "Little Terns" }

--- a/assets/images/icons/fishing-pier.svg
+++ b/assets/images/icons/fishing-pier.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" fill="var(--foreground)" stroke="var(--background)" stroke-width="4"/>
+  <g fill="var(--background)">
+    <ellipse cx="28" cy="30" rx="12" ry="8"/>
+    <polygon points="40,30 52,22 52,38"/>
+    <circle cx="24" cy="28" r="2"/>
+    <rect x="8" y="44" width="48" height="8"/>
+  </g>
+</svg>

--- a/assets/images/icons/merchants-wharf.svg
+++ b/assets/images/icons/merchants-wharf.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" fill="var(--foreground)" stroke="var(--background)" stroke-width="4"/>
+  <g fill="var(--background)">
+    <rect x="14" y="26" width="14" height="14"/>
+    <rect x="36" y="26" width="14" height="14"/>
+    <path d="M14 26l14 14m0-14l-14 14M36 26l14 14m0-14l-14 14" stroke="var(--foreground)" stroke-width="2" fill="none"/>
+    <rect x="8" y="44" width="48" height="8"/>
+  </g>
+</svg>

--- a/assets/images/icons/naval-yard.svg
+++ b/assets/images/icons/naval-yard.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" fill="var(--foreground)" stroke="var(--background)" stroke-width="4"/>
+  <g fill="var(--background)">
+    <polygon points="8,40 56,40 48,52 16,52"/>
+    <rect x="30" y="16" width="4" height="20"/>
+    <polygon points="34,16 50,26 34,26"/>
+    <rect x="34" y="12" width="10" height="4"/>
+  </g>
+</svg>

--- a/assets/images/icons/nobles-quay.svg
+++ b/assets/images/icons/nobles-quay.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" fill="var(--foreground)" stroke="var(--background)" stroke-width="4"/>
+  <g fill="var(--background)">
+    <polygon points="16,28 24,16 32,28 40,16 48,28"/>
+    <rect x="16" y="28" width="32" height="12"/>
+    <rect x="8" y="44" width="48" height="8"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Add colored SVG icons for Harbor Guard Naval Yard, Nobles' Quay, Merchants' Wharf, and Fisherman's Pier.
- Wire new icons into Wave's Break port district navigation.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b3824ae99883258a05b249d503443a