### PR TITLE
Associate icon images with navigation buttons

### DIFF
--- a/assets/data/city_nav.js
+++ b/assets/data/city_nav.js
@@ -10,89 +10,89 @@ export const CITY_NAV = {
             name: "Harbor Guard Naval Yard",
             type: "building",
             target: "Harbor Guard Naval Yard",
-            icon: "assets/images/icons/naval-yard.svg",
+            icon: "assets/images/icons/Military Pier.png",
           },
           {
             name: "Nobles' Quay",
             type: "building",
             target: "Nobles' Quay",
-            icon: "assets/images/icons/nobles-quay.svg",
+            icon: "assets/images/icons/Noble's Quay.png",
           },
           {
             name: "Merchants' Wharf",
             type: "building",
             target: "Merchants' Wharf",
-            icon: "assets/images/icons/merchants-wharf.svg",
+            icon: "assets/images/icons/Merchant Pier.png",
           },
           {
             name: "Fisherman's Pier",
             type: "building",
             target: "Fisherman's Pier",
-            icon: "assets/images/icons/fishing-pier.svg",
+            icon: "assets/images/icons/Fishing Dock 1.png",
           },
-          { name: "Tideway Inn", type: "building", target: "Tideway Inn" },
-          { name: "Upper Ward", type: "district", target: "Upper Ward" },
-          { name: "Little Terns", type: "district", target: "Little Terns" }
-        ]
+          { name: "Tideway Inn", type: "building", target: "Tideway Inn", icon: "assets/images/icons/Tidewater Inn.webp" },
+          { name: "Upper Ward", type: "district", target: "Upper Ward", icon: "assets/images/icons/Upper Ward 1.jpg" },
+          { name: "Little Terns", type: "district", target: "Little Terns", icon: "assets/images/icons/Little Terns District.png" }
+          ]
+        },
+        "Upper Ward": {
+          travelPrompt: "Walk to",
+          points: [
+            { name: "Governor's Keep", type: "building", target: "Governor's Keep" },
+            { name: "Crafting Quarter", type: "building", target: "Crafting Quarter", icon: "assets/images/icons/Crafting Yard.png" },
+            { name: "Mercantile Exchange", type: "building", target: "Mercantile Exchange" },
+            { name: "Temple of the Tides", type: "building", target: "Temple of the Tides" },
+            { name: "Hall of Records", type: "building", target: "Hall of Records" },
+            { name: "Port District", type: "district", target: "Port District", icon: "assets/images/icons/Merchant Pier.png" },
+            { name: "Greensoul Hill", type: "district", target: "Greensoul Hill", icon: "assets/images/icons/Public Park.png" }
+          ]
+        },
+        "Little Terns": {
+          travelPrompt: "Walk to",
+          points: [
+            { name: "Glassblowing Workshop", type: "building", target: "Glassblowing Workshop" },
+            { name: "Smithing Forge", type: "building", target: "Smithing Forge", icon: "assets/images/icons/Blacksmith Yard.png" },
+            { name: "Carpentry Lodge", type: "building", target: "Carpentry Lodge", icon: "assets/images/icons/Lumber Yard.png" },
+            { name: "Tailoring Shop", type: "building", target: "Tailoring Shop" },
+            { name: "Leatherworking Shed", type: "building", target: "Leatherworking Shed", icon: "assets/images/icons/Leatherworking Station.png" },
+            { name: "Alchemy Lab", type: "building", target: "Alchemy Lab", icon: "assets/images/icons/Alchemy Shop.png" },
+            { name: "Enchanting Sanctum", type: "building", target: "Enchanting Sanctum", icon: "assets/images/icons/Enchanting Shop.png" },
+            { name: "Port District", type: "district", target: "Port District", icon: "assets/images/icons/Fishing Dock 2.png" },
+            { name: "Greensoul Hill", type: "district", target: "Greensoul Hill", icon: "assets/images/icons/Public Park.png" }
+          ]
+        },
+        "Greensoul Hill": {
+          travelPrompt: "Walk to",
+          points: [
+            { name: "Upper Ward", type: "district", target: "Upper Ward", icon: "assets/images/icons/Upper Ward 2.jpg" },
+            { name: "Little Terns", type: "district", target: "Little Terns", icon: "assets/images/icons/Little Terns District.png" },
+            { name: "The Lower Gardens", type: "district", target: "The Lower Gardens", icon: "assets/images/icons/Lower Gardens District.png" }
+          ]
+        },
+        "The Lower Gardens": {
+          travelPrompt: "Walk to",
+          points: [
+            { name: "City Bakery", type: "building", target: "City Bakery", icon: "assets/images/icons/Bakery.jpg" },
+            { name: "Central Granary", type: "building", target: "Central Granary", icon: "assets/images/icons/Small Granary.png" },
+            { name: "Greensoul Hill", type: "district", target: "Greensoul Hill", icon: "assets/images/icons/Public Park.png" },
+            { name: "The High Road District", type: "district", target: "The High Road District", icon: "assets/images/icons/Small Bridge.png" }
+          ]
+        },
+        "The High Road District": {
+          travelPrompt: "Walk to",
+          points: [
+            { name: "The Lower Gardens", type: "district", target: "The Lower Gardens", icon: "assets/images/icons/Lower Gardens District.png" },
+            { name: "The Farmlands Beyond the Walls", type: "district", target: "The Farmlands Beyond the Walls", icon: "assets/images/icons/Small Garden.png" }
+          ]
+        },
+        "The Farmlands Beyond the Walls": {
+          travelPrompt: "Walk to",
+          points: [
+            { name: "The High Road District", type: "district", target: "The High Road District", icon: "assets/images/icons/Small Bridge.png" },
+            { name: "East Road to Mountain Top", type: "location", target: "Mountain Top" }
+          ]
+        }
       },
