### PR TITLE
Fix dark mode menu icon color and initial city nav buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -89,6 +89,23 @@ function isPortraitLayout() {
 function normalizeOptionButtonWidths() {
   const grid = document.querySelector('.option-grid');
   if (!grid) return;
+  const images = Array.from(grid.querySelectorAll('img'));
+  let pending = images.filter(img => !img.complete).length;
+  if (pending) {
+    images.forEach(img => {
+      if (!img.complete) {
+        img.addEventListener(
+          'load',
+          () => {
+            pending--;
+            if (pending === 0) normalizeOptionButtonWidths();
+          },
+          { once: true }
+        );
+      }
+    });
+    return;
+  }
   const buttons = Array.from(grid.querySelectorAll('button'));
   let maxWidth = 0;
   buttons.forEach(btn => {

--- a/style.css
+++ b/style.css
@@ -372,6 +372,12 @@ body.theme-dark {
   --stamina-color: #008000;
 }
 
+/* Ensure menu icons blend with the background in dark mode */
+body.theme-dark .top-menu button {
+  color: var(--menu-color-dark);
+  -webkit-text-stroke: 1px var(--menu-color-light);
+}
+
 .progress {
   width: 80%;
   height: 1rem;


### PR DESCRIPTION
## Summary
- Ensure top menu button icons in dark mode use the background color with contrasting stroke
- Wait for navigation button images to load before sizing buttons to prevent missing buttons on first visit

## Testing
- `npx tsc --noEmit` *(fails: This is not the tsc command you are looking for)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ecb3b458832596fb9b2b0e66d993