### PR TITLE
Simplify spellbook layout with filter toggles

### DIFF
--- a/style.css
+++ b/style.css
@@ -1160,42 +1160,42 @@ body.theme-dark .top-menu button {
 
 /* Spellbook screen */
 .spellbook-screen {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.spellbook-list {
   max-width: 40rem;
-  margin: 0 auto;
 }
 
-.spellbook-screen h1 {
+.spellbook-list h1 {
   display: flex;
   align-items: center;
 }
 
-.spellbook-screen .global-sort {
-  margin-left: 0.5rem;
-}
-
-.spellbook-element {
-  margin-bottom: 1rem;
-}
-
-.spellbook-element h2 {
-  color: var(--background);
-  padding: 0.25rem;
+.spellbook-filters {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.filter-toggle {
+  background: none;
+  border: none;
   cursor: pointer;
+  font-size: 1.25rem;
 }
 
-.spellbook-element.collapsed .spellbook-content {
-  display: none;
+.filter-toggle.off {
+  filter: grayscale(1);
 }
-
-.element-title {
-  display: flex;
-  align-items: center;
-}
-
-
 .element-icon,
 .school-icon {
   display: inline-flex;
@@ -1205,38 +1205,10 @@ body.theme-dark .top-menu button {
   height: 1em;
   font-size: 1em;
   line-height: 1;
-  margin-right: 0.25rem;
-}
-
-.element-icon {
-  filter: brightness(0) saturate(100%) invert(1);
-}
-
-body.theme-dark .element-icon {
-  filter: brightness(0) saturate(100%);
-}
-
-.sort-button {
-  background: none;
-  border: none;
-  color: inherit;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  font-size: 1em;
-}
-
-.sort-buttons {
-  display: inline-flex;
-  gap: 0.25rem;
+  margin-left: 0.25rem;
 }
 
 
-
-.spell-subheading {
-  margin: 0.5rem 0 0.25rem;
-  font-weight: bold;
-}
 
 .spell-list {
   list-style: none;
@@ -1271,30 +1243,6 @@ body.theme-dark .element-icon {
   height: 1em;
 }
 
-.type-icon,
-.prof-icon {
-  display: inline-flex;
-  align-items: center;
-}
-
-.type-icon svg,
-.prof-icon svg {
-  width: 1em;
-  height: 1em;
-  fill: none;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke: currentColor;
-}
-
-.type-icon .cw {
-  stroke: #3c8;
-}
-
-.type-icon .ccw {
-  stroke: #c83;
-}
 
 .icon.enfeeble .arrow {
   color: red;
@@ -1381,6 +1329,8 @@ body.theme-dark .element-icon {
   font-weight: bold;
   cursor: pointer;
   padding: 0;
+  display: inline-flex;
+  align-items: center;
 }
 
 .spell-detail-modal {


### PR DESCRIPTION
## Summary
- Remove sorting controls and element sections in spellbook
- List spells by unlock then element with inline element and school icons
- Add sidebar filter toggles for elements and magic schools

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68bb5362c41483258c6a709d87fca394