### PR TITLE
Standardize High Road district naming

### DIFF
--- a/assets/data/locations.js
+++ b/assets/data/locations.js
@@ -91,7 +91,7 @@ Its people are diverse: salt-stained sailors, silver-tongued merchants, hammer-a
         "Little Terns",
         "Greensoul Hill",
         "The Lower Gardens",
-        "The High Road District (East Gate Approach)",
+        "The High Road District",
         "The Farmlands Beyond the Walls",
     ], travel: { routes: ["sea route to Coral Keep"], connections: ["Coral Keep"] }, population: {
         estimate: 31500,

--- a/assets/data/locations.ts
+++ b/assets/data/locations.ts
@@ -185,7 +185,7 @@ Its people are diverse: salt-stained sailors, silver-tongued merchants, hammer-a
     "Little Terns",
     "Greensoul Hill",
     "The Lower Gardens",
-    "The High Road District (East Gate Approach)",
+    "The High Road District",
     "The Farmlands Beyond the Walls",
   ],
   travel: { routes: ["sea route to Coral Keep"], connections: ["Coral Keep"] },

--- a/assets/data/waves_break_backstories.ts
+++ b/assets/data/waves_break_backstories.ts
@@ -189,7 +189,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     narrative: "You stretch within the gardeners' tool shed, dawn light spilling across beds awaiting your care.",
   },
   {
-    district: "The High Road District (East Gate Approach)",
+    district: "The High Road District",
     background: "Wagoneer",
     past: "Teamster who guides caravans through the gate while searching for his missing father.",
     items: ["sturdy gloves", "horse brush"],
@@ -200,7 +200,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     narrative: "You wake atop a wagon in the caravan yard, horses stamping nearby as travelers ready for the road.",
   },
   {
-    district: "The High Road District (East Gate Approach)",
+    district: "The High Road District",
     background: "Caravan merchant",
     past: "Runs a trinket stall in Caravan Square, trading in curiosities from distant roads.",
     items: ["merchant's ledger", "lockbox"],
@@ -211,7 +211,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     narrative: "You flip open the awning of your Caravan Square stall, coins already jingling as merchants begin to haggle.",
   },
   {
-    district: "The High Road District (East Gate Approach)",
+    district: "The High Road District",
     background: "Gate guard",
     past: "Son of a veteran mason, joined the watch to protect the east gate.",
     items: ["iron cap", "short sword"],


### PR DESCRIPTION
## Summary
- use "The High Road District" consistently across Wave's Break data
- update backstories and location subdivisions to match

## Testing
- `npm test` *(fails: package.json not found)*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b72e4568b4832581175dc4ae4d9b99