### PR TITLE
feat: add element proficiency wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Resource collection skills such as **Mining**, **Foraging**, **Logging**, **Herb
 ### Magical Proficiencies
 
 Characters now track separate proficiencies for Stone, Water, Wind, Fire, Ice, Thunder, Dark, Light, Destructive, Healing, Reinforcement, Enfeebling and Summoning. The `applySpellProficiencyGain` helper in `assets/data/spell_proficiency.js` calculates how these values increase when spells are cast. The spellbook requires a character to meet the proficiency threshold in both a spell's element and its school before it can be used.
+Elemental gains pass through a `gainElementProficiency` wrapper, enabling per-element tuning before calling the base `gainProficiency` utility.
 
 ### Weapon Skills
 

--- a/assets/data/spell_proficiency.js
+++ b/assets/data/spell_proficiency.js
@@ -14,6 +14,20 @@ export const elementalProficiencyMap = {
 
 export const ELEMENTAL_MAGIC_KEYS = Object.values(elementalProficiencyMap);
 
+const DEFAULT_ELEMENT_GAIN_FN = params => gainProficiency(params);
+export const ELEMENT_GAIN_FUNCTIONS = ELEMENTAL_MAGIC_KEYS.reduce(
+  (acc, key) => {
+    acc[key] = DEFAULT_ELEMENT_GAIN_FN;
+    return acc;
+  },
+  {}
+);
+
+export function gainElementProficiency(element, params) {
+  const fn = ELEMENT_GAIN_FUNCTIONS[element] || DEFAULT_ELEMENT_GAIN_FN;
+  return fn(params);
+}
+
 export const schoolProficiencyMap = {
   Destructive: "destructive",
   Healing: "healing",
@@ -33,7 +47,7 @@ export function applySpellProficiencyGain(character, spell, params) {
   if (!HYBRID_MAP[spell.element]) {
     const elemKey = elementalProficiencyMap[spell.element?.toLowerCase()];
     if (elemKey) {
-      character[elemKey] = gainProficiency({
+      character[elemKey] = gainElementProficiency(elemKey, {
         P: character[elemKey],
         ...params,
       });


### PR DESCRIPTION
## Summary
- add `gainElementProficiency` wrapper to allow element-specific tuning
- route elemental gains in `applySpellProficiencyGain` through the new wrapper
- document wrapper in README

## Testing
- `node --check assets/data/spell_proficiency.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68ba2428db448325b3be9e718601ba69