### PR TITLE
Refine menu icons and navigation buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@
   --foreground: #333333;
   /* Menu button colors default to the light theme */
   --menu-color-dark: #333333;
-  --menu-color-light: #333333;
+  --menu-color-light: #f0f0f0;
   --range-color: #555555;
   --capped-color: #2e8b57;
   --new-char-bg: #333333;
@@ -76,15 +76,15 @@ main {
   height: var(--menu-button-size);
   padding: 2px;
   box-sizing: border-box;
-  font-size: 1rem;
+  font-size: calc(var(--menu-button-size) * 0.7);
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 50%;
   border: none;
   background: #e0e0e0;
-  color: var(--menu-color-dark);
-  -webkit-text-stroke: 1px var(--menu-color-light);
+  color: var(--menu-color-light);
+  -webkit-text-stroke: 1px var(--menu-color-dark);
   box-shadow: inset 2px 2px 4px rgba(255,255,255,0.6),
               inset -2px -2px 4px rgba(0,0,0,0.2);
   transition: box-shadow 0.3s ease, background 0.3s ease;
@@ -92,8 +92,8 @@ main {
 }
 
 .top-menu button svg {
-  width: 100%;
-  height: 100%;
+  width: 70%;
+  height: 70%;
   stroke: currentColor;
   fill: none;
   stroke-width: 2;
@@ -334,7 +334,7 @@ body.theme-light {
   --background: #f0f0f0;
   --foreground: #333333;
   --menu-color-dark: #333333;
-  --menu-color-light: #333333;
+  --menu-color-light: #f0f0f0;
   --range-color: #555555;
   --capped-color: #2e8b57;
   --new-char-bg: #333333;
@@ -348,7 +348,7 @@ body.theme-sepia {
   --background: #e8dcc2;
   --foreground: #4a3b2d;
   --menu-color-dark: #4a3b2d;
-  --menu-color-light: #4a3b2d;
+  --menu-color-light: #e8dcc2;
   --range-color: #4a3b2d;
   --capped-color: #1e90ff;
   --new-char-bg: #4a3b2d;
@@ -361,7 +361,7 @@ body.theme-sepia {
 body.theme-dark {
   --background: #222222;
   --foreground: #eeeeee;
-  --menu-color-dark: #cccccc;
+  --menu-color-dark: #222222;
   --menu-color-light: #cccccc;
   --range-color: #aaaaaa;
   --capped-color: #9370db;
@@ -696,21 +696,32 @@ body.theme-dark {
     display: flex;
     align-items: center;
     justify-content: center;
+    border-radius: 50%;
+    border: none;
+    background: #e0e0e0;
+    color: var(--foreground);
+    box-shadow: inset 2px 2px 4px rgba(255,255,255,0.6),
+                inset -2px -2px 4px rgba(0,0,0,0.2);
+    transition: box-shadow 0.3s ease, background 0.3s ease;
   }
 
-  .navigation .nav-item button:hover {
+  .navigation .nav-item button:hover,
+  .navigation .nav-item button:active {
     background: var(--foreground);
     color: var(--background);
+    box-shadow: 0 0 8px var(--foreground),
+                inset 2px 2px 4px rgba(255,255,255,0.6),
+                inset -2px -2px 4px rgba(0,0,0,0.2);
   }
 
   .navigation .nav-item button .nav-icon {
-    width: 3rem;
-    height: 3rem;
+    width: 70%;
+    height: 70%;
   }
 
   .navigation .nav-item button span.nav-icon {
-    font-size: 2.5rem;
-    line-height: 3rem;
+    font-size: 3.5rem;
+    line-height: 3.5rem;
   }
 
   .navigation .nav-item button img.nav-icon {


### PR DESCRIPTION
## Summary
- Invert top menu button icon colors and scale SVG icons to 70% to prevent border overlap
- Style city and district navigation buttons as round with a soft glow on hover or press
- Adjust navigation icons to scale within buttons without touching borders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a8c92cb48325bd58d96f9a075c6b