### PR TITLE
Revert top menu icons to outlines

### DIFF
--- a/style.css
+++ b/style.css
@@ -97,7 +97,7 @@ main {
     height: 70%;
     stroke: currentColor;
     stroke-width: 2;
-    fill: currentColor;
+    fill: none;
     display: block;
   }
   #menu-button,


### PR DESCRIPTION
## Summary
- Restore top menu SVG icons to use stroke-only outlines
- Keep menu, minus and plus buttons solid by disabling text stroke

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ba307d0483258eda101852a5ef6a