### PR TITLE
feat: use backstory starting location

### DIFF
--- a/assets/data/core.js
+++ b/assets/data/core.js
@@ -113,7 +113,8 @@ export const characterTemplate = {
     tags: []
   },
   backstory: null,
-  spawnInfoShown: false
+  spawnInfoShown: false,
+  position: null
 };
 
 // ---- Combat / Utility Function Stubs ----


### PR DESCRIPTION
## Summary
- tie backstory to starting city position
- show backstory narrative instead of location description on first load
- record character position in template

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb055d22408325b45d0409785e9bdc