### PR TITLE
Dynamically tailor backstories to character details

### DIFF
--- a/assets/data/core.js
+++ b/assets/data/core.js
@@ -56,6 +56,7 @@ export const characterTemplate = {
   id: "",
   name: "",
   race: "",
+  sex: "",
   class: "",
   homeTown: "",
   location: "",

--- a/assets/data/waves_break_backstories.js
+++ b/assets/data/waves_break_backstories.js
@@ -2,7 +2,7 @@ export const WAVES_BREAK_BACKSTORIES = [
     {
         district: "The Port District",
         background: "Fishmonger's assistant",
-        past: "Daughter of seasoned sailors, grew up gutting and selling catch on Fishmongers' Row.",
+        past: "[Race] daughter of seasoned sailors, grew up gutting and selling catch on Fishmongers' Row.",
         items: ["scale-stained apron", "gutting knife"],
         money: "5 cp",
         skills: ["filleting", "haggling"],

--- a/assets/data/waves_break_backstories.ts
+++ b/assets/data/waves_break_backstories.ts
@@ -16,7 +16,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
   {
     district: "The Port District",
     background: "Fishmonger's assistant",
-    past: "Daughter of seasoned sailors, grew up gutting and selling catch on Fishmongers' Row.",
+    past: "[Race] daughter of seasoned sailors, grew up gutting and selling catch on Fishmongers' Row.",
     items: ["scale-stained apron", "gutting knife"],
     money: "5 cp",
     skills: ["filleting", "haggling"],

--- a/script.js
+++ b/script.js
@@ -56,6 +56,62 @@ const BACKSTORY_MAP = {
   "Wave's Break": WAVES_BREAK_BACKSTORIES,
 };
 
+function matchCase(word, pattern) {
+  if (pattern.toUpperCase() === pattern) return word.toUpperCase();
+  if (pattern[0].toUpperCase() === pattern[0]) return word[0].toUpperCase() + word.slice(1);
+  return word;
+}
+
+function swapGenderedTerms(text, sex) {
+  if (!text || !sex) return text;
+  if (sex === 'Male') {
+    text = text.replace(/\bdaughter\b/gi, m => matchCase('son', m));
+    text = text.replace(/\bgirl\b/gi, m => matchCase('boy', m));
+    text = text.replace(/\bmother\b/gi, m => matchCase('father', m));
+    text = text.replace(/\bsister\b/gi, m => matchCase('brother', m));
+    text = text.replace(/\bniece\b/gi, m => matchCase('nephew', m));
+    text = text.replace(/\baunt\b/gi, m => matchCase('uncle', m));
+    text = text.replace(/\bwomen\b/gi, m => matchCase('men', m));
+    text = text.replace(/\bwoman\b/gi, m => matchCase('man', m));
+    text = text.replace(/\bshe\b/gi, m => matchCase('he', m));
+    text = text.replace(/\bherself\b/gi, m => matchCase('himself', m));
+    text = text.replace(/\bher\b(?=\s+[a-z])/gi, m => matchCase('his', m));
+    text = text.replace(/\bher\b/gi, m => matchCase('him', m));
+  } else {
+    text = text.replace(/\bson\b/gi, m => matchCase('daughter', m));
+    text = text.replace(/\bboy\b/gi, m => matchCase('girl', m));
+    text = text.replace(/\bfather\b/gi, m => matchCase('mother', m));
+    text = text.replace(/\bbrother\b/gi, m => matchCase('sister', m));
+    text = text.replace(/\bnephew\b/gi, m => matchCase('niece', m));
+    text = text.replace(/\buncle\b/gi, m => matchCase('aunt', m));
+    text = text.replace(/\bmen\b/gi, m => matchCase('women', m));
+    text = text.replace(/\bman\b/gi, m => matchCase('woman', m));
+    text = text.replace(/\bhe\b/gi, m => matchCase('she', m));
+    text = text.replace(/\bhimself\b/gi, m => matchCase('herself', m));
+    text = text.replace(/\bhis\b(?=\s+[a-z])/gi, m => matchCase('her', m));
+    text = text.replace(/\bhis\b/gi, m => matchCase('hers', m));
+    text = text.replace(/\bhim\b/gi, m => matchCase('her', m));
+  }
+  return text;
+}
+
+function capitalize(str) {
+  return str ? str.charAt(0).toUpperCase() + str.slice(1) : '';
+}
+
+function replaceCharacterRefs(text, character) {
+  if (!text) return text;
+  let result = text;
+  if (character.race) {
+    result = result.replace(/\[Race\]/g, capitalize(character.race));
+    result = result.replace(/\[race\]/g, character.race.toLowerCase());
+  }
+  if (character.sex) {
+    result = swapGenderedTerms(result, character.sex);
+  }
+  return result;
+}
+
 function citySlug(name) {
   return CITY_SLUGS[name] || name.toLowerCase().replace(/'s/g, 's').replace(/[^a-z0-9]+/g, '_');
 }
@@ -2414,7 +2470,13 @@ function finalizeCharacter(character) {
   });
   const bs = BACKSTORY_MAP[character.location];
   if (bs && bs.length) {
-    newChar.backstory = bs[Math.floor(Math.random() * bs.length)];
+    const raw = bs[Math.floor(Math.random() * bs.length)];
+    newChar.backstory = {
+      ...raw,
+      background: replaceCharacterRefs(raw.background, newChar),
+      past: replaceCharacterRefs(raw.past, newChar),
+      narrative: replaceCharacterRefs(raw.narrative, newChar),
+    };
     const cityData = CITY_NAV[character.location];
     if (cityData) {
       const district = newChar.backstory.district;


### PR DESCRIPTION
## Summary
- store player's sex in character template for pronoun-aware backstories
- extend gendered term replacement to cover niece/nephew and aunt/uncle
- correct race placeholder replacements to preserve capitalization

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `node /tmp/gender_test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb069744c0832599dcdf7415ca29e4