### PR TITLE
Use grayscale for disabled districts

### DIFF
--- a/style.css
+++ b/style.css
@@ -807,10 +807,10 @@ body.theme-dark .top-menu button {
     text-shadow: 0 0 10px var(--foreground);
   }
 
-  .navigation .district-nav .nav-item button:disabled {
+  .navigation .district-nav .nav-item:not(.current-district) button:disabled {
     background: none;
     color: var(--foreground);
-    opacity: 1;
+    filter: grayscale(100%) brightness(0.5);
   }
 
   .navigation .district-map {
@@ -849,10 +849,10 @@ body.theme-dark .top-menu button {
     text-shadow: 0 0 10px var(--foreground);
   }
 
-  .navigation .district-map .nav-item button:disabled {
-    opacity: 0.5;
+  .navigation .district-map .nav-item:not(.current-district) button:disabled {
     background: none;
     color: var(--foreground);
+    filter: grayscale(100%) brightness(0.5);
   }
 
   .navigation .street-sign {


### PR DESCRIPTION
## Summary
- use grayscale brightness filter instead of opacity to dim inaccessible districts so map lines do not show through icons

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1cf2044c8325aa8873421ff94e93