### PR TITLE
Improve character creation defaults and UI icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,11 @@
   <div id="app">
 <nav class="top-menu">
   <button id="menu-button" aria-label="Menu">☰</button>
-  <button id="back-button" aria-label="Back" style="display:none;">←</button>
+  <button id="back-button" aria-label="Back" style="display:none;">
+    <svg viewBox="0 0 24 24">
+      <path d="M15 19l-7-7 7-7v14z" />
+    </svg>
+  </button>
   <button id="character-button" aria-label="Character" style="display:none;">
     <svg viewBox="0 0 24 24">
       <circle cx="12" cy="8" r="4" />

--- a/script.js
+++ b/script.js
@@ -1897,10 +1897,22 @@ function startCharacterCreation() {
     const activeFields = fields.filter(
       f => !f.races || f.races.includes(character.race)
     );
+    if (step > activeFields.length + 1) step = activeFields.length + 1;
+
+    let field;
+    if (step < activeFields.length) field = activeFields[step];
+    else if (step === activeFields.length + 1) field = locationField;
+    if (field && field.key === 'race' && !character.race) {
+      character.race = field.options[0];
+      localStorage.setItem(TEMP_CHARACTER_KEY, JSON.stringify({ step, character }));
+    }
+    if (field && field.key === 'location' && !character.location) {
+      character.location = locationField.options[0];
+    }
+
     const stepLabels = activeFields
       .map(f => FIELD_STEP_LABELS[f.key])
       .concat(['Name', 'Location']);
-    if (step > activeFields.length + 1) step = activeFields.length + 1;
     const isComplete = () =>
       activeFields.every(f => character[f.key]) && character.name && character.location;
     const progressHTML =
@@ -1920,17 +1932,6 @@ function startCharacterCreation() {
         .join('') +
       `<button id="cc-complete" class="complete-button" ${isComplete() ? '' : 'disabled'}></button>` +
       '<button id="cc-cancel" title="Cancel">✖</button>';
-
-    let field;
-    if (step < activeFields.length) field = activeFields[step];
-    else if (step === activeFields.length + 1) field = locationField;
-    if (field && field.key === 'race' && !character.race) {
-      character.race = field.options[0];
-      localStorage.setItem(TEMP_CHARACTER_KEY, JSON.stringify({ step, character }));
-    }
-    if (step === activeFields.length + 1 && !character.location) {
-      character.location = locationField.options[0];
-    }
     const displayData = (() => {
       if (field && field.key === 'location' && character.location) {
         const loc = LOCATIONS[character.location];

--- a/style.css
+++ b/style.css
@@ -100,6 +100,12 @@ main {
     fill: none;
     display: block;
   }
+  #back-button svg {
+    width: 80%;
+    height: 80%;
+    stroke: none;
+    fill: currentColor;
+  }
   #menu-button,
   #back-button,
   #scale-dec,
@@ -835,8 +841,9 @@ body.theme-dark .top-menu button {
     line-height: 1;
     padding: 0;
     width: 2rem;
-    height: 2rem;
-    display: inline-flex;
+    height: 100%;
+    aspect-ratio: 1 / 1;
+    display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
@@ -852,7 +859,7 @@ body.theme-dark .top-menu button {
   .wheel-selector {
     margin-left: 0;
     display: flex;
-    align-items: center;
+    align-items: stretch;
   }
 
   .progress-current-detail {


### PR DESCRIPTION
## Summary
- Pre-select default city when entering location step, enabling immediate confirmation
- Align character creation wheel chevrons with option height
- Replace back button glyph with larger filled arrow SVG

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b5eb91e5c08325bbed22099990c771