### PR TITLE
feat: add gather proficiency progression

### DIFF
--- a/assets/data/gathering_proficiency.js
+++ b/assets/data/gathering_proficiency.js
@@ -1,0 +1,37 @@
+import { gainProficiency } from "./proficiency_base.js";
+
+/**
+ * Increase a character's gathering proficiency.
+ *
+ * @param {Object} character - The acting character.
+ * @param {string} skillKey - Gathering skill key (e.g., 'mining', 'foraging').
+ * @param {Object} [opts]
+ * @param {boolean} [opts.success=true] - Whether the gathering attempt succeeded.
+ * @returns {number} Updated proficiency value.
+ */
+export function gainGatherProficiency(character, skillKey, opts = {}) {
+  const { success = true } = opts;
+  const current = character[skillKey] || 0;
+  const level = character.level || 1;
+  character[skillKey] = gainProficiency({
+    P: current,
+    L: level,
+    A0: 1,
+    A: 0,
+    r: 1,
+    success,
+  });
+  return character[skillKey];
+}
+
+/**
+ * Convenience helper to perform a gathering activity and apply progression.
+ *
+ * @param {Object} character - The acting character.
+ * @param {string} skillKey - Gathering skill key.
+ * @param {Object} [opts]
+ * @returns {number} New proficiency value.
+ */
+export function performGathering(character, skillKey, opts = {}) {
+  return gainGatherProficiency(character, skillKey, opts);
+}

--- a/script.js
+++ b/script.js
@@ -17,6 +17,7 @@ import {
   applySpellProficiencyGain,
 } from "./assets/data/spell_proficiency.js";
 import { trainCraftSkill } from "./assets/data/trainer_proficiency.js";
+import { performGathering } from "./assets/data/gathering_proficiency.js";
 
 function totalXpForLevel(level) {
   return Math.floor((4 * Math.pow(level, 3)) / 5);
@@ -1394,7 +1395,7 @@ function showNavigation() {
               );
               return;
             } else if (action === 'train-pearl-diving') {
-              const prof = trainCraftSkill(currentCharacter, 'pearlDiving');
+              const prof = performGathering(currentCharacter, 'pearlDiving');
               saveProfiles();
               showBackButton();
               setMainHTML(


### PR DESCRIPTION
## Summary
- add `gainGatherProficiency` for gathering skills
- update pearl-diving training to use gather progression

## Testing
- `node --version`
- `node --check assets/data/gathering_proficiency.js`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba28e99c9c8325b1e40f065f89de08