### PR TITLE
Ensure city navigation button overlays city map

### DIFF
--- a/script.js
+++ b/script.js
@@ -2719,7 +2719,7 @@ const dropdownMenu = document.getElementById('dropdownMenu');
 const characterMenu = document.getElementById('characterMenu');
 const mapContainer = document.createElement('div');
 mapContainer.id = 'map-container';
-body.appendChild(mapContainer);
+app.appendChild(mapContainer);
 let mapToggleButton = null;
 function toggleCityMap(btn) {
   if (!currentCharacter) return;


### PR DESCRIPTION
## Summary
- Attach the city map container to the app root so the map toggle floats above the map and background

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68be344d21788325b5f3e2f608c10c76