### PR TITLE
Refine navigation text display

### DIFF
--- a/script.js
+++ b/script.js
@@ -143,6 +143,16 @@ function getDistrictIcon(city, district) {
   return `assets/images/icons/${citySlug(city)}/${districtFileName(district)}`;
 }
 
+function getBuildingIcon(city, district, building) {
+  const cityData = CITY_NAV[city];
+  const districtData = cityData && cityData.districts[district];
+  if (!districtData) return "";
+  const point = districtData.points.find(
+    pt => pt.type === 'building' && (pt.target === building || pt.name === building)
+  );
+  return point && point.icon ? point.icon : "";
+}
+
 function getDistrictsEnvelope(city) {
   return `assets/images/icons/${citySlug(city)}/Districts Envelope.png`;
 }
@@ -1328,8 +1338,11 @@ function showNavigation() {
         ? 'Open 24 hours'
         : `Open ${hours.open}–${hours.close}`
       : '';
+    const bIcon = getBuildingIcon(pos.city, pos.district, pos.building);
+    const dIcon = getDistrictIcon(pos.city, pos.district);
+    const headerHTML = `<div class="nav-header">${bIcon ? `<img src="${bIcon}" alt="" class="nav-icon">` : ''}<img src="${dIcon}" alt="" class="nav-icon"></div>`;
     setMainHTML(
-      `<div class="navigation"><h2>${pos.building}</h2>${descriptionHTML}${hoursText ? `<p class="business-hours">${hoursText}</p>` : ''}<div class="option-grid">${buttons.join('')}</div></div>`
+      `<div class="navigation">${headerHTML}${descriptionHTML}${hoursText ? `<p class="business-hours">${hoursText}</p>` : ''}<div class="option-grid">${buttons.join('')}</div></div>`
     );
   } else {
     const district = cityData.districts[pos.district];

--- a/style.css
+++ b/style.css
@@ -740,19 +740,18 @@ body.theme-dark .top-menu button {
     color: var(--background);
   }
 
-  .building-description {
-    margin: 0 0 0.5rem 0;
-    text-align: center;
-  }
-
+  .building-description,
   .location-description {
-    margin: 0.5rem 0;
-    text-align: center;
+    margin: 1rem 0;
+    padding: 0.5rem;
+    background: rgba(0, 0, 0, 0.1);
+    border: 1px solid var(--foreground);
+    text-align: left;
   }
 
   .business-hours {
     margin: 0 0 0.5rem 0;
-    text-align: center;
+    text-align: left;
     font-size: 0.9rem;
   }
 
@@ -766,6 +765,21 @@ body.theme-dark .top-menu button {
     flex-wrap: wrap;
     gap: 1rem;
     align-items: center;
+  }
+
+  .navigation .nav-header {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0.5rem 0;
+  }
+
+  .navigation .nav-header .nav-icon {
+    width: 5rem;
+    height: 5rem;
+    display: block;
+    object-fit: contain;
   }
 
   .navigation .nav-item {


### PR DESCRIPTION
## Summary
- Replace building headers with building and district nav icons
- Style descriptions with padded, left-aligned dark text box

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf7ac81b9c83259ce10da784cf1d8c