### PR TITLE
feat: add gathering proficiency category

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Crafting is now learned from tiered trainers rather than academies. Trainers ran
 
 New activity skills – **Swimming**, **Sailing** and **Horseback Riding** – progress through time spent performing their respective activities. Progression helpers for these skills live in `assets/data/outdoor_skills.ts`.
 
+### Gathering
+
+Resource collection skills such as **Mining**, **Foraging**, **Logging**, **Herbalism**, **Pearl Diving**, **Gardening**, and **Farming** now belong to a dedicated Gathering category.
+
 ### Magical Proficiencies
 
 Characters now track separate proficiencies for Stone, Water, Wind, Fire, Ice, Thunder, Dark, Light, Destructive, Healing, Reinforcement, Enfeebling and Summoning. The `gainProficiencyWithChance` function in `script.js` calculates how these values increase when spells are cast. The spellbook requires a character to meet the proficiency threshold in both a spell's element and its school before it can be used.

--- a/assets/data/party.ts
+++ b/assets/data/party.ts
@@ -14,7 +14,8 @@ export type ProficiencyKind =
   | "Element_Ice"|"Element_Thunder"|"Element_Dark"|"Element_Light"
   | "Weapon_Sword"|"Weapon_Axe"|"Weapon_Spear"|"Weapon_Dagger"|"Weapon_Mace"|"Weapon_Bow"|"Weapon_Staff"|"Weapon_Shield"|"Weapon_Wand"|"Weapon_Unarmed"
   | "Instrument"|"Dance"|"Singing"
-  | "Craft_Alchemy"|"Craft_Brewing"|"Craft_Carpentry"|"Craft_Weaving"|"Craft_Fletching"|"Craft_Rope"|"Craft_Calligraphy"|"Craft_Drawing"|"Craft_Herbalism"|"Craft_Gardening"|"Craft_Farming"|"Craft_Cooking"
+  | "Craft_Alchemy"|"Craft_Brewing"|"Craft_Carpentry"|"Craft_Weaving"|"Craft_Fletching"|"Craft_Rope"|"Craft_Calligraphy"|"Craft_Drawing"|"Craft_Cooking"
+  | "Gather_Mining"|"Gather_Foraging"|"Gather_Logging"|"Gather_Herbalism"|"Gather_Gardening"|"Gather_Farming"|"Gather_PearlDiving"
   | "Evasion"|"Parry"|"Block";
 
 export interface ProfBlock {

--- a/script.js
+++ b/script.js
@@ -836,6 +836,9 @@ const defaultProficiencies = {
   tailoring: 0,
   leatherworking: 0,
   herbalism: 0,
+  mining: 0,
+  foraging: 0,
+  logging: 0,
   brewing: 0,
   drawing: 0,
   alchemy: 0,
@@ -992,14 +995,19 @@ const proficiencyCategories = {
     'weaving',
     'fletching',
     'glassblowing',
-    'pearlDiving',
     'rope',
     'calligraphy',
     'drawing',
-    'herbalism',
-    'gardening',
-    'farming',
     'cooking'
+  ],
+  Gathering: [
+    'mining',
+    'foraging',
+    'logging',
+    'herbalism',
+    'pearlDiving',
+    'gardening',
+    'farming'
   ]
 };
 


### PR DESCRIPTION
## Summary
- add Gathering proficiency category for resource collection
- move gardening, farming, herbalism, and pearl diving from Crafting to Gathering
- document Gathering skills in README
- add Logging to Gathering proficiencies

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0cff61ac832588fc9b9251f75f0e