### PR TITLE
Fix back arrow styling in dark theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -101,9 +101,11 @@ main {
     display: block;
   }
   #menu-button,
+  #back-button,
   #scale-dec,
   #scale-inc {
     -webkit-text-stroke: 0;
+    line-height: 1;
   }
 
   #scale-dec,
@@ -115,6 +117,10 @@ main {
   body.theme-dark #scale-dec,
   body.theme-dark #scale-inc {
     color: var(--menu-color-dark);
+  }
+
+  body.theme-dark #back-button {
+    color: #555555;
   }
 
 .top-menu button:hover,


### PR DESCRIPTION
## Summary
- ensure back arrow and minus icons are vertically centered
- show a solid dark grey back arrow in dark theme

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b5e5dcd6c08325b4bd59ef0e721b28