### PR TITLE
refactor: extract proficiency utilities

### DIFF
--- a/assets/data/core.js
+++ b/assets/data/core.js
@@ -2,83 +2,6 @@
 
 import { createEmptyEquipment } from "./equipment.js";
 
-// ---- Global Tunables & Tables ----
-export const PROF_MILESTONES = [10,20,30,40,50,60,70,80,90,100];
-export const RACIAL_START_MULTIPLIER = {};
-export const CAP_LEVEL_FOR_100 = 50;
-export const CAP_BASE_PROF = 1;
-
-export function proficiencyCap(L, A0 = CAP_BASE_PROF, A = 0, r = 1) {
-  return Math.round(A0 + A + r * L);
-}
-
-// Full gain function with chance gate & fail/partial outcomes
-export function gainProficiency(params) {
-  const {
-    P,
-    L,
-    A0,
-    A,
-    r,
-    g0 = 1,
-    F_context = 1,
-    F_level = 1,
-    F_attr = 1,
-    F_repeat = 1,
-    F_unlock_dist = 1,
-    F_post = 1,
-    F_capgap = 1,
-    F_variety = 1,
-    isNewSpellUse = false,
-    success = true,
-    M_new = 1,
-    p_partial_fail = 0,
-    fail_partial_factor = 0,
-    \u03c4_high = 1,
-    \u03c4_low = 0,
-    p_small_min = 0,
-    rand = Math.random
-  } = params;
-
-  const Cap = proficiencyCap(L, A0, A, r);
-  const dP_raw =
-    g0 *
-    F_context *
-    F_level *
-    F_attr *
-    F_repeat *
-    F_unlock_dist *
-    F_post *
-    F_capgap *
-    F_variety;
-
-  const dP_success = isNewSpellUse
-    ? Math.min(dP_raw * M_new, Cap - P)
-    : Math.min(dP_raw, Cap - P);
-
-  if (!success) {
-    if (rand() < p_partial_fail) {
-      return Math.round(P + dP_success * fail_partial_factor, 2);
-    }
-    return Math.round(P, 2);
-  }
-
-  let p_gain;
-  if (isNewSpellUse) {
-    p_gain = 0.95;
-  } else if (dP_success >= \u03c4_high) {
-    p_gain = 1;
-  } else if (dP_success <= \u03c4_low) {
-    p_gain = p_small_min;
-  } else {
-    const t = (dP_success - \u03c4_low) / (\u03c4_high - \u03c4_low);
-    p_gain = p_small_min + (1 - p_small_min) * t;
-  }
-
-  const dP_final = rand() < p_gain ? dP_success : 0;
-  return Math.round(P + dP_final, 2);
-}
-
 // ---- Cost & Scaling ----
 export function mpCost(tier) {
   return Math.ceil(3 * (1 + Math.log2(tier)));
@@ -113,27 +36,6 @@ export const HEAL_BASE_COEFF_PER_BP = 1;
 export const SHIELD_ABSORB_PCT_PER_BP = 1;
 export const LIFESTEAL_PCT_PER_BP = 1;
 export const ENHANCE_PCT_PER_BP = 1;
-
-// ---- Proficiency Formula Tunables ----
-export const g0 = 1;
-export const F_CONTEXT = { practice: 0.2, spar: 0.6, battle: 1.0 };
-export const LEVEL_GAIN_MIN = 0.25;
-export const LEVEL_GAIN_MAX = 1.75;
-export const LEVEL_GAIN_SLOPE = 0.1;
-export const ATTR_GAIN_MIN = 0.7;
-export const ATTR_GAIN_MAX = 1.3;
-export const ATTR_GAIN_SLOPE = 0.01;
-export const W_unlock_window = 10;
-export const POST_UNLOCK_CHOKE_K = 3;
-export const VARIETY_BONUS_MAX = 0.25;
-export const F_repeat = N => 1 / (1 + Math.log(1 + N));
-export const τ_low = 0;
-export const τ_high = 1;
-export const p_small_min = 0;
-export const p_partial_fail = 0;
-export const fail_partial_factor = 0;
-export const M_new = 1;
-export const p_gain_newSpell = 0.95;
 
 // ---- Data Catalog Placeholders ----
 export const RESIST_PROFILE_DEFAULT = {};

--- a/assets/data/crafting_proficiency.ts
+++ b/assets/data/crafting_proficiency.ts
@@ -1,6 +1,6 @@
 // crafting_proficiency.ts — crafting proficiency progression tied to successful crafts
 
-import { F_repeat, W_unlock_window, POST_UNLOCK_CHOKE_K } from "./core.js";
+import { F_repeat, W_unlock_window, POST_UNLOCK_CHOKE_K } from "./proficiency_base.js";
 
 const r2 = (x: number) => Math.round(x * 100) / 100;
 

--- a/assets/data/proficiency_base.js
+++ b/assets/data/proficiency_base.js
@@ -1,0 +1,100 @@
+// Shared proficiency utilities and tunables
+
+// ---- Global Tunables & Tables ----
+export const PROF_MILESTONES = [10,20,30,40,50,60,70,80,90,100];
+export const RACIAL_START_MULTIPLIER = {};
+export const CAP_LEVEL_FOR_100 = 50;
+export const CAP_BASE_PROF = 1;
+
+export function proficiencyCap(L, A0 = CAP_BASE_PROF, A = 0, r = 1) {
+  return Math.round(A0 + A + r * L);
+}
+
+// Full gain function with chance gate & fail/partial outcomes
+export function gainProficiency(params) {
+  const {
+    P,
+    L,
+    A0,
+    A,
+    r,
+    g0 = 1,
+    F_context = 1,
+    F_level = 1,
+    F_attr = 1,
+    F_repeat = 1,
+    F_unlock_dist = 1,
+    F_post = 1,
+    F_capgap = 1,
+    F_variety = 1,
+    isNewSpellUse = false,
+    success = true,
+    M_new = 1,
+    p_partial_fail = 0,
+    fail_partial_factor = 0,
+    \u03c4_high = 1,
+    \u03c4_low = 0,
+    p_small_min = 0,
+    rand = Math.random
+  } = params;
+
+  const Cap = proficiencyCap(L, A0, A, r);
+  const dP_raw =
+    g0 *
+    F_context *
+    F_level *
+    F_attr *
+    F_repeat *
+    F_unlock_dist *
+    F_post *
+    F_capgap *
+    F_variety;
+
+  const dP_success = isNewSpellUse
+    ? Math.min(dP_raw * M_new, Cap - P)
+    : Math.min(dP_raw, Cap - P);
+
+  if (!success) {
+    if (rand() < p_partial_fail) {
+      return Math.round(P + dP_success * fail_partial_factor, 2);
+    }
+    return Math.round(P, 2);
+  }
+
+  let p_gain;
+  if (isNewSpellUse) {
+    p_gain = 0.95;
+  } else if (dP_success >= \u03c4_high) {
+    p_gain = 1;
+  } else if (dP_success <= \u03c4_low) {
+    p_gain = p_small_min;
+  } else {
+    const t = (dP_success - \u03c4_low) / (\u03c4_high - \u03c4_low);
+    p_gain = p_small_min + (1 - p_small_min) * t;
+  }
+
+  const dP_final = rand() < p_gain ? dP_success : 0;
+  return Math.round(P + dP_final, 2);
+}
+
+// ---- Proficiency Formula Tunables ----
+export const g0 = 1;
+export const F_CONTEXT = { practice: 0.2, spar: 0.6, battle: 1.0 };
+export const LEVEL_GAIN_MIN = 0.25;
+export const LEVEL_GAIN_MAX = 1.75;
+export const LEVEL_GAIN_SLOPE = 0.1;
+export const ATTR_GAIN_MIN = 0.7;
+export const ATTR_GAIN_MAX = 1.3;
+export const ATTR_GAIN_SLOPE = 0.01;
+export const W_unlock_window = 10;
+export const POST_UNLOCK_CHOKE_K = 3;
+export const VARIETY_BONUS_MAX = 0.25;
+export const F_repeat = N => 1 / (1 + Math.log(1 + N));
+export const \u03c4_low = 0;
+export const \u03c4_high = 1;
+export const p_small_min = 0;
+export const p_partial_fail = 0;
+export const fail_partial_factor = 0;
+export const M_new = 1;
+export const p_gain_newSpell = 0.95;
+

--- a/assets/data/spell_proficiency.js
+++ b/assets/data/spell_proficiency.js
@@ -1,4 +1,4 @@
-import { gainProficiency } from "./core.js";
+import { gainProficiency } from "./proficiency_base.js";
 import { HYBRID_RELATIONS } from "./hybrid_relations.js";
 
 export const elementalProficiencyMap = {

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 import { SPELLBOOK, MILESTONES } from "./assets/data/spells.js";
 import { WEAPON_SKILLS } from "./assets/data/weapon_skills.js";
-import { characterTemplate, gainProficiency, proficiencyCap } from "./assets/data/core.js";
+import { characterTemplate } from "./assets/data/core.js";
+import { gainProficiency, proficiencyCap } from "./assets/data/proficiency_base.js";
 import { getRaceStartingAttributes, RACE_DESCRIPTIONS } from "./assets/data/race_attrs.js";
 import { maxHP, maxMP, maxStamina } from "./assets/data/resources.js";
 import { DENOMINATIONS, CURRENCY_VALUES, convertCurrency, toIron, fromIron } from "./assets/data/currency.js";


### PR DESCRIPTION
## Summary
- move gainProficiency and related constants to new proficiency_base module
- update imports in script and proficiency helpers
- remove proficiency logic from core

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1cc44b788325833d02af87d98144