### PR TITLE
Fix district icon glow to respect transparency

### DIFF
--- a/style.css
+++ b/style.css
@@ -795,9 +795,16 @@ body.theme-dark .top-menu button {
   }
 
   .navigation .district-nav .nav-item.current-district button {
-    box-shadow: 0 0 10px 2px var(--foreground);
     pointer-events: none;
     cursor: default;
+  }
+
+  .navigation .district-nav .nav-item.current-district img.nav-icon {
+    filter: drop-shadow(0 0 10px var(--foreground));
+  }
+
+  .navigation .district-nav .nav-item.current-district span.nav-icon {
+    text-shadow: 0 0 10px var(--foreground);
   }
 
   .navigation .district-nav .nav-item button:disabled {


### PR DESCRIPTION
## Summary
- Replace box-shadow glow on current district with drop-shadow and text-shadow so transparent district icons glow around their shape

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8babab93483259a80e8194cacdee3