### PR TITLE
Center current district in navigation

### DIFF
--- a/style.css
+++ b/style.css
@@ -786,6 +786,26 @@ body.theme-dark .top-menu button {
       font-size: calc(4rem * var(--location-scale));
     }
 
+  .navigation .district-nav {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    width: 100%;
+  }
+
+  .navigation .district-nav .nav-item.current-district button {
+    box-shadow: 0 0 10px 2px var(--foreground);
+    pointer-events: none;
+    cursor: default;
+  }
+
+  .navigation .district-nav .nav-item button:disabled {
+    background: none;
+    color: var(--foreground);
+    opacity: 1;
+  }
+
   .navigation .street-sign {
     background: #2e8b57;
     color: #fff;


### PR DESCRIPTION
## Summary
- Center the active district in navigation and surround it with neighboring districts
- Highlight the current district with a glow and disable interactions

## Testing
- `npm test` (fails: package.json not found)
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b89e87240083259173f8cdd1fcf454