### PR TITLE
Fix menu icons and standardize navigation icon sizing

### DIFF
--- a/assets/data/city_nav.js
+++ b/assets/data/city_nav.js
@@ -30,7 +30,7 @@ export const CITY_NAV = {
             target: "Fisherman's Pier",
             icon: "assets/images/icons/Fishing Dock 1.png",
           },
-          { name: "Tideway Inn", type: "building", target: "Tideway Inn", icon: "assets/images/icons/Tidewater Inn.webp" },
+          { name: "Tideway Inn", type: "building", target: "Tideway Inn", icon: "assets/images/icons/Tideway Inn.png" },
           { name: "Upper Ward", type: "district", target: "Upper Ward", icon: "assets/images/icons/Upper Ward District.png" },
           { name: "Little Terns", type: "district", target: "Little Terns", icon: "assets/images/icons/Little Terns District.png" }
           ]
@@ -267,7 +267,7 @@ export const CITY_NAV = {
           { name: "Leatherworking Shed", type: "building", target: "Leatherworking Shed" },
           { name: "Alchemy Lab", type: "building", target: "Alchemy Lab" },
           { name: "Enchanting Sanctum", type: "building", target: "Enchanting Sanctum" },
-          { name: "Military Ward", type: "district", target: "Military Ward" }
+          { name: "Military Ward", type: "district", target: "Military Ward", icon: "assets/images/icons/Military Ward District.png" }
         ]
       },
       "Military Ward": {
@@ -280,7 +280,7 @@ export const CITY_NAV = {
       "Greywind's Edge": {
         travelPrompt: "Walk to",
         points: [
-          { name: "Military Ward", type: "district", target: "Military Ward" },
+          { name: "Military Ward", type: "district", target: "Military Ward", icon: "assets/images/icons/Military Ward District.png" },
           { name: "West Road to Timber Grove", type: "location", target: "Timber Grove" }
         ]
       }

--- a/style.css
+++ b/style.css
@@ -96,9 +96,25 @@ main {
     width: 70%;
     height: 70%;
     stroke: currentColor;
-    fill: none;
     stroke-width: 2;
+    fill: currentColor;
     display: block;
+  }
+  #menu-button,
+  #scale-dec,
+  #scale-inc {
+    -webkit-text-stroke: 0;
+  }
+
+  #scale-dec,
+  #scale-inc {
+    font-size: calc(var(--menu-button-size) * 0.9);
+  }
+
+  body.theme-dark #menu-button,
+  body.theme-dark #scale-dec,
+  body.theme-dark #scale-inc {
+    color: var(--menu-color-light);
   }
 
 .top-menu button:hover,
@@ -723,8 +739,8 @@ body.theme-dark .top-menu button {
     }
 
     .navigation .nav-item button .nav-icon {
-      width: 80%;
-      height: 80%;
+      width: 100%;
+      height: 100%;
       display: block;
       object-fit: contain;
     }


### PR DESCRIPTION
## Summary
- render top menu icons as solid and enlarge zoom controls
- ensure navigation icons fill their buttons for consistent sizing
- fix Tideway Inn and Military Ward icon paths

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: /usr/bin/npx: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b200ecc8832597c6c03f981b196c