### PR TITLE
feat: handle double click and tap in spellbook

### DIFF
--- a/script.js
+++ b/script.js
@@ -1911,6 +1911,7 @@ function showSpellbookUI() {
     let longPress = false;
     if (type !== 'all') {
       let timer;
+      let lastTap = 0;
       const start = () => {
         longPress = false;
         timer = setTimeout(() => {
@@ -1924,6 +1925,20 @@ function showSpellbookUI() {
       ['mouseup', 'mouseleave', 'touchend'].forEach(ev =>
         btn.addEventListener(ev, cancel)
       );
+      btn.addEventListener('dblclick', () => {
+        longPress = true;
+        handleFilterLongPress(type, btn.dataset.filter);
+      });
+      btn.addEventListener('touchend', e => {
+        const now = Date.now();
+        const tapLen = now - lastTap;
+        if (tapLen > 0 && tapLen < 300) {
+          longPress = true;
+          handleFilterLongPress(type, btn.dataset.filter);
+          e.preventDefault();
+        }
+        lastTap = now;
+      });
     }
     btn.addEventListener('click', () => {
       if (longPress) return;


### PR DESCRIPTION
## Summary
- allow spellbook filters to respond to double clicks and taps in addition to long presses

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8d1c2144832595278b0b3bde3ae6