### PR TITLE
refactor: reorder district layout and reposition toggle

### DIFF
--- a/assets/data/city_nav.js
+++ b/assets/data/city_nav.js
@@ -228,16 +228,16 @@ export const CITY_NAV = {
         }
       },
     layout: {
-      rows: 3,
-      cols: 3,
+      rows: 4,
+      cols: 4,
       positions: {
-        "The Port District": [0, 0],
-        "The Upper Ward": [0, 1],
-        "Greensoul Hill": [0, 2],
-        "Little Terns": [1, 0],
-        "The High Road District": [1, 1],
-        "The Lower Gardens": [2, 0],
-        "The Farmlands": [2, 1],
+        "The Port District": [1, 0],
+        "Greensoul Hill": [0, 1],
+        "The Upper Ward": [1, 1],
+        "Little Terns": [2, 1],
+        "The Lower Gardens": [3, 1],
+        "The High Road District": [2, 2],
+        "The Farmlands": [2, 3],
       },
       connections: [
         ["The Port District", "The Upper Ward"],

--- a/script.js
+++ b/script.js
@@ -1269,7 +1269,7 @@ function showNavigation() {
       });
     };
     const groups = [];
-    if (exits.length) groups.push(exits.map(makeButton));
+    const exitGroup = exits.map(makeButton);
     const hasMultipleDistricts = Object.keys(cityData.districts).length > 1;
     const buildDistrictNav = () => {
       const layout = cityData.layout;
@@ -1324,18 +1324,22 @@ function showNavigation() {
       return [`<div class="district-nav">${neighborButtons.join('')}</div>`];
     };
     if (hasMultipleDistricts) {
-      groups.push([
-        createNavItem({
-          type: 'district-toggle',
-          action: 'toggle-districts',
-          name: 'Districts',
-          icon: getDistrictsEnvelope(pos.city),
-        }),
-      ]);
+      const districtToggle = createNavItem({
+        type: 'district-toggle',
+        action: 'toggle-districts',
+        name: 'Districts',
+        icon: getDistrictsEnvelope(pos.city),
+      });
+      if (exitGroup.length) {
+        exitGroup.unshift(districtToggle);
+      } else {
+        groups.push([districtToggle]);
+      }
       if (showDistricts) groups.push(buildDistrictNav());
     } else {
       groups.push(buildDistrictNav());
     }
+    if (exitGroup.length) groups.push(exitGroup);
     if (locals.length) groups.push(locals.map(makeButton));
     const buttons = [];
     groups.forEach(g => {


### PR DESCRIPTION
## Summary
- realign Wave's Break district map to show Port District left, stacked neighbors, and Farmlands east
- show district toggle inline with location buttons

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba2c0e9e44832581d78e88f460ed34