### PR TITLE
Use new icons for wave's break locations

### DIFF
--- a/assets/data/city_nav.js
+++ b/assets/data/city_nav.js
@@ -10,13 +10,13 @@ export const CITY_NAV = {
             name: "Harborwatch Trading House",
             type: "building",
             target: "Harborwatch Trading House",
-            icon: "assets/images/icons/waves_break/Default.png",
+            icon: "assets/images/icons/waves_break/Harborwatch Trading House.png",
           },
           {
             name: "Warehouse Row",
             type: "building",
             target: "Warehouse Row",
-            icon: "assets/images/icons/waves_break/Default.png",
+            icon: "assets/images/icons/waves_break/Warehouse Row.png",
           },
           {
             name: "Stormkeel Shipwrights",


### PR DESCRIPTION
## Summary
- swap default port icons for Harborwatch Trading House and Warehouse Row with their new art assets

## Testing
- `node --check assets/data/city_nav.js`


------
https://chatgpt.com/codex/tasks/task_e_68b81eac5d7c83259850098814298699