### PR TITLE
Refine gathering and armor proficiency scaling

### DIFF
--- a/assets/data/gathering_proficiency.js
+++ b/assets/data/gathering_proficiency.js
@@ -1,4 +1,35 @@
-import { gainProficiency } from "./proficiency_base.js";
+import {
+  gainProficiency,
+  ATTR_GAIN_MIN,
+  ATTR_GAIN_MAX,
+  ATTR_GAIN_SLOPE,
+} from "./proficiency_base.js";
+
+// Mapping of gathering skills to their primary and secondary attributes.
+// Primary attribute contributes to the physical component of the task while
+// secondary represents endurance or knowledge.
+export const GATHERING_ATTRS = {
+  // Logging trees requires strength and overall vitality to keep swinging.
+  logging: { primary: "STR", secondary: "VIT" },
+  // Mining stone and ore relies on strength and constitution to endure.
+  mining: { primary: "STR", secondary: "CON" },
+  // Foraging or gathering herbs needs deft hands and knowledge to identify.
+  foraging: { primary: "DEX", secondary: "INT" },
+  // Farming large plots leans on endurance and learned technique.
+  farming: { primary: "VIT", secondary: "INT" },
+  // Gardening smaller plots – dexterity plus botanical understanding.
+  gardening: { primary: "DEX", secondary: "WIS" },
+};
+
+function attrFactor(attrs, key) {
+  const mapping = GATHERING_ATTRS[key];
+  if (!mapping) return 1;
+  const pri = attrs[mapping.primary] || 0;
+  const sec = attrs[mapping.secondary] || 0;
+  const avg = (pri + sec) / 2;
+  const f = ATTR_GAIN_MIN + ATTR_GAIN_SLOPE * avg;
+  return Math.min(ATTR_GAIN_MAX, Math.max(ATTR_GAIN_MIN, f));
+}
 
 /**
  * Increase a character's gathering proficiency.
@@ -13,12 +44,15 @@ export function gainGatherProficiency(character, skillKey, opts = {}) {
   const { success = true } = opts;
   const current = character[skillKey] || 0;
   const level = character.level || 1;
+  const attrs = character.attributes?.current || {};
+  const F_attr = attrFactor(attrs, skillKey);
   character[skillKey] = gainProficiency({
     P: current,
     L: level,
     A0: 1,
     A: 0,
     r: 1,
+    F_attr,
     success,
   });
   return character[skillKey];


### PR DESCRIPTION
## Summary
- add attribute-based scaling for logging, mining, foraging, farming, and gardening
- require majority of worn armor pieces to match type for proficiency gains

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba427be9b88325845cb930460dcf9e