### PR TITLE
fix: space district topology icons

### DIFF
--- a/script.js
+++ b/script.js
@@ -1280,7 +1280,8 @@ function showNavigation() {
         const accessible = new Set(districts.map(d => d.name).concat(pos.district));
         const fontSize =
           parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
-        const size = 5 * fontSize;
+        // Each district icon button is 10rem square, so space nodes accordingly
+        const size = 10 * fontSize;
         const nodes = allNames.map(name => {
           const coords = layout.positions[name] || [0, 0];
           const [row, col] = coords;


### PR DESCRIPTION
## Summary
- prevent district topology icons from overlapping by matching map spacing to 10rem nav icon size

## Testing
- `node --check script.js`
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3fcafb808325a916eb53088343ea