### PR TITLE
Skip width normalization for navigation grids

### DIFF
--- a/script.js
+++ b/script.js
@@ -89,6 +89,7 @@ function isPortraitLayout() {
 function normalizeOptionButtonWidths() {
   const grid = document.querySelector('.option-grid');
   if (!grid) return;
+  if (grid.closest('.navigation')) return; // skip nav grids
   const images = Array.from(grid.querySelectorAll('img'));
   let pending = images.filter(img => !img.complete).length;
   if (pending) {


### PR DESCRIPTION
## Summary
- avoid normalizing option buttons when option grid is inside a navigation container

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ba497bb48325aa4f664f0dc2033b