### PR TITLE
Show city map in popup overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,13 +21,6 @@
       <path d="M4 20c0-4 4-6 8-6s8 2 8 6" />
     </svg>
   </button>
-  <button id="map-button" aria-label="Map" style="display:none;">
-    <svg viewBox="0 0 24 24">
-      <path d="M3 6l6-3 6 3 6-3v15l-6 3-6-3-6 3z" />
-      <path d="M9 3v15" />
-      <path d="M15 6v15" />
-    </svg>
-  </button>
   <div class="settings-group">
     <button id="settings-button" aria-label="Settings">
       <svg viewBox="0 0 24 24">

--- a/script.js
+++ b/script.js
@@ -198,6 +198,11 @@ updateMenuHeight();
 
 function setMainHTML(html) {
   if (main) main.innerHTML = html;
+  if (typeof mapContainer !== "undefined") mapContainer.style.display = "none";
+  if (typeof mapToggleButton !== "undefined" && mapToggleButton) {
+    mapToggleButton.classList.remove("map-toggle-floating");
+    mapToggleButton = null;
+  }
 }
 
 function isPortraitLayout() {
@@ -1485,7 +1490,7 @@ function showNavigation() {
           showNavigation();
           return;
         } else if (action === 'toggle-city-map') {
-          mapButton.click();
+          toggleCityMap(btn);
           return;
         }
         const type = btn.dataset.type;
@@ -1591,14 +1596,12 @@ function showCharacter() {
   if (!currentCharacter) return;
   hideBackButton();
   updateCharacterButton();
-  updateMapButton();
   showNavigation();
 }
 
 function showNoCharacterUI() {
   hideBackButton();
   updateCharacterButton();
-  updateMapButton();
   setMainHTML(`<div class="no-character"><h1>Start your journey...</h1><button id="new-character">New Character</button></div>`);
   document.getElementById('new-character').addEventListener('click', startCharacterCreation);
   updateMenuHeight();
@@ -1606,7 +1609,6 @@ function showNoCharacterUI() {
 
 function showCharacterSelectUI() {
   showBackButton();
-  updateMapButton();
   const characters = currentProfile?.characters || {};
   const ids = Object.keys(characters);
   let html = '<div class="no-character"><h1>Select Character</h1><div class="option-grid">';
@@ -2026,7 +2028,6 @@ function showEquipmentUI() {
 function startCharacterCreation() {
   updateScale();
   showBackButton();
-  mapButton.style.display = 'none';
   mapContainer.style.display = 'none';
   const saved = JSON.parse(localStorage.getItem(TEMP_CHARACTER_KEY) || '{}');
   const character = saved.character || {};
@@ -2704,18 +2705,33 @@ layoutToggle.addEventListener('click', () => {
 // Dropdown menu
 const menuButton = document.getElementById('menu-button');
 const characterButton = document.getElementById('character-button');
-const mapButton = document.getElementById('map-button');
 const dropdownMenu = document.getElementById('dropdownMenu');
 const characterMenu = document.getElementById('characterMenu');
 const mapContainer = document.createElement('div');
 mapContainer.id = 'map-container';
 body.appendChild(mapContainer);
+let mapToggleButton = null;
+function toggleCityMap(btn) {
+  if (!currentCharacter) return;
+  if (mapContainer.style.display === 'flex') {
+    mapContainer.style.display = 'none';
+    if (mapToggleButton) {
+      mapToggleButton.classList.remove('map-toggle-floating');
+      mapToggleButton = null;
+    }
+    return;
+  }
+  const locName = currentCharacter.location;
+  const loc = LOCATIONS[locName] || LOCATIONS['Duvilia Kingdom'];
+  mapContainer.innerHTML = `<img src="${loc.map}" alt="${loc.name}"><div class="map-description">${loc.description || ''}</div>`;
+  mapContainer.style.display = 'flex';
+  mapToggleButton = btn;
+  mapToggleButton.classList.add('map-toggle-floating');
+}
+
 
 function updateCharacterButton() {
   characterButton.style.display = currentCharacter ? 'inline-flex' : 'none';
-}
-function updateMapButton() {
-  mapButton.style.display = currentCharacter ? 'inline-flex' : 'none';
   if (!currentCharacter) mapContainer.style.display = 'none';
 }
 
@@ -2726,17 +2742,6 @@ menuButton.addEventListener('click', () => {
 characterButton.addEventListener('click', () => {
   dropdownMenu.classList.remove('active');
   characterMenu.classList.toggle('active');
-});
-mapButton.addEventListener('click', () => {
-  if (!currentCharacter) return;
-  if (mapContainer.style.display === 'flex') {
-    mapContainer.style.display = 'none';
-    return;
-  }
-  const locName = currentCharacter.location;
-  const loc = LOCATIONS[locName] || LOCATIONS['Duvilia Kingdom'];
-  mapContainer.innerHTML = `<img src="${loc.map}" alt="${loc.name}"><div class="map-description">${loc.description || ''}</div>`;
-  mapContainer.style.display = 'flex';
 });
 
 dropdownMenu.addEventListener('click', e => {

--- a/style.css
+++ b/style.css
@@ -1170,6 +1170,13 @@ body.theme-dark .top-menu button {
   text-align: center;
 }
 
+.map-toggle-floating {
+  position: fixed;
+  top: calc(var(--menu-height) + 0.5rem);
+  right: 0.5rem;
+  z-index: 275;
+}
+
 /* Spellbook screen */
 .spellbook-screen {
   display: flex;


### PR DESCRIPTION
## Summary
- Display city map in a popup overlay that can be toggled on/off
- Keep the city map button visible over the map for easy dismissal
- Remove obsolete map button from the top menu

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdb107858c832595da0fd460bd97e2