### PR TITLE
Add grayscale hover glow for spellbook filters

### DIFF
--- a/style.css
+++ b/style.css
@@ -1267,6 +1267,10 @@ body.theme-dark .top-menu button {
   filter: grayscale(1);
 }
 
+.filter-toggle.off:hover {
+  filter: grayscale(1) drop-shadow(0 0 0.5rem var(--foreground));
+}
+
 .filter-toggle img {
   max-width: 4rem;
   max-height: 4rem;


### PR DESCRIPTION
## Summary
- Keep inactive spellbook filter icons grayscale when hovered
- Add drop-shadow glow to indicate hover state while remaining grayscale

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf87d8d7d48325ba5432f670f35452