### PR TITLE
feat: add orphan backstory and currency overhaul

### DIFF
--- a/assets/data/core.js
+++ b/assets/data/core.js
@@ -1,6 +1,7 @@
 // Core game constants, enums, templates and helper functions
 
 import { createEmptyEquipment } from "./equipment.js";
+import { createEmptyCurrency } from "./currency.js";
 
 // ---- Cost & Scaling ----
 export function mpCost(tier) {
@@ -113,6 +114,7 @@ export const characterTemplate = {
     cooldowns: {},
     tags: []
   },
+  money: createEmptyCurrency(),
   buildings: [],
   employment: [],
   guildRank: 'None',

--- a/assets/data/currency.js
+++ b/assets/data/currency.js
@@ -1,16 +1,36 @@
-export const DENOMINATIONS = ['iron', 'copper', 'silver', 'gold', 'platinum', 'gem'];
+export const DENOMINATIONS = [
+  'coldIron',
+  'steel',
+  'copper',
+  'silver',
+  'gold',
+  'platinum',
+  'diamond'
+];
 
 export const CURRENCY_VALUES = {
-  iron: 1,
-  copper: 10,
-  silver: 10 * 25, // 250 iron
-  gold: 10 * 25 * 50, // 12,500 iron
-  platinum: 10 * 25 * 50 * 100, // 1,250,000 iron
-  gem: 10 * 25 * 50 * 100 * 100, // 125,000,000 iron
+  coldIron: 1,
+  steel: 10,
+  copper: 100,
+  silver: 1000,
+  gold: 10000,
+  platinum: 100000,
+  diamond: 1000000,
 };
 
-export function convertCurrency(amount, from, to) {
+const ABBR_MAP = {
+  ci: 'coldIron',
+  st: 'steel',
+  cp: 'copper',
+  sp: 'silver',
+  gp: 'gold',
+  pp: 'platinum',
+  d: 'diamond',
+};
+
+export function convertCurrency(amount, from, to, authorized = false) {
   if (!CURRENCY_VALUES[from] || !CURRENCY_VALUES[to]) return null;
+  if ((from === 'diamond' || to === 'diamond') && !authorized) return null;
   return (amount * CURRENCY_VALUES[from]) / CURRENCY_VALUES[to];
 }
 
@@ -34,4 +54,34 @@ export function fromIron(iron) {
     }
   }
   return result;
+}
+
+export function createEmptyCurrency() {
+  return Object.fromEntries(DENOMINATIONS.map(d => [d, 0]));
+}
+
+export function parseCurrency(str) {
+  const result = createEmptyCurrency();
+  if (!str || str.trim() === '0') return result;
+  const regex = /(\d+)\s*(ci|st|cp|sp|gp|pp|d)/gi;
+  let match;
+  while ((match = regex.exec(str))) {
+    const amount = parseInt(match[1], 10);
+    const denom = ABBR_MAP[match[2].toLowerCase()];
+    if (denom) result[denom] += amount;
+  }
+  return result;
+}
+
+export function formatCurrency(obj) {
+  const parts = [];
+  for (let i = DENOMINATIONS.length - 1; i >= 0; i--) {
+    const denom = DENOMINATIONS[i];
+    const val = obj[denom];
+    if (val) {
+      const name = denom.replace(/([A-Z])/g, ' $1').toLowerCase();
+      parts.push(`${val} ${name}`);
+    }
+  }
+  return parts.join(' ') || '0 cold iron';
 }

--- a/assets/data/waves_break_backstories.js
+++ b/assets/data/waves_break_backstories.js
@@ -1,5 +1,17 @@
 export const WAVES_BREAK_BACKSTORIES = [
     {
+        district: "The High Road District",
+        background: "Coming-of-age orphan",
+        past: "Raised without family, you scraped by on odd jobs around Wave's Break. Now, on your eighteenth birthday, you're ready to join the Adventurers' Guild.",
+        items: ["patched cloak", "worn boots"],
+        money: "20 st",
+        skills: ["labor", "streetwise"],
+        combat: "Untrained",
+        startingLocation: "Adventurers' Guildhall",
+        adventurersGuildRank: 'Cold Iron',
+        narrative: "You stand before the Adventurers' Guildhall on your eighteenth birthday, steel coins from years of toil clutched in hand, your old life behind you.",
+    },
+    {
         district: "The Port District",
         background: "Fishmonger's assistant",
         past: "[Race] daughter of seasoned sailors, grew up gutting and selling catch on Fishmongers' Row.",


### PR DESCRIPTION
## Summary
- add default coming-of-age orphan backstory
- overhaul currency system with rank-based coins and diamond restrictions
- track funds for characters and businesses

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2c94d0d88325a5cf2530ed0e0338