-      "Upper Ward": {
-        travelPrompt: "Walk to",
-        points: [
-          { name: "Governor's Keep", type: "building", target: "Governor's Keep" },
-          { name: "Crafting Quarter", type: "building", target: "Crafting Quarter" },
-          { name: "Mercantile Exchange", type: "building", target: "Mercantile Exchange" },
-          { name: "Temple of the Tides", type: "building", target: "Temple of the Tides" },
-          { name: "Hall of Records", type: "building", target: "Hall of Records" },
-          { name: "Port District", type: "district", target: "Port District" },
-          { name: "Greensoul Hill", type: "district", target: "Greensoul Hill" }
-        ]
-      },
-      "Little Terns": {
-        travelPrompt: "Walk to",
-        points: [
-          { name: "Glassblowing Workshop", type: "building", target: "Glassblowing Workshop" },
-          { name: "Smithing Forge", type: "building", target: "Smithing Forge", icon: "assets/images/icons/blacksmith.svg" },
-          { name: "Carpentry Lodge", type: "building", target: "Carpentry Lodge" },
-          { name: "Tailoring Shop", type: "building", target: "Tailoring Shop" },
-          { name: "Leatherworking Shed", type: "building", target: "Leatherworking Shed" },
-          { name: "Alchemy Lab", type: "building", target: "Alchemy Lab" },
-          { name: "Enchanting Sanctum", type: "building", target: "Enchanting Sanctum" },
-          { name: "Port District", type: "district", target: "Port District" },
-          { name: "Greensoul Hill", type: "district", target: "Greensoul Hill" }
-        ]
-      },
-      "Greensoul Hill": {
-        travelPrompt: "Walk to",
-        points: [
-          { name: "Upper Ward", type: "district", target: "Upper Ward" },
-          { name: "Little Terns", type: "district", target: "Little Terns" },
-          { name: "The Lower Gardens", type: "district", target: "The Lower Gardens" }
-        ]
-      },
-      "The Lower Gardens": {
-        travelPrompt: "Walk to",
-        points: [
-          { name: "City Bakery", type: "building", target: "City Bakery" },
-          { name: "Central Granary", type: "building", target: "Central Granary" },
-          { name: "Greensoul Hill", type: "district", target: "Greensoul Hill" },
-          { name: "The High Road District", type: "district", target: "The High Road District" }
-        ]
-      },
-      "The High Road District": {
-        travelPrompt: "Walk to",
-        points: [
-          { name: "The Lower Gardens", type: "district", target: "The Lower Gardens" },
-          { name: "The Farmlands Beyond the Walls", type: "district", target: "The Farmlands Beyond the Walls" }
-        ]
-      },
-      "The Farmlands Beyond the Walls": {
-        travelPrompt: "Walk to",
-        points: [
-          { name: "The High Road District", type: "district", target: "The High Road District" },
-          { name: "East Road to Mountain Top", type: "location", target: "Mountain Top" }
-        ]
-      }
-    },
     buildings: {
       "Tideway Inn": {
         travelPrompt: "Exit to",


### PR DESCRIPTION
## Summary
- Link existing icon images to city navigation entries
- Replace obsolete SVG references with matching PNG/WebP assets
- Provide visual cues for districts and buildings in navigation buttons

## Testing
- `node --check assets/data/city_nav.js`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b486485c3c8325899695eae6ec4975