### PR TITLE
Treat gates as locations and unify nav button sizing

### DIFF
--- a/assets/data/city_nav.js
+++ b/assets/data/city_nav.js
@@ -181,8 +181,8 @@ export const CITY_NAV = {
             { name: "Shrine of the Roadwarden", type: "building", target: "Shrine of the Roadwarden", icon: "assets/images/icons/waves_break/Shrine of the Roadwarden.png" },
             { name: "Caravan Square", type: "building", target: "Caravan Square", icon: "assets/images/icons/waves_break/Caravan Square.png" },
             { name: "Gatewatch Barracks", type: "building", target: "Gatewatch Barracks", icon: "assets/images/icons/waves_break/Gatewatch Barracks.png" },
-              { name: "North Gate", type: "building", target: "North Gate", icon: "assets/images/icons/waves_break/North Gate.png" },
-              { name: "South Gate", type: "building", target: "South Gate", icon: "assets/images/icons/waves_break/South Gate.png" },
+              { name: "North Gate", type: "location", target: "North Gate", icon: "assets/images/icons/waves_break/North Gate.png" },
+              { name: "South Gate", type: "location", target: "South Gate", icon: "assets/images/icons/waves_break/South Gate.png" },
               { name: "Wayfarer's Rest Tavern", type: "building", target: "Wayfarer's Rest Tavern", icon: "assets/images/icons/waves_break/Wayfarer's Rest Tavern.png" },
             { name: "The Farmlands", type: "district", target: "The Farmlands", icon: "assets/images/icons/waves_break/Farmlands District.png" },
             { name: "Little Terns", type: "district", target: "Little Terns", icon: "assets/images/icons/waves_break/Little Terns District.png" },
@@ -221,8 +221,8 @@ export const CITY_NAV = {
               { name: "Cliffbreak Quarry", type: "building", target: "Cliffbreak Quarry", icon: "assets/images/icons/waves_break/Cliffbreak Quarry.png" },
               { name: "Wavecut Stoneworks", type: "building", target: "Wavecut Stoneworks", icon: "assets/images/icons/waves_break/Wavecut Stoneworks.png" },
               { name: "Coast Road Watchtower", type: "building", target: "Coast Road Watchtower", icon: "assets/images/icons/waves_break/Coast Road Watchtower.png" },
-              { name: "North Gate", type: "building", target: "North Gate", icon: "assets/images/icons/waves_break/North Gate.png" },
-              { name: "South Gate", type: "building", target: "South Gate", icon: "assets/images/icons/waves_break/South Gate.png" },
+              { name: "North Gate", type: "location", target: "North Gate", icon: "assets/images/icons/waves_break/North Gate.png" },
+              { name: "South Gate", type: "location", target: "South Gate", icon: "assets/images/icons/waves_break/South Gate.png" },
               { name: "East Road to Mountain Top", type: "location", target: "Mountain Top", icon: "assets/images/icons/waves_break/The East Road to Mountain Top.png" }
           ]
         }
@@ -242,7 +242,6 @@ export const CITY_NAV = {
       connections: [
         ["The Port District", "The Upper Ward"],
         ["The Port District", "Little Terns"],
-        ["The Upper Ward", "Little Terns"],
         ["The Upper Ward", "The High Road District"],
         ["The Upper Ward", "Greensoul Hill"],
         ["Little Terns", "The High Road District"],

--- a/style.css
+++ b/style.css
@@ -1,6 +1,5 @@
 :root {
   --ui-scale: 1;
-  --location-scale: calc((var(--ui-scale) + 1) / var(--ui-scale));
   --background: #f0f0f0;
   --foreground: #333333;
   /* Menu button colors default to the light theme */
@@ -681,11 +680,6 @@ body.theme-dark .top-menu button {
     white-space: nowrap;
   }
 
-  .option-button.location-button {
-    width: calc(8rem * var(--location-scale));
-    height: calc(2rem * var(--location-scale));
-    font-size: calc(1rem * var(--location-scale));
-  }
 
   .option-grid button {
     border: 2px solid var(--foreground);
@@ -744,8 +738,8 @@ body.theme-dark .top-menu button {
   }
 
     .navigation .nav-item button {
-      width: 5rem;
-      height: 5rem;
+      width: 10rem;
+      height: 10rem;
       padding: 0;
       display: flex;
       align-items: center;
@@ -773,17 +767,8 @@ body.theme-dark .top-menu button {
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 4rem;
+      font-size: 8rem;
       line-height: 1;
-    }
-
-    .navigation .nav-item button[data-type="location"] {
-      width: calc(5rem * var(--location-scale));
-      height: calc(5rem * var(--location-scale));
-    }
-
-    .navigation .nav-item button[data-type="location"] span.nav-icon {
-      font-size: calc(4rem * var(--location-scale));
     }
 
   .navigation .district-nav {


### PR DESCRIPTION
## Summary
- Marked North and South Gate navigation points as locations
- Removed erroneous connection between Little Terns and the Upper Ward
- Dropped location-specific scaling and set all navigation buttons to a 10rem default size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba20c1388c8325a3eb315daab87c7c