### PR TITLE
Improve building navigation icons

### DIFF
--- a/script.js
+++ b/script.js
@@ -1314,7 +1314,7 @@ function showNavigation() {
             icon: e.icon,
           })
         );
-      } else {
+      } else if (e.target !== pos.district) {
         const prompt = e.prompt || building.travelPrompt || 'Travel to';
         const icon = e.icon || getDistrictIcon(pos.city, e.name);
         buttons.push(
@@ -1322,7 +1322,7 @@ function showNavigation() {
         );
       }
     });
-    if (building.exits.length && (building.interactions || []).length) {
+    if (buttons.length && (building.interactions || []).length) {
       buttons.push('<div class="group-separator"></div>');
     }
     (building.interactions || []).forEach(i => {
@@ -1340,7 +1340,9 @@ function showNavigation() {
       : '';
     const bIcon = getBuildingIcon(pos.city, pos.district, pos.building);
     const dIcon = getDistrictIcon(pos.city, pos.district);
-    const headerHTML = `<div class="nav-header">${bIcon ? `<img src="${bIcon}" alt="" class="nav-icon">` : ''}<img src="${dIcon}" alt="" class="nav-icon"></div>`;
+    const headerHTML = `<div class="nav-header">${
+      bIcon ? `<img src="${bIcon}" alt="" class="nav-icon">` : ''
+    }<button data-type="district" data-target="${pos.district}" aria-label="Return to ${pos.district}"><img src="${dIcon}" alt="" class="nav-icon"></button></div>`;
     setMainHTML(
       `<div class="navigation">${headerHTML}${descriptionHTML}${hoursText ? `<p class="business-hours">${hoursText}</p>` : ''}<div class="option-grid">${buttons.join('')}</div></div>`
     );
@@ -1490,8 +1492,10 @@ function showNavigation() {
   normalizeOptionButtonWidths();
   updateMenuHeight();
   if (main) {
-    main.querySelectorAll('.option-grid button:not(:disabled)').forEach(btn => {
-      btn.addEventListener('click', () => {
+    main
+      .querySelectorAll('.option-grid button:not(:disabled), .nav-header button:not(:disabled)')
+      .forEach(btn => {
+        btn.addEventListener('click', () => {
         const action = btn.dataset.action;
         if (action === 'toggle-districts') {
           showDistricts = !showDistricts;

--- a/style.css
+++ b/style.css
@@ -769,17 +769,33 @@ body.theme-dark .top-menu button {
 
   .navigation .nav-header {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
     gap: 0.5rem;
     margin: 0.5rem 0;
   }
 
   .navigation .nav-header .nav-icon {
-    width: 5rem;
-    height: 5rem;
+    width: 10rem;
+    height: 10rem;
     display: block;
     object-fit: contain;
+  }
+
+  .navigation .nav-header button {
+    width: 10rem;
+    height: 10rem;
+    padding: 0;
+    border: none;
+    background: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .navigation .nav-header button .nav-icon {
+    width: 100%;
+    height: 100%;
   }
 
   .navigation .nav-item {


### PR DESCRIPTION
## Summary
- Size building and district icons to 10rem and align them to the left of building pages
- Make the district icon a button returning to the previous district
- Remove redundant district navigation button below building description

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7f1ac5c88325a7a9d9ba1628dbeb