### PR TITLE
Increase district topology spacing to avoid overlap

### DIFF
--- a/script.js
+++ b/script.js
@@ -1278,7 +1278,8 @@ function showNavigation() {
         const accessible = new Set(districts.map(d => d.name).concat(pos.district));
         const fontSize =
           parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
-        const size = 5 * fontSize;
+        // Increase spacing so district nodes do not overlap and connection lines remain visible
+        const size = 12 * fontSize;
         const nodes = allNames.map(name => {
           const coords = layout.positions[name] || [0, 0];
           const [row, col] = coords;


### PR DESCRIPTION
## Summary
- enlarge district map grid size so nodes don't overlap and connections stay visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f6a8f2c83259376e5d129261efc