### PR TITLE
Expand character backstory narratives

### DIFF
--- a/assets/data/coral_keep_backstories.ts
+++ b/assets/data/coral_keep_backstories.ts
@@ -10,7 +10,7 @@ export const CORAL_KEEP_BACKSTORIES: Backstory[] = [
     skills: ["inventory", "marching drills"],
     combat: "Spear proficiency 10 (beginner)",
     startingLocation: "Supply depot loft",
-    narrative: "You wake atop a stack of crates in the supply depot, morning horns echoing off the coral-white walls.",
+    narrative: "You wake atop a stack of crates in the supply depot loft as pre-dawn horns echo against the coral-white walls. Damp sea air drifts through the slats while you scoop up your ledger and stub of chalk beside a pouch of five coppers; quartermaster muster begins at first bell.",
   },
   {
     district: "The South Docks & Steel Docks",
@@ -21,7 +21,7 @@ export const CORAL_KEEP_BACKSTORIES: Backstory[] = [
     skills: ["free diving", "reef navigation"],
     combat: "Knife proficiency 10 (beginner)",
     startingLocation: "Steel Watch Naval Docks bunk",
-    narrative: "Salt spray stings your face as you rouse on a coil of rope beside the Steel Watch Docks.",
+    narrative: "Salt spray stings your face as you rouse on a coil of rope beside the Steel Watch Docks. The grey dawn promises calm seas while your diving knife and string of shells hang from your belt with two silvers in a pocket; you must catch the tide before the patrol ship departs.",
   },
   {
     district: "The Forge District",
@@ -33,7 +33,7 @@ export const CORAL_KEEP_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { glass: 10 },
     startingLocation: "Great Glassworks dormitory",
-    narrative: "You wake in the heat-hazed dormitory of the Great Glassworks, embers still glowing in the furnaces below.",
+    narrative: "Heat from the furnaces seeps into the Great Glassworks dormitory where you wake before sunrise. Embers glow below as you pull on leather gloves, take up your blowpipe, and pocket six coppers; the foreman rings the bell soon to begin shaping glass.",
   },
   {
     district: "The Old City",
@@ -44,7 +44,7 @@ export const CORAL_KEEP_BACKSTORIES: Backstory[] = [
     skills: ["busking", "pickpocketing"],
     combat: "Dagger proficiency 10 (beginner)",
     startingLocation: "Old Market Square stall",
-    narrative: "You blink awake beneath your stall in Old Market Square as merchants raise their awnings.",
+    narrative: "You blink awake beneath your stall in Old Market Square as merchants raise awnings in the cool dawn. Your lute and pouch of copper rings sit beside four coppers and threadbare clothes; crowds gather soon and you must tune before the square fills.",
   },
   {
     district: "The Northern Slums",
@@ -55,7 +55,7 @@ export const CORAL_KEEP_BACKSTORIES: Backstory[] = [
     skills: ["sneaking", "streetwise"],
     combat: "Club proficiency 10 (beginner)",
     startingLocation: "Thieves' Market shanty",
-    narrative: "You stir in a damp shanty behind the Thieves' Market, clutching the satchel you must deliver before dawn.",
+    narrative: "You stir in a damp shanty behind the Thieves' Market, clutching the hidden satchel that holds contraband and three coppers. A chill breeze slips through the boards while you pull on your cheap cloak; the contact expects the delivery before sunrise.",
   },
 ];
 

--- a/assets/data/corner_stone_backstories.ts
+++ b/assets/data/corner_stone_backstories.ts
@@ -11,7 +11,7 @@ export const CORNER_STONE_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { engraving: 15 },
     startingLocation: "Guild Palace workshop",
-    narrative: "You rub your eyes beside the mint's presses, yesterday's coin dies cooling on the bench.",
+    narrative: "You rub your eyes beside the mint's presses as a faint grey dawn filters through the high windows. Oil-slicked gears stand silent while your engraving chisel and wax tablet rest near a pouch holding one silver; the master engraver arrives at sunrise to review the dies.",
   },
   {
     district: "Misty Crossing",
@@ -22,7 +22,7 @@ export const CORNER_STONE_BACKSTORIES: Backstory[] = [
     skills: ["negotiation", "river navigation"],
     combat: "Untrained",
     startingLocation: "Great Stone Bridge dock",
-    narrative: "You wake on your barge tied beneath the Great Stone Bridge, river mist seeping into your clothes.",
+    narrative: "You wake on your barge tied beneath the Great Stone Bridge, river mist beading on your clothes in the early morning chill. Gripping your pole and tucking the ledger beside three silvers into a chest, you must shove off before first bell to catch the market rush.",
   },
   {
     district: "Cherry Rock",
@@ -34,7 +34,7 @@ export const CORNER_STONE_BACKSTORIES: Backstory[] = [
     combat: "Hammer proficiency 10 (beginner)",
     craftProficiencies: { smithing: 20 },
     startingLocation: "Mithril Hall forge",
-    narrative: "You wake to the glow of the Mithril Hall forge, your master's anvil already ringing.",
+    narrative: "You wake to the glow of the Mithril Hall forge, your dwarven master's anvil already ringing as dawn light seeps down the chimney. Tongs and a fragment of mithril lie on your workbench with seven coppers in your apron; the day's hammering begins at sunrise.",
   },
   {
     district: "Stonecrest Town",
@@ -46,7 +46,7 @@ export const CORNER_STONE_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { drawing: 15 },
     startingLocation: "Crystal Court Plaza",
-    narrative: "You stretch beside your easel in Crystal Court Plaza as early shoppers pause to watch.",
+    narrative: "You stretch beside your easel in Crystal Court Plaza while morning shoppers drift past under a clear sky. Charcoal sticks, a folded easel, and five coppers wait in your bag; you must sketch quickly to entice a patron before the plaza grows crowded.",
   },
   {
     district: "The Hill",
@@ -57,7 +57,7 @@ export const CORNER_STONE_BACKSTORIES: Backstory[] = [
     skills: ["guarding", "intimidation"],
     combat: "Sword proficiency 20 (novice)",
     startingLocation: "Caravanserai of the Hill bunk",
-    narrative: "You wake on a cot in the Hill's caravanserai, hand already seeking your sword belt.",
+    narrative: "You wake on a cot in the Hill's caravanserai, hand already seeking your short sword and travel cloak as dawn cools the stone hall. Eight coppers jingle in your belt pouch; the merchant train musters at sunrise and you rush to join your post.",
   },
 ];
 

--- a/assets/data/corona_backstories.ts
+++ b/assets/data/corona_backstories.ts
@@ -10,7 +10,7 @@ export const CORONA_BACKSTORIES: Backstory[] = [
     skills: ["swift running", "protocol"],
     combat: "Untrained",
     startingLocation: "Hall of Governance corridor",
-    narrative: "You jerk awake on a bench in the Hall of Governance, another scroll tucked beneath your arm.",
+    narrative: "You jerk awake on a bench in the Hall of Governance as first light glints off polished floors. Your satchel and signet token lie across your lap with five coppers in a pocket; the commanders expect their sealed notes delivered before the second bell.",
   },
   {
     district: "Brightshade",
@@ -22,7 +22,7 @@ export const CORONA_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { gardening: 15 },
     startingLocation: "Great Market stall",
-    narrative: "Sunlight filters through awnings as you arrange fresh greens on your Brightshade market stall.",
+    narrative: "Sunlight filters through awnings as you arrange fresh greens on your Brightshade market stall at the cool break of day. A hand rake rests against the cart, bundled produce and six coppers tucked in your apron; opening at six each morning has become routine.",
   },
   {
     district: "Greatwood Gate District",
@@ -34,7 +34,7 @@ export const CORONA_BACKSTORIES: Backstory[] = [
     combat: "Hammer proficiency 10 (beginner)",
     craftProficiencies: { smithing: 20 },
     startingLocation: "Smiths' Yard forge",
-    narrative: "You wake beside the warm coals of the Smiths' Yard forge, hammer still in your grip.",
+    narrative: "You wake beside the warm coals of the Smiths' Yard forge while a crisp dawn breeze slips under the door. Smith's hammer and bundle of nails lie ready with eight coppers in your belt; caravans arrive by midmorning expecting new hinges and spearheads.",
   },
   {
     district: "West Corona",
@@ -46,7 +46,7 @@ export const CORONA_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { glass: 10 },
     startingLocation: "Glasswrights' Guildhouse dormitory",
-    narrative: "You awaken in the Guildhouse dormitory, heat from the furnace seeping through the floorboards.",
+    narrative: "You awaken in the Guildhouse dormitory, furnace heat seeping through the floorboards as pale light filters through shutters. Your blowpipe and goggles hang nearby with four coppers in a pouch; the glassblowers begin work at sunrise and you hurry to join them.",
   },
   {
     district: "Western Slums",
@@ -57,7 +57,7 @@ export const CORONA_BACKSTORIES: Backstory[] = [
     skills: ["sneaking", "streetwise"],
     combat: "Knife proficiency 10 (beginner)",
     startingLocation: "Shanty Markets alley",
-    narrative: "You wake curled beneath a tarp in the Shanty Markets, the smell of cheap ale in the air.",
+    narrative: "You wake curled beneath a tarp in the Shanty Markets with a light drizzle tapping the canvas. Patched cloak and rusty knife are clutched close with two coppers hidden in a heel; the Rat's Tail Tavern runner expects you before the streets grow busy.",
   },
   {
     district: "The Wetlands Wall",
@@ -68,7 +68,7 @@ export const CORONA_BACKSTORIES: Backstory[] = [
     skills: ["tracking", "endurance"],
     combat: "Spear proficiency 30 (adept)",
     startingLocation: "Bastion Fort ramparts",
-    narrative: "You stand from your post on the Bastion Fort, dawn burning off the wetlands fog below.",
+    narrative: "You stand from your post on the Bastion Fort as dawn burns away the wetlands fog below. Long spear in hand and weathered cloak about your shoulders, one silver rests in your purse; the next patrol begins at seventh bell.",
   },
 ];
 

--- a/assets/data/creekside_backstories.ts
+++ b/assets/data/creekside_backstories.ts
@@ -10,7 +10,7 @@ export const CREEKSIDE_BACKSTORIES: Backstory[] = [
     skills: ["animal handling", "whistling"],
     combat: "Staff proficiency 10 (beginner)",
     startingLocation: "Cattle Yards corral",
-    narrative: "You wake leaning against a fence in the Cattle Yards, dawn fog drifting over lowing herds.",
+    narrative: "You wake leaning against a fence in the Cattle Yards while dawn fog drifts over the lowing herds. Your crook and leather satchel holding four coppers hang on the rail; the drive to market leaves at sunrise.",
   },
   {
     district: "Everrise Bridge",
@@ -21,7 +21,7 @@ export const CREEKSIDE_BACKSTORIES: Backstory[] = [
     skills: ["river navigation", "bartering"],
     combat: "Untrained",
     startingLocation: "Riverside Warehouses dock",
-    narrative: "You roll off a coiled rope on the docks as the Everrise Bridge glows in morning light.",
+    narrative: "You roll off a coiled rope on the docks as the Everrise Bridge glows in morning light. Pole and river charts are tucked beside a pouch of three silvers; you must ferry goods across before the first bell tolls.",
   },
   {
     district: "Stoneknot",
@@ -33,7 +33,7 @@ export const CREEKSIDE_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { writing: 10 },
     startingLocation: "Grand Guildhall archives",
-    narrative: "You blink away sleep amid stacks of parchment in the Guildhall archives.",
+    narrative: "You blink away sleep amid stacks of parchment in the Grand Guildhall archives, lantern smoke curling in the still air. An ink pot and quest ledger sit next to six coppers in your drawer; the clerk's desk opens at sunrise to post new contracts.",
   },
   {
     district: "Surrounding Farmlands & Orchards",
@@ -44,7 +44,7 @@ export const CREEKSIDE_BACKSTORIES: Backstory[] = [
     skills: ["harvesting", "climbing"],
     combat: "Sling proficiency 10 (beginner)",
     startingLocation: "Fruit orchard camp",
-    narrative: "You wake beneath a laden apple tree, basket already half-filled for market.",
+    narrative: "You wake beneath a laden apple tree, dew soaking your clothes as birds chirp in the dawn. Your fruit knife and woven basket lie nearby with five coppers tied in a cloth; the wagon to market departs at third bell.",
   },
 ];
 

--- a/assets/data/dancing_pines_backstories.ts
+++ b/assets/data/dancing_pines_backstories.ts
@@ -10,7 +10,7 @@ export const DANCING_PINES_BACKSTORIES: Backstory[] = [
     skills: ["timber cutting", "balance"],
     combat: "Axe proficiency 10 (beginner)",
     startingLocation: "Sawmill bunkhouse",
-    narrative: "You wake to the hum of waterwheels and scent of fresh-cut pine in the Sawmill bunkhouse.",
+    narrative: "You wake to the hum of waterwheels and scent of fresh-cut pine in the Sawmill bunkhouse just before dawn. Your earplugs and sawblade rest atop your bedroll with three coppers in a pouch; the mill whistle will sound soon to start the day's cutting.",
   },
   {
     district: "Diamond Mines",
@@ -21,7 +21,7 @@ export const DANCING_PINES_BACKSTORIES: Backstory[] = [
     skills: ["scouting", "stone sense"],
     combat: "Dagger proficiency 10 (beginner)",
     startingLocation: "Diamond Mine entrance",
-    narrative: "You shake off sleep at the mine mouth, chalk tucked behind your ear and lantern in hand.",
+    narrative: "You shake off sleep at the mine mouth, morning chill seeping through the rock as you spark your hooded lantern. Chalk line slips behind your ear and five coppers jingle in your pocket; miners wait for your signal before they descend.",
   },
   {
     district: "Hunter's Quarter",
@@ -33,7 +33,7 @@ export const DANCING_PINES_BACKSTORIES: Backstory[] = [
     combat: "Bow proficiency 10 (beginner)",
     craftProficiencies: { tanning: 10 },
     startingLocation: "Hunter's Lodge bunk",
-    narrative: "You rise from a cot in the Hunter's Lodge, the smell of smoked meat lingering in the air.",
+    narrative: "You rise from a cot in the Hunter's Lodge while the smell of smoked meat mingles with the crisp dawn air. Snare wire and a fur-lined cloak hang from a peg, four coppers tucked inside; you must set your lines before the sun climbs.",
   },
 ];
 

--- a/assets/data/dragons_reach_road_backstories.ts
+++ b/assets/data/dragons_reach_road_backstories.ts
@@ -10,7 +10,7 @@ export const DRAGONS_REACH_ROAD_BACKSTORIES: Backstory[] = [
     skills: ["reading", "rumor gathering"],
     combat: "Untrained",
     startingLocation: "Guild Post steps",
-    narrative: "You wake on the steps of the Guild Post as dawn caravans creak into the plaza.",
+    narrative: "You wake on the steps of the Guild Post as dawn caravans creak into the plaza, the chill air filled with hoofbeats. A bundle of nails and quest parchment lie in your lap with four coppers in a pouch; notices must be posted before the guild opens.",
   },
   {
     district: "The Lakeside Quarter",
@@ -21,7 +21,7 @@ export const DRAGONS_REACH_ROAD_BACKSTORIES: Backstory[] = [
     skills: ["fishing", "scavenging"],
     combat: "Spear proficiency 10 (beginner)",
     startingLocation: "Fishermen's Docks",
-    narrative: "You yawn beside your boat at the Fishermen's Docks, lake mist drifting over the water.",
+    narrative: "You yawn beside your boat at the Fishermen's Docks, lake mist drifting over the water in the early light. Net and scale pouch rest at your feet with three coppers tied in a cord; you must cast off before the sun burns away the fog.",
   },
   {
     district: "The Artisan's Lane",
@@ -33,7 +33,7 @@ export const DRAGONS_REACH_ROAD_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { cooking: 10 },
     startingLocation: "Exotic Fruit Press",
-    narrative: "You wake to sticky sweet aromas in your workshop along the Artisan's Lane.",
+    narrative: "You wake to sticky sweet aromas in your workshop along the Artisan's Lane as sunlight filters through slatted shutters. A wooden press and bottle of syrup sit on the table with two silvers locked in a drawer; a caravan arrives by midday for the next batch.",
   },
 ];
 

--- a/assets/data/mountain_top_backstories.ts
+++ b/assets/data/mountain_top_backstories.ts
@@ -10,7 +10,7 @@ export const MOUNTAIN_TOP_BACKSTORIES: Backstory[] = [
     skills: ["record keeping", "bargaining"],
     combat: "Untrained",
     startingLocation: "Merchant's Exchange stall",
-    narrative: "You wake at a table in the Merchant's Exchange, ink drying on last night's ledgers.",
+    narrative: "You wake at a table in the Merchant's Exchange, ink drying on last night's ledgers while dawn light spills through the plaza. Your quill and bundle of contracts are stacked beside a pouch of six coppers; merchants arrive at first bell for deals.",
   },
   {
     district: "Fortress Quarter",
@@ -21,7 +21,7 @@ export const MOUNTAIN_TOP_BACKSTORIES: Backstory[] = [
     skills: ["drill formation", "spotting"],
     combat: "Sword proficiency 10 (beginner)",
     startingLocation: "Barracks of the Iron Watch",
-    narrative: "You snap awake in the barracks as the morning bell calls recruits to muster.",
+    narrative: "You snap awake in the barracks as the morning bell calls recruits to muster. A dented helm and practice sword rest beside your bunk with two coppers in your boot; the drill yard awaits by sunrise.",
   },
   {
     district: "Terraces & Farms",
@@ -33,7 +33,7 @@ export const MOUNTAIN_TOP_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { gardening: 10 },
     startingLocation: "Tea Gardens shack",
-    narrative: "You wake on a straw mat beside the tea rows, mist beading on the leaves.",
+    narrative: "You wake on a straw mat beside the misty tea rows, dew beading on the leaves in the cool morning. Shears and a satchel of tea leaves sit within reach along with five coppers in a small pouch; the pickers must fill baskets before the sun dries the fields.",
   },
   {
     district: "Artisan's Row",
@@ -45,7 +45,7 @@ export const MOUNTAIN_TOP_BACKSTORIES: Backstory[] = [
     combat: "Dagger proficiency 10 (beginner)",
     craftProficiencies: { leatherwork: 15 },
     startingLocation: "Leatherwright's Hall workbench",
-    narrative: "You rub sleep from your eyes at the Leatherwright's Hall, yesterday's project still half-laced.",
+    narrative: "You rub sleep from your eyes at the Leatherwright's Hall as morning light slants across half-laced packs. Awl and spool of thread lie on the bench with seven coppers in a drawer; the master expects today's work finished by second bell.",
   },
 ];
 

--- a/assets/data/timber_grove_backstories.ts
+++ b/assets/data/timber_grove_backstories.ts
@@ -10,7 +10,7 @@ export const TIMBER_GROVE_BACKSTORIES: Backstory[] = [
     skills: ["log rolling", "river sense"],
     combat: "Axe proficiency 10 (beginner)",
     startingLocation: "Riverside log jam",
-    narrative: "You wake on a damp log by the Lumberworks, river mist curling around your peavey hook.",
+    narrative: "You wake on a damp log by the Lumberworks while river mist curls around your peavey hook. Waterlogged boots drip beside a pouch of three coppers; the jam must be cleared before the sun climbs.",
   },
   {
     district: "The Mine",
@@ -21,7 +21,7 @@ export const TIMBER_GROVE_BACKSTORIES: Backstory[] = [
     skills: ["mining", "stone appraisal"],
     combat: "Pick proficiency 10 (beginner)",
     startingLocation: "Mine entrance camp",
-    narrative: "The scent of earth greets you as you rise from your bedroll near the mine entrance.",
+    narrative: "The scent of earth greets you as you rise from your bedroll near the mine entrance, dawn chill nipping your nose. Pickaxe and glowstone shard fit into your pack with five coppers in a pocket; the tunneling crew assembles at first light.",
   },
   {
     district: "Fields & Orchards",
@@ -33,7 +33,7 @@ export const TIMBER_GROVE_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { cooking: 5 },
     startingLocation: "Orchard shed",
-    narrative: "You rouse in an orchard shed, sticky with sap and the buzz of waking insects.",
+    narrative: "You rouse in an orchard shed, sticky with sap as buzzing insects herald the warm morning. A drill and bucket of sap stand ready with two coppers in your belt; trees must be tapped before the day heats.",
   },
 ];
 

--- a/assets/data/warm_springs_backstories.ts
+++ b/assets/data/warm_springs_backstories.ts
@@ -11,7 +11,7 @@ export const WARM_SPRINGS_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { alchemy: 5 },
     startingLocation: "Terraced Hot Springs",
-    narrative: "Steam curls around you as you rise from your pallet beside the terraced pools.",
+    narrative: "Steam curls around you as you rise from your pallet beside the terraced pools at daybreak. A bundle of towels and a vial of spring water wait in a chest with four coppers in your sash; the first travelers arrive with sunrise.",
   },
   {
     district: "The Mines",
@@ -22,7 +22,7 @@ export const WARM_SPRINGS_BACKSTORIES: Backstory[] = [
     skills: ["tunneling", "endurance"],
     combat: "Pick proficiency 10 (beginner)",
     startingLocation: "Mine entrance barrack",
-    narrative: "You wake to the clatter of carts outside the mine barrack, lantern already sputtering.",
+    narrative: "You wake to the clatter of carts outside the mine barrack, lantern already sputtering in the pre-dawn gloom. Short pick hangs from a peg with three coppers in your pocket; the shift descends at first bell.",
   },
   {
     district: "Craft Halls",
@@ -34,7 +34,7 @@ export const WARM_SPRINGS_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { alchemy: 20 },
     startingLocation: "Alchemists' Hall bunk",
-    narrative: "You stir amid shelves of glass as morning light filters into the Alchemists' Hall.",
+    narrative: "You stir amid shelves of glass as morning light filters into the Alchemists' Hall. Mixing spoon and pouch of salts sit on your bunk beside two silver pieces; the master expects restorative salves brewed before noon.",
   },
 ];
 

--- a/assets/data/waves_break_backstories.ts
+++ b/assets/data/waves_break_backstories.ts
@@ -23,7 +23,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     combat: "Knife proficiency 10 (beginner)",
     craftProficiencies: { cooking: 10 },
     startingLocation: "Fishmongers' Row stall",
-    narrative: "You wake before dawn on a damp crate in Fishmongers' Row, gulls crying as the scent of brine clings to your skin.",
+    narrative: "You wake before dawn on a damp crate in Fishmongers' Row as gulls cry over the foggy harbor. Your scale-stained apron and gutting knife lie folded beside a pouch holding five coppers; the stall must be readied before the first boats dock.",
   },
   {
     district: "The Port District",
@@ -35,7 +35,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     combat: "No real experience",
     craftProficiencies: { rope: 20 },
     startingLocation: "Ropewalk loft",
-    narrative: "You stretch awake in the drafty loft above the Ropewalk, fingers already twitching to mend another net.",
+    narrative: "You stretch awake in the drafty loft above the Ropewalk while rain taps the long roof at daybreak. A bone needle and spool of twine lie at your side with two coppers in your pocket; the foreman expects nets mended by the six o'clock whistle.",
   },
   {
     district: "The Port District",
@@ -46,7 +46,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     skills: ["swimming", "sea songs"],
     combat: "Untrained",
     startingLocation: "Shrine of the Deep Current",
-    narrative: "You blink up at the carved ceiling of the Shrine of the Deep Current, priests murmuring nearby as you clutch your lone locket.",
+    narrative: "You blink up at the carved ceiling of the Shrine of the Deep Current, incense smoke drifting through the dawn stillness. Clutching the weathered locket—the only thing you own—you hear the distant surf and know the priests will send you out once prayers end.",
   },
   {
     district: "The Upper Ward",
@@ -58,7 +58,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     combat: "Rapier proficiency 10 (beginner)",
     craftProficiencies: { calligraphy: 10 },
     startingLocation: "Rented attic in the Upper Ward",
-    narrative: "You rouse in a cramped attic overlooking manicured streets, your tarnished signet ring the last token of a cast-off name.",
+    narrative: "You rouse in a cramped attic overlooking manicured streets as the sun climbs over the Upper Ward. Your tarnished signet ring and travel cloak sit atop a chest beside a lone silver coin; today you are due at the etiquette tutor's door by ninth bell to beg for work.",
   },
   {
     district: "The Upper Ward",
@@ -69,7 +69,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     skills: ["record keeping", "languages"],
     combat: "Beginner",
     startingLocation: "Hall of Records scriptorium",
-    narrative: "You wake slumped over a ledger in the Hall of Records, fingers stiff from a night of copying.",
+    narrative: "You wake slumped over a ledger in the Hall of Records, dawn light slanting through tall windows. Ink-stained gloves cling to your quill set and a single silver piece rests in your purse; the head scribe's bell for copying duty will ring within the hour.",
   },
   {
     district: "The Upper Ward",
@@ -80,7 +80,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     skills: ["spear drills", "watchfulness"],
     combat: "Spear proficiency 10 (beginner)",
     startingLocation: "Gatewatch Barracks bunk",
-    narrative: "You jerk awake on a straw pallet in the Gatewatch Barracks as the morning horn blares for drill.",
+    narrative: "You jerk awake on a straw pallet in the Gatewatch Barracks as the morning horn blares for drill. Your dented shield leans against the bunk, short spear across your knees, and three coppers jingle in your belt pouch as you scramble for muster.",
   },
   {
     district: "Little Terns",
@@ -91,7 +91,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     skills: ["climbing", "sneaking"],
     combat: "Dagger proficiency 10 (beginner)",
     startingLocation: "Rooftop hideout in Little Terns",
-    narrative: "You awaken on a rooftop hideout, city breeze ruffling your patched cloak as you clutch your worn dagger.",
+    narrative: "You awaken on a rooftop hideout, the city breeze ruffling your patched cloak while dawn paints the sky. A worn dagger rests under your hand with four copper coins in a tin; the alley gang expects you at first light to scout for treasure.",
   },
   {
     district: "Little Terns",
@@ -103,7 +103,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     combat: "Hammer proficiency 10 (beginner)",
     craftProficiencies: { carpentry: 10 },
     startingLocation: "Cooper's Yard shed",
-    narrative: "You rise among stacked staves in the Cooper's Yard shed, the scent of fresh tar and wood filling the air.",
+    narrative: "You rise among stacked staves in the Cooper's Yard shed as the morning fog curls over Little Terns. Hammer and barrel-hoop belt hang ready with six coppers tucked in your pocket; the bell will toll soon to start loading barrels.",
   },
   {
     district: "Little Terns",
@@ -114,7 +114,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     skills: ["teaching", "arithmetic"],
     combat: "Untrained",
     startingLocation: "Alleyway classroom",
-    narrative: "You wake on a bench in your improvised alley classroom, yesterday's sums still chalked across the stone wall.",
+    narrative: "You wake on a bench in your improvised alley classroom, yesterday's sums still chalked across the stone wall. Chalk and primer book sit beside your lone copper piece as the dawn chill creeps in; the children will arrive by sunrise for lessons.",
   },
   {
     district: "Greensoul Hill",
@@ -126,7 +126,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     combat: "Knife proficiency 10 (beginner)",
     craftProficiencies: { herbalism: 10, brewing: 10 },
     startingLocation: "Greensoul Hill herb clearing",
-    narrative: "You greet the sunrise in a dew-laden clearing on Greensoul Hill, satchel ready for the morning's harvest.",
+    narrative: "You greet the sunrise in a dew-laden clearing on Greensoul Hill, birdsong mingling with distant city bells. Your herb satchel and small knife lie ready with two coppers tucked inside; the apothecary expects fresh sprigs before the market opens.",
   },
   {
     district: "Greensoul Hill",
@@ -138,7 +138,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     combat: "Staff proficiency 10 (beginner)",
     craftProficiencies: { brewing: 10 },
     startingLocation: "Greensoul Monastery cell",
-    narrative: "You rise from a simple cot in Greensoul Monastery as bells toll the call to morning meditation.",
+    narrative: "You rise from a simple cot in Greensoul Monastery as bells toll the call to meditation. Prayer beads loop around your neck and a walking staff stands nearby; with no coin to your name you join the line for first light prayers.",
   },
   {
     district: "Greensoul Hill",
@@ -150,7 +150,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { drawing: 10 },
     startingLocation: "Monastery healing ward",
-    narrative: "You awake in the monastery's healing ward, the scorched pendant warm against your chest yet your past a void.",
+    narrative: "You awake in the monastery's healing ward, sunlight warming the shutters while the scent of herbs drifts in. The scorched pendant on your chest is your only belonging, and the monks will ask again at midday if any memories return.",
   },
   {
     district: "The Lower Gardens",
@@ -162,7 +162,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     combat: "Beginner",
     craftProficiencies: { brewing: 20 },
     startingLocation: "Tea stall by the Sunleaf Inn",
-    narrative: "You unroll the shutters of your tea stall beside the Sunleaf Inn, kettles quiet after yesterday's trade.",
+    narrative: "You unroll the shutters of your tea stall beside the Sunleaf Inn just as a golden dawn breaks over the Lower Gardens. Tea tins and ledger sit arranged on the counter and an eight-silver cache rests in a lockbox beneath; opening at six each morning has become routine.",
   },
   {
     district: "The Lower Gardens",
@@ -174,7 +174,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { alchemy: 20 },
     startingLocation: "Emberflask workshop cot",
-    narrative: "You wake amid clinking glass on a cot in the Emberflask workshop, fumes of last night's mixtures stinging your nose.",
+    narrative: "You wake amid clinking glass on a cot in the Emberflask workshop, fumes from last night's mixtures stinging your nose. A mixing kit and stained gloves lie beside a purse with three silvers; the master demands the morning tonic brewed before the third bell.",
   },
   {
     district: "The Lower Gardens",
@@ -186,7 +186,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     combat: "Beginner",
     craftProficiencies: { gardening: 10 },
     startingLocation: "Gardener's tool shed",
-    narrative: "You stretch within the gardeners' tool shed, dawn light spilling across beds awaiting your care.",
+    narrative: "You stretch within the gardeners' tool shed as dawn light spills across beds awaiting your care. Spade and straw hat lean against the wall with five coppers in a small tin box; the head gardener expects irrigation to begin by sunrise.",
   },
   {
     district: "The High Road District",
@@ -197,7 +197,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     skills: ["animal handling", "driving wagons"],
     combat: "Beginner",
     startingLocation: "Caravan staging yard wagon",
-    narrative: "You wake atop a wagon in the caravan yard, horses stamping nearby as travelers ready for the road.",
+    narrative: "You wake atop a wagon in the caravan yard, horses stamping nearby while a cool pre-dawn breeze carries dust. Sturdy gloves and a horse brush sit on the seat next to a pouch with seven copper coins; the caravan forms up at first light and you ready the reins.",
   },
   {
     district: "The High Road District",
@@ -208,7 +208,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     skills: ["appraisal", "negotiation"],
     combat: "Beginner",
     startingLocation: "Caravan Square stall",
-    narrative: "You flip open the awning of your Caravan Square stall, coins already jingling as merchants begin to haggle.",
+    narrative: "You flip open the awning of your Caravan Square stall as sunlight creeps over the High Road District. A merchant's ledger lies beside a locked box holding one silver and ten coppers; haggling begins at eighth bell so you arrange trinkets in neat rows.",
   },
   {
     district: "The High Road District",
@@ -219,7 +219,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     skills: ["sword drills", "gate protocols"],
     combat: "Sword proficiency 10 (beginner)",
     startingLocation: "East Gate watchtower",
-    narrative: "You wake at the east gate watchtower, dawn patrol handing you a steaming mug as you take your post.",
+    narrative: "You wake at the east gate watchtower, dawn patrol handing you a steaming mug while the sky pales. Iron cap and short sword rest on a rack with two coppers in your pouch; your watch begins at sunrise as travelers queue outside.",
   },
   {
     district: "The Farmlands",
@@ -231,7 +231,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { farming: 10 },
     startingLocation: "Family farmstead",
-    narrative: "You wake on your family's farmstead beyond the walls, morning chores calling before the city beckons.",
+    narrative: "You wake on your family's farmstead beyond the walls, rooster crows echoing through the misty fields. Hoe and seed pouch sit beside your single copper piece; morning chores must be finished before you can head toward the city.",
   },
   {
     district: "The Farmlands",
@@ -243,7 +243,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     combat: "Knife proficiency 10 (beginner)",
     craftProficiencies: { weaving: 10 },
     startingLocation: "Riverbank lean-to",
-    narrative: "You crawl from your riverbank lean-to, reeds swaying as the current whispers toward Wave's Break.",
+    narrative: "You crawl from your riverbank lean-to as reeds sway in the early breeze, the water whispering toward Wave's Break. A bundle of reeds and small knife are at hand with three coppers wrapped in cloth; the barge leaves at second bell so you hurry to harvest more.",
   },
   {
     district: "The Farmlands",
@@ -255,7 +255,7 @@ export const WAVES_BREAK_BACKSTORIES: Backstory[] = [
     combat: "Bow proficiency 10 (beginner)",
     craftProficiencies: { fletching: 10 },
     startingLocation: "Roadside camp near the city",
-    narrative: "You wake at a roadside camp with Wave's Break on the horizon, bow and pack ready for your first adventure.",
+    narrative: "You wake at a roadside camp with Wave's Break on the horizon, dawn light glinting off your short bow. A small pack lies open with two silver coins tucked inside; you plan to reach the Adventurers' Guild before midday for your first quest.",
   },
 ];
 

--- a/assets/data/whiteheart_backstories.ts
+++ b/assets/data/whiteheart_backstories.ts
@@ -10,7 +10,7 @@ export const WHITEHEART_BACKSTORIES: Backstory[] = [
     skills: ["tracking", "mapping"],
     combat: "Bow proficiency 10 (beginner)",
     startingLocation: "Barracks bunk",
-    narrative: "You wake on a narrow bunk in the Whiteheart barracks, gear already packed for patrol.",
+    narrative: "You wake on a narrow bunk in the Whiteheart barracks as dawn seeps through the shutters. Short bow and worn boots are already packed with three coppers in your pouch; patrol sets out at first light.",
   },
   {
     district: "Residences & Community",
@@ -22,7 +22,7 @@ export const WHITEHEART_BACKSTORIES: Backstory[] = [
     combat: "Untrained",
     craftProficiencies: { herbalism: 15 },
     startingLocation: "Forager's Lodge",
-    narrative: "You rise from the Forager's Lodge, the morning forest humming with unseen life.",
+    narrative: "You rise from the Forager's Lodge, the morning forest humming with unseen life. Foraging knife and basket hang by the door with two coppers tied in a cloth; the elders await you in the grove before sunrise.",
   },
 ];
 


### PR DESCRIPTION
## Summary
- Elaborated every character backstory with first-action scenes, surroundings, time or weather details, appointments, and belongings
- Added richer flavor text across all settlement backstory files

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bb0a5266a4832582cb0d90bbccc3e4