### PR TITLE
Persist current location on refresh

### DIFF
--- a/script.js
+++ b/script.js
@@ -665,7 +665,12 @@ function applySpellProficiencyGain(character, spell, params) {
   }
 }
 
-const saveProfiles = () => localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles));
+const saveProfiles = () => {
+  if (currentProfile && currentCharacter) {
+    currentProfile.characters[currentCharacter.id] = currentCharacter;
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles));
+};
 
 const formatHeight = cm => {
   const totalInches = Math.round(cm / 2.54);


### PR DESCRIPTION
## Summary
- ensure saveProfiles writes current character back to profile before saving

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b657612883258a4c445e7e367177