### PR TITLE
Add spell school proficiencies

### DIFF
--- a/assets/data/party.ts
+++ b/assets/data/party.ts
@@ -12,6 +12,7 @@ export type Element = "Stone"|"Water"|"Wind"|"Fire"|"Ice"|"Thunder"|"Dark"|"Ligh
 export type ProficiencyKind =
   | "Element_Stone"|"Element_Water"|"Element_Wind"|"Element_Fire"
   | "Element_Ice"|"Element_Thunder"|"Element_Dark"|"Element_Light"
+  | "Destructive"|"Healing"|"Reinforcement"|"Enfeebling"|"Summoning"
   | "Weapon_Sword"|"Weapon_Axe"|"Weapon_Spear"|"Weapon_Dagger"|"Weapon_Mace"|"Weapon_Bow"|"Weapon_Staff"|"Weapon_Shield"|"Weapon_Wand"|"Weapon_Unarmed"
   | "Instrument"|"Dance"|"Singing"
   | "Craft_Alchemy"|"Craft_Brewing"|"Craft_Carpentry"|"Craft_Weaving"|"Craft_Fletching"|"Craft_Rope"|"Craft_Calligraphy"|"Craft_Drawing"|"Craft_Cooking"

--- a/assets/data/summoning_proficiency.ts
+++ b/assets/data/summoning_proficiency.ts
@@ -1,5 +1,8 @@
 // summoning_proficiency.ts — progression for Summoning based on effective use (TS/JS)
 
+// Key for accessing this proficiency on a member record
+export const SUMMONING_PROFICIENCY_KEY = "Summoning";
+
 /* ========================= Types ========================= */
 
 const r2 = (x: number) => Math.round(x * 100) / 100;


### PR DESCRIPTION
## Summary
- extend `ProficiencyKind` to cover Destructive, Healing, Reinforcement, Enfeebling, and Summoning spell schools
- expose `SUMMONING_PROFICIENCY_KEY` for accessing Summoning proficiency
- confirm spell proficiency helper maps include the new school keys

## Testing
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68ba2aff23d08325a18dd7bd9fd84591