### PR TITLE
Remove action button from top menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,11 +21,6 @@
       <path d="M4 20c0-4 4-6 8-6s8 2 8 6" />
     </svg>
   </button>
-  <button id="action-button" aria-label="Actions" style="display:none;">
-    <svg viewBox="0 0 24 24">
-      <path d="M12 2l3 7h7l-5.5 4 2 7-6-4-6 4 2-7L2 9h7z" />
-    </svg>
-  </button>
   <button id="map-button" aria-label="Map" style="display:none;">
     <svg viewBox="0 0 24 24">
       <path d="M3 6l6-3 6 3 6-3v15l-6 3-6-3-6 3z" />
@@ -110,10 +105,6 @@
   </button>
   </div>
 
-<div id="actionMenu">
-  <button data-action="rest">Rest</button>
-  <button data-action="search">Search</button>
-</div>
 
 <main style="padding:1rem;"></main>
   </div>

--- a/script.js
+++ b/script.js
@@ -1584,7 +1584,6 @@ function showCharacter() {
   hideBackButton();
   updateCharacterButton();
   updateMapButton();
-  updateActionButton();
   showNavigation();
 }
 
@@ -1592,7 +1591,6 @@ function showNoCharacterUI() {
   hideBackButton();
   updateCharacterButton();
   updateMapButton();
-  updateActionButton();
   setMainHTML(`<div class="no-character"><h1>Start your journey...</h1><button id="new-character">New Character</button></div>`);
   document.getElementById('new-character').addEventListener('click', startCharacterCreation);
   updateMenuHeight();
@@ -2739,11 +2737,9 @@ layoutToggle.addEventListener('click', () => {
 // Dropdown menu
 const menuButton = document.getElementById('menu-button');
 const characterButton = document.getElementById('character-button');
-const actionButton = document.getElementById('action-button');
 const mapButton = document.getElementById('map-button');
 const dropdownMenu = document.getElementById('dropdownMenu');
 const characterMenu = document.getElementById('characterMenu');
-const actionMenu = document.getElementById('actionMenu');
 const mapContainer = document.createElement('div');
 mapContainer.id = 'map-container';
 body.appendChild(mapContainer);
@@ -2755,24 +2751,14 @@ function updateMapButton() {
   mapButton.style.display = currentCharacter ? 'inline-flex' : 'none';
   if (!currentCharacter) mapContainer.style.display = 'none';
 }
-function updateActionButton() {
-  actionButton.style.display = currentCharacter ? 'inline-flex' : 'none';
-}
 
 menuButton.addEventListener('click', () => {
   dropdownMenu.classList.toggle('active');
   characterMenu.classList.remove('active');
-  actionMenu.classList.remove('active');
 });
 characterButton.addEventListener('click', () => {
   dropdownMenu.classList.remove('active');
   characterMenu.classList.toggle('active');
-  actionMenu.classList.remove('active');
-});
-actionButton.addEventListener('click', () => {
-  dropdownMenu.classList.remove('active');
-  characterMenu.classList.remove('active');
-  actionMenu.classList.toggle('active');
 });
 mapButton.addEventListener('click', () => {
   if (!currentCharacter) return;
@@ -2780,7 +2766,6 @@ mapButton.addEventListener('click', () => {
     mapContainer.style.display = 'none';
     return;
   }
-  actionMenu.classList.remove('active');
   const locName = currentCharacter.location;
   const loc = LOCATIONS[locName] || LOCATIONS['Duvilia Kingdom'];
   mapContainer.innerHTML = `<img src="${loc.map}" alt="${loc.name}"><div class="map-description">${loc.description || ''}</div>`;
@@ -2823,18 +2808,9 @@ characterMenu.addEventListener('click', e => {
   }
 });
 
-actionMenu.addEventListener('click', e => {
-  const action = e.target.dataset.action;
-  if (!action) return;
-  actionMenu.classList.remove('active');
-  showBackButton();
-  setMainHTML(`<div class="no-character"><h1>${action} not implemented</h1></div>`);
-});
-
 backButton.addEventListener('click', () => {
   dropdownMenu.classList.remove('active');
   characterMenu.classList.remove('active');
-  actionMenu.classList.remove('active');
   showMainUI();
 });
 

--- a/style.css
+++ b/style.css
@@ -197,8 +197,7 @@ main {
 }
 
 
-#characterMenu,
-#actionMenu {
+#characterMenu {
   position: absolute;
   top: var(--menu-height);
   width: 14rem;
@@ -217,21 +216,13 @@ main {
   transform: translateX(-100%);
 }
 
-#actionMenu {
-  right: 0;
-  transform: translateX(100%);
-  box-shadow: -2px 0 4px rgba(0, 0, 0, 0.2);
-}
-
-#characterMenu.active,
-#actionMenu.active {
+#characterMenu.active {
   transform: translateX(0);
   pointer-events: auto;
   opacity: 1;
 }
 
-#characterMenu button,
-#actionMenu button {
+#characterMenu button {
   margin: 0;
   padding: 0.5rem 1rem;
   display: flex;
@@ -248,9 +239,7 @@ main {
 #dropdownMenu button:hover,
 #dropdownMenu button.selected,
 #characterMenu button:hover,
-#characterMenu button.selected,
-#actionMenu button:hover,
-#actionMenu button.selected {
+#characterMenu button.selected {
   background: var(--foreground);
   color: var(--background);
 }
@@ -261,8 +250,7 @@ button:not(:disabled):hover,
 }
 
 #dropdownMenu button:not(:last-child)::after,
-#characterMenu button:not(:last-child)::after,
-#actionMenu button:not(:last-child)::after {
+#characterMenu button:not(:last-child)::after {
   content: "";
   position: absolute;
   left: 0;
@@ -280,16 +268,13 @@ button:not(:disabled):hover,
 }
 
 #characterMenu button svg,
-#characterMenu .letter-icon,
-#actionMenu button svg,
-#actionMenu .letter-icon {
+#characterMenu .letter-icon {
   width: 1.5rem;
   height: 1.5rem;
   flex-shrink: 0;
 }
 
-#characterMenu .letter-icon,
-#actionMenu .letter-icon {
+#characterMenu .letter-icon {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -297,8 +282,7 @@ button:not(:disabled):hover,
   font-size: 1.2rem;
 }
 
-#characterMenu button svg,
-#actionMenu button svg {
+#characterMenu button svg {
   stroke: currentColor;
   fill: none;
   stroke-width: 2;
@@ -312,11 +296,6 @@ button:not(:disabled):hover,
   height: calc(100% - var(--menu-height));
 }
 
-#actionMenu {
-  top: var(--menu-height);
-  right: 0;
-  height: calc(100% - var(--menu-height));
-}
 
 .portrait-grid {
   display: flex;


### PR DESCRIPTION
## Summary
- Remove action button and its dropdown menu from the navigation bar
- Strip related CSS selectors for the old action menu
- Clean up JS to drop action button handling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5129e9cc83259cdd4fe4f7b0bb6a