### PR TITLE
Add hunting proficiency and progression function

### DIFF
--- a/assets/data/hunting_proficiency.js
+++ b/assets/data/hunting_proficiency.js
@@ -1,0 +1,44 @@
+import { gainProficiency } from "./proficiency_base.js";
+
+function levelFactor(charLevel, huntLevel) {
+  const diff = Math.abs((huntLevel ?? charLevel) - charLevel);
+  return 1 / (1 + diff);
+}
+
+/**
+ * Increase a character's hunting proficiency.
+ *
+ * @param {Object} character - The acting character.
+ * @param {number} huntLevel - Difficulty or monster level of the hunt.
+ * @param {Object} [opts]
+ * @param {boolean} [opts.success=true] - Whether the hunt succeeded.
+ * @returns {number} Updated proficiency value.
+ */
+export function gainHuntingProficiency(character, huntLevel, opts = {}) {
+  const { success = true } = opts;
+  const current = character.hunting || 0;
+  const level = character.level || 1;
+  const F_level = levelFactor(level, huntLevel);
+  character.hunting = gainProficiency({
+    P: current,
+    L: level,
+    A0: 1,
+    A: 0,
+    r: 1,
+    F_level,
+    success,
+  });
+  return character.hunting;
+}
+
+/**
+ * Convenience helper to apply hunting progression after a hunt.
+ *
+ * @param {Object} character
+ * @param {number} huntLevel
+ * @param {Object} [opts]
+ * @returns {number} New proficiency value.
+ */
+export function performHunt(character, huntLevel, opts = {}) {
+  return gainHuntingProficiency(character, huntLevel, opts);
+}

--- a/script.js
+++ b/script.js
@@ -29,6 +29,7 @@ import {
 import { trainCraftSkill } from "./assets/data/trainer_proficiency.js";
 import { performGathering } from "./assets/data/gathering_proficiency.js";
 import { performOutdoorActivity } from "./assets/data/outdoor_skills.js";
+import { performHunt } from "./assets/data/hunting_proficiency.js";
 import {
   ADVENTURERS_GUILD_RANKS,
   determineOwnership,
@@ -55,6 +56,7 @@ window.parseCurrency = parseCurrency;
 window.formatCurrency = formatCurrency;
 window.LOCATIONS = LOCATIONS;
 window.ADVENTURERS_GUILD_RANKS = ADVENTURERS_GUILD_RANKS;
+window.performHunt = performHunt;
 
 const NAV_ICONS = {
   location: '🗺️',
@@ -955,6 +957,7 @@ const defaultProficiencies = {
   weaving: 0,
   fletching: 0,
   glassblowing: 0,
+  hunting: 0,
   pearlDiving: 0
 };
 
@@ -1095,7 +1098,7 @@ const proficiencyCategories = {
     'dualWield'
   ],
   'Non Combat': ['singing', 'instrument', 'dancing'],
-  Outdoor: ['swimming', 'sailing', 'riding'],
+  Outdoor: ['swimming', 'sailing', 'riding', 'hunting'],
   Crafting: [
     'alchemy',
     'brewing',


### PR DESCRIPTION
## Summary
- introduce hunting proficiency with level-based diminishing returns
- expose `performHunt` helper for applying progression
- list hunting proficiency in character defaults and UI categories

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68bf5ba44b488325969833c0ebcc6572