### PR TITLE
Standardize navigation icons and map city districts

### DIFF
--- a/assets/data/city_nav.js
+++ b/assets/data/city_nav.js
@@ -227,6 +227,29 @@ export const CITY_NAV = {
           ]
         }
       },
+    layout: {
+      rows: 3,
+      cols: 3,
+      positions: {
+        "The Port District": [0, 0],
+        "The Upper Ward": [0, 1],
+        "Greensoul Hill": [0, 2],
+        "Little Terns": [1, 0],
+        "The High Road District": [1, 1],
+        "The Lower Gardens": [2, 0],
+        "The Farmlands": [2, 1],
+      },
+      connections: [
+        ["The Port District", "The Upper Ward"],
+        ["The Port District", "Little Terns"],
+        ["The Upper Ward", "Little Terns"],
+        ["The Upper Ward", "The High Road District"],
+        ["The Upper Ward", "Greensoul Hill"],
+        ["Little Terns", "The High Road District"],
+        ["Little Terns", "The Lower Gardens"],
+        ["The High Road District", "The Farmlands"],
+      ],
+    },
     buildings: {
       "Harborwatch Trading House": {
         travelPrompt: "Exit to",
@@ -790,8 +813,8 @@ export const CITY_NAV = {
           { name: "West Road to Timber Grove", type: "location", target: "Timber Grove" }
         ]
       }
-    },
-    buildings: {
+  },
+  buildings: {
       "Steel Watch Naval Docks": {
         travelPrompt: "Exit to",
         description: "Warships rest in ordered rows while crews drill with precision.",

--- a/style.css
+++ b/style.css
@@ -813,6 +813,48 @@ body.theme-dark .top-menu button {
     opacity: 1;
   }
 
+  .navigation .district-map {
+    position: relative;
+    margin: 0 auto;
+  }
+
+  .navigation .district-map .district-node {
+    position: absolute;
+    z-index: 1;
+  }
+
+  .navigation .district-map .district-connections {
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .navigation .district-map .district-connections line {
+    stroke: var(--foreground);
+    stroke-width: 2;
+  }
+
+  .navigation .district-map .nav-item.current-district button {
+    pointer-events: none;
+    cursor: default;
+  }
+
+  .navigation .district-map .nav-item.current-district img.nav-icon {
+    filter: drop-shadow(0 0 10px var(--foreground));
+  }
+
+  .navigation .district-map .nav-item.current-district span.nav-icon {
+    text-shadow: 0 0 10px var(--foreground);
+  }
+
+  .navigation .district-map .nav-item button:disabled {
+    opacity: 0.5;
+    background: none;
+    color: var(--foreground);
+  }
+
   .navigation .street-sign {
     background: #2e8b57;
     color: #fff;


### PR DESCRIPTION
## Summary
- fix navigation button sizing so location icons remain consistent
- display full city district map with connections and disabled inaccessible districts
- add layout metadata for Wave's Break districts

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1443bed48325a38d13572e0fa1f0