### PR TITLE
Display location description between navigation groups and align map button

### DIFF
--- a/script.js
+++ b/script.js
@@ -1443,20 +1443,24 @@ function showNavigation() {
       if (districtNav.length) groups.push(districtNav);
     }
     if (exitGroup.length) groups.push(exitGroup);
-    if (locals.length) groups.push(locals.map(makeButton));
-    const buttons = [];
+    const navButtons = [];
     groups.forEach(g => {
       if (g.length) {
-        if (buttons.length) buttons.push('<div class="group-separator"></div>');
-        buttons.push(...g);
+        if (navButtons.length) navButtons.push('<div class="group-separator"></div>');
+        navButtons.push(...g);
       }
     });
     const description = pos.previousDistrict && district.descriptions
       ? district.descriptions[pos.previousDistrict]
       : null;
-    const heading = description || pos.district;
+    const localsHTML = locals.length
+      ? `<div class="option-grid">${locals.map(makeButton).join('')}</div>`
+      : '';
+    const descHTML = description
+      ? `<p class="location-description">${description}</p>`
+      : '';
     setMainHTML(
-      `<div class="navigation"><h2>${heading}</h2><div class="option-grid">${buttons.join('')}</div></div>`
+      `<div class="navigation"><h2>${pos.district}</h2><div class="option-grid">${navButtons.join('')}</div>${descHTML}${localsHTML}</div>`
     );
   }
   normalizeOptionButtonWidths();

--- a/style.css
+++ b/style.css
@@ -713,6 +713,11 @@ body.theme-dark .top-menu button {
     text-align: center;
   }
 
+  .location-description {
+    margin: 0.5rem 0;
+    text-align: center;
+  }
+
   .business-hours {
     margin: 0 0 0.5rem 0;
     text-align: center;
@@ -1157,7 +1162,7 @@ body.theme-dark .top-menu button {
 .map-toggle-floating {
   position: fixed;
   top: calc(var(--menu-height) + 0.5rem);
-  right: 0.5rem;
+  left: 0.5rem;
   z-index: 275;
 }
 


### PR DESCRIPTION
## Summary
- Reposition city map toggle button to left when the map is displayed
- Insert current location description between city/district controls and building buttons
- Add styling for location descriptions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bef12eaa7c8325aa87b3e172c82cca