### PR TITLE
Add swimming, sailing and riding proficiencies

### DIFF
--- a/assets/data/outdoor_skills.js
+++ b/assets/data/outdoor_skills.js
@@ -1,4 +1,5 @@
 // outdoor_skills.ts — activity based progression for swimming, sailing and horseback riding
+import { proficiencyCap } from "./proficiency_base.js";
 const r2 = (x) => Math.round(x * 100) / 100;
 function gainActivity(base, input) {
     const { P, cap, duration, difficulty = 1 } = input;
@@ -10,3 +11,19 @@ function gainActivity(base, input) {
 export const gainSwimming = (input) => gainActivity(0.06, input); // steady improvement through time in water
 export const gainSailing = (input) => gainActivity(0.05, input); // progress at the helm or managing sails
 export const gainRiding = (input) => gainActivity(0.055, input); // horseback riding progression
+
+export const OUTDOOR_GAIN_FUNCTIONS = {
+    swimming: gainSwimming,
+    sailing: gainSailing,
+    riding: gainRiding,
+};
+
+export function performOutdoorActivity(character, skillKey, opts) {
+    const fn = OUTDOOR_GAIN_FUNCTIONS[skillKey];
+    if (!fn)
+        return character[skillKey] || 0;
+    const current = character[skillKey] || 0;
+    const cap = proficiencyCap(character.level);
+    character[skillKey] = fn({ P: current, cap, ...opts });
+    return character[skillKey];
+}

--- a/assets/data/outdoor_skills.ts
+++ b/assets/data/outdoor_skills.ts
@@ -1,5 +1,7 @@
 // outdoor_skills.ts — activity based progression for swimming, sailing and horseback riding
 
+import { proficiencyCap } from "./proficiency_base.js";
+
 const r2 = (x: number) => Math.round(x * 100) / 100;
 
 export interface ActivityGainInput {
@@ -25,3 +27,27 @@ export const gainSailing = (input: ActivityGainInput): number =>
 
 export const gainRiding = (input: ActivityGainInput): number =>
   gainActivity(0.055, input); // horseback riding progression
+
+export const OUTDOOR_GAIN_FUNCTIONS = {
+  swimming: gainSwimming,
+  sailing: gainSailing,
+  riding: gainRiding,
+};
+
+export interface OutdoorActivityOpts {
+  duration: number;
+  difficulty?: number;
+}
+
+export function performOutdoorActivity(
+  character: { level: number; [k: string]: number },
+  skillKey: keyof typeof OUTDOOR_GAIN_FUNCTIONS,
+  opts: OutdoorActivityOpts
+): number {
+  const fn = OUTDOOR_GAIN_FUNCTIONS[skillKey];
+  if (!fn) return character[skillKey] || 0;
+  const current = character[skillKey] || 0;
+  const cap = proficiencyCap(character.level);
+  character[skillKey] = fn({ P: current, cap, ...opts });
+  return character[skillKey];
+}

--- a/assets/data/party.ts
+++ b/assets/data/party.ts
@@ -16,6 +16,7 @@ export type ProficiencyKind =
   | "Instrument"|"Dance"|"Singing"
   | "Craft_Alchemy"|"Craft_Brewing"|"Craft_Carpentry"|"Craft_Weaving"|"Craft_Fletching"|"Craft_Rope"|"Craft_Calligraphy"|"Craft_Drawing"|"Craft_Cooking"
   | "Gather_Mining"|"Gather_Foraging"|"Gather_Logging"|"Gather_Herbalism"|"Gather_Gardening"|"Gather_Farming"|"Gather_PearlDiving"
+  | "Swimming"|"Sailing"|"Riding"
   | "Evasion"|"Parry"|"Block";
 
 export interface ProfBlock {

--- a/script.js
+++ b/script.js
@@ -18,6 +18,7 @@ import {
 } from "./assets/data/spell_proficiency.js";
 import { trainCraftSkill } from "./assets/data/trainer_proficiency.js";
 import { performGathering } from "./assets/data/gathering_proficiency.js";
+import { performOutdoorActivity } from "./assets/data/outdoor_skills.js";
 
 function totalXpForLevel(level) {
   return Math.floor((4 * Math.pow(level, 3)) / 5);
@@ -990,6 +991,7 @@ const proficiencyCategories = {
     'dualWield'
   ],
   'Non Combat': ['singing', 'instrument', 'dancing'],
+  Outdoor: ['swimming', 'sailing', 'riding'],
   Crafting: [
     'alchemy',
     'brewing',


### PR DESCRIPTION
## Summary
- extend `ProficiencyKind` with Swimming, Sailing and Riding
- map outdoor skills to progression helpers and add a unified outdoor activity function
- expose outdoor skills and import helpers in UI

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68ba2af627ec832591bc53fbaf84be83