### PR TITLE
feat: enlarge character portrait with zoom controls

### DIFF
--- a/script.js
+++ b/script.js
@@ -1694,7 +1694,13 @@ function showCharacterUI() {
       <h1>${c.name}</h1>
       <div class="profile-grid">
         <div class="portrait-section">
-          <div class="portrait-wrapper">${portrait}</div>
+          <div class="portrait-wrapper">${portrait}
+            <div class="portrait-zoom">
+              <button id="portrait-zoom-dec" class="portrait-zoom-dec" aria-label="Zoom out">-</button>
+              <button id="portrait-zoom-reset" class="portrait-zoom-reset" aria-label="Reset zoom">100%</button>
+              <button id="portrait-zoom-inc" class="portrait-zoom-inc" aria-label="Zoom in">+</button>
+            </div>
+          </div>
         </div>
         <div>
           ${info}
@@ -1705,6 +1711,34 @@ function showCharacterUI() {
       </div>
       <button id="delete-character">Delete Character</button>
     </div>`);
+
+  const portraitImg = document.querySelector('.profile-portrait');
+  const zoomDec = document.getElementById('portrait-zoom-dec');
+  const zoomInc = document.getElementById('portrait-zoom-inc');
+  const zoomReset = document.getElementById('portrait-zoom-reset');
+  let portraitZoom = 1;
+
+  function updatePortraitZoom() {
+    portraitImg.style.transform = `scale(${portraitZoom})`;
+    zoomReset.textContent = `${Math.round(portraitZoom * 100)}%`;
+  }
+
+  zoomDec.addEventListener('click', () => {
+    portraitZoom = Math.max(0.1, portraitZoom - 0.1);
+    updatePortraitZoom();
+  });
+
+  zoomInc.addEventListener('click', () => {
+    portraitZoom += 0.1;
+    updatePortraitZoom();
+  });
+
+  zoomReset.addEventListener('click', () => {
+    portraitZoom = 1;
+    updatePortraitZoom();
+  });
+
+  updatePortraitZoom();
   document.getElementById('delete-character').addEventListener('click', () => {
     delete currentProfile.characters[c.id];
     currentProfile.lastCharacter = null;

--- a/style.css
+++ b/style.css
@@ -323,11 +323,12 @@ button:not(:disabled):hover,
 }
 
 .profile-portrait {
-  max-width: 10rem;
-  max-height: 10rem;
+  max-width: 20rem;
+  max-height: 20rem;
   width: auto;
   height: auto;
   object-fit: contain;
+  transform-origin: center;
 }
 
 .no-character {
@@ -428,9 +429,40 @@ body.theme-dark .top-menu button {
 
   .portrait-wrapper {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: center;
     gap: 0.5rem;
+  }
+
+  .portrait-zoom {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .portrait-zoom button {
+    width: 3rem;
+    height: 3rem;
+    background: transparent;
+    border: 2px solid var(--foreground);
+    color: var(--foreground);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 1rem;
+  }
+
+  .portrait-zoom button:hover {
+    filter: drop-shadow(0 0 0.5rem var(--foreground));
+  }
+
+  .portrait-zoom-dec,
+  .portrait-zoom-inc {
+    border-radius: 50%;
+  }
+
+  .portrait-zoom-reset {
+    border-radius: 0.25rem;
   }
 
   
@@ -937,7 +969,7 @@ body.theme-dark .top-menu button {
   }
 
   .character-carousel img {
-    max-width: 8rem;
+    max-width: 16rem;
     height: auto;
   }
 


### PR DESCRIPTION
## Summary
- double default character portrait and selection image sizes
- add dedicated -/100%/+ zoom controls for the portrait with glow outlines

## Testing
- `node --check script.js`
- `npx -y tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bf6675f8e483258b78982f32252bfb