### PR TITLE
feat: add weapon proficiency progression

### DIFF
--- a/assets/data/party.ts
+++ b/assets/data/party.ts
@@ -12,7 +12,7 @@ export type Element = "Stone"|"Water"|"Wind"|"Fire"|"Ice"|"Thunder"|"Dark"|"Ligh
 export type ProficiencyKind =
   | "Element_Stone"|"Element_Water"|"Element_Wind"|"Element_Fire"
   | "Element_Ice"|"Element_Thunder"|"Element_Dark"|"Element_Light"
-  | "Weapon_Sword"|"Weapon_Axe"|"Weapon_Spear"|"Weapon_Dagger"|"Weapon_Mace"|"Weapon_Bow"|"Weapon_Staff"|"Weapon_Shield"|"Weapon_Wand"|"Weapon_Unarmed"
+  | "Weapon_Sword"|"Weapon_Greatsword"|"Weapon_Axe"|"Weapon_Greataxe"|"Weapon_Spear"|"Weapon_Dagger"|"Weapon_Mace"|"Weapon_Bow"|"Weapon_Crossbow"|"Weapon_Staff"|"Weapon_Shield"|"Weapon_Wand"|"Weapon_Unarmed"
   | "Instrument"|"Dance"|"Singing"
   | "Craft_Alchemy"|"Craft_Brewing"|"Craft_Carpentry"|"Craft_Weaving"|"Craft_Fletching"|"Craft_Rope"|"Craft_Calligraphy"|"Craft_Drawing"|"Craft_Cooking"
   | "Gather_Mining"|"Gather_Foraging"|"Gather_Logging"|"Gather_Herbalism"|"Gather_Gardening"|"Gather_Farming"|"Gather_PearlDiving"

--- a/assets/data/weapon_proficiency.ts
+++ b/assets/data/weapon_proficiency.ts
@@ -1,0 +1,78 @@
+// weapon_proficiency.ts — generic weapon proficiency progression
+
+import { gainProficiency, proficiencyCap, PROF_MILESTONES } from "./proficiency_base.js";
+import type { Member, ProficiencyKind } from "./party.ts";
+
+/** Options for gainWeaponProficiency */
+export interface WeaponProficiencyOpts {
+  /** Whether the weapon action succeeded (hit/kill). Defaults to true. */
+  success?: boolean;
+}
+
+/**
+ * Increase a member's weapon proficiency.
+ *
+ * The member must have a `proficiencies` map following the {@link ProfBlock}
+ * shape from {@link party.ts}. If the block for the given kind does not
+ * exist it will be initialised with default cap and thresholds.
+ */
+export function gainWeaponProficiency(
+  member: Member,
+  kind: ProficiencyKind,
+  opts: WeaponProficiencyOpts = {}
+): number {
+  const { success = true } = opts;
+
+  if (!member.proficiencies[kind]) {
+    member.proficiencies[kind] = {
+      value: 0,
+      cap: proficiencyCap(member.level),
+      thresholds: [...PROF_MILESTONES],
+    };
+  }
+
+  const block = member.proficiencies[kind]!;
+
+  // refresh cap for current level
+  block.cap = proficiencyCap(member.level);
+
+  block.value = gainProficiency({
+    P: block.value,
+    L: member.level,
+    A0: 1,
+    A: 0,
+    r: 1,
+    success,
+  });
+
+  return block.value;
+}
+
+// Convenience wrappers for specific weapons
+export const gainSwordProficiency = (m: Member, opts?: WeaponProficiencyOpts) =>
+  gainWeaponProficiency(m, "Weapon_Sword", opts);
+export const gainGreatswordProficiency = (m: Member, opts?: WeaponProficiencyOpts) =>
+  gainWeaponProficiency(m, "Weapon_Greatsword", opts);
+export const gainAxeProficiency = (m: Member, opts?: WeaponProficiencyOpts) =>
+  gainWeaponProficiency(m, "Weapon_Axe", opts);
+export const gainGreataxeProficiency = (m: Member, opts?: WeaponProficiencyOpts) =>
+  gainWeaponProficiency(m, "Weapon_Greataxe", opts);
+export const gainSpearProficiency = (m: Member, opts?: WeaponProficiencyOpts) =>
+  gainWeaponProficiency(m, "Weapon_Spear", opts);
+export const gainDaggerProficiency = (m: Member, opts?: WeaponProficiencyOpts) =>
+  gainWeaponProficiency(m, "Weapon_Dagger", opts);
+export const gainMaceProficiency = (m: Member, opts?: WeaponProficiencyOpts) =>
+  gainWeaponProficiency(m, "Weapon_Mace", opts);
+export const gainBowProficiency = (m: Member, opts?: WeaponProficiencyOpts) =>
+  gainWeaponProficiency(m, "Weapon_Bow", opts);
+export const gainCrossbowProficiency = (m: Member, opts?: WeaponProficiencyOpts) =>
+  gainWeaponProficiency(m, "Weapon_Crossbow", opts);
+export const gainStaffProficiency = (m: Member, opts?: WeaponProficiencyOpts) =>
+  gainWeaponProficiency(m, "Weapon_Staff", opts);
+export const gainShieldProficiency = (m: Member, opts?: WeaponProficiencyOpts) =>
+  gainWeaponProficiency(m, "Weapon_Shield", opts);
+export const gainWandProficiency = (m: Member, opts?: WeaponProficiencyOpts) =>
+  gainWeaponProficiency(m, "Weapon_Wand", opts);
+export const gainUnarmedProficiency = (m: Member, opts?: WeaponProficiencyOpts) =>
+  gainWeaponProficiency(m, "Weapon_Unarmed", opts);
+

--- a/assets/data/weapon_skills.js
+++ b/assets/data/weapon_skills.js
@@ -173,6 +173,23 @@ const WEAPON_DEFS = {
   }
 };
 
+// Mapping weapon names to their corresponding ProficiencyKind entries
+const WEAPON_PROFICIENCY_KIND = {
+  Sword: "Weapon_Sword",
+  Greatsword: "Weapon_Greatsword",
+  Dagger: "Weapon_Dagger",
+  Axe: "Weapon_Axe",
+  Greataxe: "Weapon_Greataxe",
+  Spear: "Weapon_Spear",
+  Bow: "Weapon_Bow",
+  Crossbow: "Weapon_Crossbow",
+  Mace: "Weapon_Mace",
+  Staff: "Weapon_Staff",
+  Shield: "Weapon_Shield",
+  Wand: "Weapon_Wand",
+  Unarmed: "Weapon_Unarmed",
+};
+
 /* --------------------------- Effect Builders --------------------------- */
 
 function buildDisableEffect(kind, target, basePower, extra = {}) {
@@ -268,6 +285,7 @@ function buildWeaponSkills(weaponName, def) {
     return {
       id: `${weaponName}:DMG:${tier}`,
       weapon: weaponName,
+      proficiencyKind: WEAPON_PROFICIENCY_KIND[weaponName],
       name,
       family: "damage",
       type: "Attack",
@@ -348,6 +366,7 @@ function buildWeaponSkills(weaponName, def) {
     return {
       id: `${weaponName}:SPC:${tier}`,
       weapon: weaponName,
+      proficiencyKind: WEAPON_PROFICIENCY_KIND[weaponName],
       name,
       family: "special",
       type,


### PR DESCRIPTION
## Summary
- add generic `gainWeaponProficiency` with per-weapon helpers
- link weapon skills to `ProficiencyKind` mappings
- extend `ProficiencyKind` for heavy and ranged weapons

## Testing
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68ba2aecde1883258aa0dc4547c7fd8a