### PR TITLE
Improve spellbook icon scaling and navigation layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -1340,9 +1340,9 @@ function showNavigation() {
       : '';
     const bIcon = getBuildingIcon(pos.city, pos.district, pos.building);
     const dIcon = getDistrictIcon(pos.city, pos.district);
-    const headerHTML = `<div class="nav-header">${
+    const headerHTML = `<div class="nav-header"><button data-type="district" data-target="${pos.district}" aria-label="Return to ${pos.district}"><img src="${dIcon}" alt="" class="nav-icon"></button>${
       bIcon ? `<img src="${bIcon}" alt="" class="nav-icon">` : ''
-    }<button data-type="district" data-target="${pos.district}" aria-label="Return to ${pos.district}"><img src="${dIcon}" alt="" class="nav-icon"></button></div>`;
+    }</div>`;
     setMainHTML(
       `<div class="navigation">${headerHTML}${descriptionHTML}${hoursText ? `<p class="business-hours">${hoursText}</p>` : ''}<div class="option-grid">${buttons.join('')}</div></div>`
     );

--- a/style.css
+++ b/style.css
@@ -246,7 +246,7 @@ main {
 
 button:not(:disabled):hover,
 .clickable:hover {
-  filter: drop-shadow(0 0 0.5rem currentColor);
+  filter: drop-shadow(0 0 0.5rem var(--foreground));
 }
 
 #dropdownMenu button:not(:last-child)::after,
@@ -1268,16 +1268,18 @@ body.theme-dark .top-menu button {
 }
 
 .filter-toggle img {
-  width: 5rem;
-  height: 5rem;
+  max-width: 4rem;
+  max-height: 4rem;
+  width: auto;
+  height: auto;
 }
 .element-icon,
 .school-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 5rem;
-  height: 5rem;
+  width: 2.5rem;
+  height: 2.5rem;
   margin-left: 0.25rem;
 }
 


### PR DESCRIPTION
## Summary
- Preserve aspect ratio and reduce size of spellbook filter icons
- Halve inline spell icon dimensions and adjust glow to contrast
- Show district navigation icon before building icon in header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf81f086b48325a6d3dfa58eeb231a