### PR TITLE
Hide street sign labels for icon-based navigation

### DIFF
--- a/script.js
+++ b/script.js
@@ -1234,7 +1234,8 @@ function showNavigation() {
     const aria = prompt ? `${prompt} ${name}` : name;
     const dis = disabled ? 'disabled' : '';
     const cls = extraClass ? ` ${extraClass}` : '';
-    return `<div class="nav-item${cls}"><button data-type="${type}" ${attrs} aria-label="${aria}" ${dis}>${iconHTML}</button><span class="street-sign">${name}</span></div>`;
+    const labelHTML = icon ? '' : `<span class="street-sign">${name}</span>`;
+    return `<div class="nav-item${cls}"><button data-type="${type}" ${attrs} aria-label="${aria}" ${dis}>${iconHTML}</button>${labelHTML}</div>`;
   };
   if (pos.building) {
     const building = cityData.buildings[pos.building];


### PR DESCRIPTION
## Summary
- Skip street-sign labels for navigation entries that supply their own icons

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba0fba0c48832588b17546d5a3a358