### PR TITLE
Refine character creation options

### DIFF
--- a/script.js
+++ b/script.js
@@ -2071,16 +2071,12 @@ function startCharacterCreation() {
       type: 'select',
       options: ['Male', 'Female']
     },
-    { key: 'accentColor', label: 'Choose your accent color', type: 'color', races: ['Cait Sith'] },
-    { key: 'scaleColor', label: 'Choose your scale color', type: 'color', races: ['Salamander'] },
     { key: 'characterImage', label: 'Choose your character', type: 'select' }
   ];
 
   const FIELD_STEP_LABELS = {
     race: 'Race',
     sex: 'Sex',
-    accentColor: 'Accents',
-    scaleColor: 'Scales',
     characterImage: 'Character'
   };
 
@@ -2140,9 +2136,8 @@ function startCharacterCreation() {
       if (field && field.key === 'location' && character.location) {
         const loc = LOCATIONS[character.location];
         if (!loc) return {};
-        const imageHTML = `<img class="race-image" src="${loc.map}" alt="${character.location}">`;
         const descHTML = `<div class="race-description">${loc.description || ''}</div>`;
-        return { imageHTML, descHTML };
+        return { descHTML };
       }
       if (field && field.key === 'backstory' && character.backstory) {
         const bs = BACKSTORY_MAP[character.location] || [];
@@ -2166,12 +2161,11 @@ function startCharacterCreation() {
         .map(([k, v]) => `<li>${k}: ${v}</li>`)
         .join('');
       const statsHTML = `<div class="race-stats"><ul>${attrList}</ul><ul>${resList}</ul></div>`;
-      const imageSrc = RACE_IMAGES[character.race];
-      const imageHTML = imageSrc ? `<img class="race-image" src="${imageSrc}" alt="${character.race}">` : '';
       const descHTML = `<div class="race-description">${RACE_DESCRIPTIONS[character.race] || ''}</div>`;
-      return { statsHTML, imageHTML, descHTML };
+      return { statsHTML, descHTML };
     })();
-    const { statsHTML = '', imageHTML = '', descHTML = '' } = displayData;
+    const { statsHTML = '', descHTML = '' } = displayData;
+    const statsSection = field && field.key === 'race' ? statsHTML : '';
 
     if (field) {
       let inputHTML = '';
@@ -2264,10 +2258,6 @@ function startCharacterCreation() {
           colors = eyeColorOptionsByRace[character.race] || humanEyeColors;
         } else if (field.key === 'skinColor') {
           colors = skinColorOptionsByRace[character.race] || humanSkinColors;
-        } else if (field.key === 'accentColor') {
-          colors = accentColorOptionsByRace[character.race] || [];
-        } else if (field.key === 'scaleColor') {
-          colors = scaleColorOptionsByRace[character.race] || [];
         }
         colors = colors.slice().sort();
         let value = character[field.key];
@@ -2287,7 +2277,7 @@ function startCharacterCreation() {
       }
 
       setMainHTML(
-        `<div class="character-creation"><div class="cc-top-row"><div class="progress-container">${progressHTML}</div><div class="cc-right"><div class="cc-options">${inputHTML}</div>${statsHTML}</div></div><div class="cc-info">${descHTML}${imageHTML}</div></div>`
+        `<div class="character-creation"><div class="cc-top-row"><div class="progress-container">${progressHTML}</div><div class="cc-right"><div class="cc-options">${inputHTML}</div>${statsSection}</div></div><div class="cc-info">${descHTML}</div></div>`
       );
       normalizeOptionButtonWidths();
 
@@ -2371,10 +2361,6 @@ function startCharacterCreation() {
           colors = eyeColorOptionsByRace[character.race] || humanEyeColors;
         } else if (field.key === 'skinColor') {
           colors = skinColorOptionsByRace[character.race] || humanSkinColors;
-        } else if (field.key === 'accentColor') {
-          colors = accentColorOptionsByRace[character.race] || [];
-        } else if (field.key === 'scaleColor') {
-          colors = scaleColorOptionsByRace[character.race] || [];
         }
         colors = colors.slice().sort();
         let index = colors.indexOf(character[field.key]);
@@ -2409,7 +2395,7 @@ function startCharacterCreation() {
         ] || [];
       const placeholderName = nameList[0] || 'Name';
       setMainHTML(
-        `<div class="character-creation"><div class="cc-top-row"><div class="progress-container">${progressHTML}</div><div class="cc-right"><div class="cc-options name-entry"><input type="text" id="name-input" value="${nameVal}" placeholder="${placeholderName}"><button id="name-random" class="dice-button" aria-label="Randomize Name">🎲</button></div>${statsHTML}</div></div><div class="cc-info">${descHTML}${imageHTML}</div></div>`
+        `<div class="character-creation"><div class="cc-top-row"><div class="progress-container">${progressHTML}</div><div class="cc-right"><div class="cc-options name-entry"><input type="text" id="name-input" value="${nameVal}" placeholder="${placeholderName}"><button id="name-random" class="dice-button" aria-label="Randomize Name">🎲</button></div>${statsSection}</div></div><div class="cc-info">${descHTML}</div></div>`
       );
       normalizeOptionButtonWidths();
       const nameInput = document.getElementById('name-input');

--- a/style.css
+++ b/style.css
@@ -877,7 +877,8 @@ body.theme-dark .top-menu button {
 
   .location-button,
   .race-button,
-  .sex-button {
+  .sex-button,
+  .backstory-button {
     position: relative;
     background: transparent;
     border: none;
@@ -890,7 +891,9 @@ body.theme-dark .top-menu button {
   .race-button::before,
   .race-button::after,
   .sex-button::before,
-  .sex-button::after {
+  .sex-button::after,
+  .backstory-button::before,
+  .backstory-button::after {
     content: '';
     position: absolute;
     left: 0;
@@ -901,19 +904,23 @@ body.theme-dark .top-menu button {
 
   .location-button::before,
   .race-button::before,
-  .sex-button::before {
+  .sex-button::before,
+  .backstory-button::before {
     top: 0;
   }
 
   .location-button::after,
   .race-button::after,
-  .sex-button::after {
+  .sex-button::after,
+  .backstory-button::after {
     bottom: 0;
   }
 
   .loc-arrow,
   .race-arrow,
   .sex-arrow,
+  .backstory-arrow,
+  .character-arrow,
   .color-arrow {
     background: transparent;
     border: none;
@@ -933,6 +940,8 @@ body.theme-dark .top-menu button {
   .loc-arrow:hover,
   .race-arrow:hover,
   .sex-arrow:hover,
+  .backstory-arrow:hover,
+  .character-arrow:hover,
   .color-arrow:hover {
     filter: drop-shadow(0 0 0.5rem currentColor);
   }


### PR DESCRIPTION
## Summary
- Disable Cait Sith and Salamander accent color pickers
- Show starting stats only during race selection
- Align backstory and character wheel selectors with existing style
- Remove redundant profile image preview from character creation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2dc4c0988325bb50a9342df795be