### PR TITLE
Remove manual orientation controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Text RPG</title>
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="theme-light layout-auto">
+<body class="theme-light">
   <div id="app">
 <nav class="top-menu">
   <button id="menu-button" aria-label="Menu">☰</button>
@@ -30,7 +30,6 @@
     </button>
     <div id="settings-panel">
       <button id="theme-toggle" aria-label="Toggle theme"></button>
-      <button id="layout-toggle" aria-label="Toggle layout"></button>
       <button id="scale-dec" aria-label="Decrease UI size">-</button>
       <button id="scale-inc" aria-label="Increase UI size">+</button>
     </div>

--- a/script.js
+++ b/script.js
@@ -174,22 +174,11 @@ function updateLayoutSize() {
   if (!app) return;
   const vw = window.innerWidth;
   const vh = window.innerHeight;
-  let width = vw;
-  let height = vh;
-  if (body.classList.contains('layout-landscape')) {
-    const aspect = 16 / 9;
-    width = Math.min(vw, vh * aspect);
-    height = width / aspect;
-  } else if (body.classList.contains('layout-portrait')) {
-    const aspect = 9 / 16;
-    height = vh;
-    width = Math.min(vw, vh * aspect);
-  }
   const scale = parseFloat(
     getComputedStyle(document.documentElement).getPropertyValue('--ui-scale')
   ) || 1;
-  app.style.width = `${width / scale}px`;
-  app.style.height = `${height / scale}px`;
+  app.style.width = `${vw / scale}px`;
+  app.style.height = `${vh / scale}px`;
 }
 
 function updateMenuHeight() {
@@ -214,10 +203,7 @@ function setMainHTML(html) {
 }
 
 function isPortraitLayout() {
-  return (
-    body.classList.contains('layout-portrait') ||
-    (body.classList.contains('layout-auto') && window.innerHeight > window.innerWidth)
-  );
+  return window.innerHeight > window.innerWidth;
 }
 
 function normalizeOptionButtonWidths() {
@@ -2751,11 +2737,8 @@ function loadPreferences() {
   if (typeof prefs.uiScale === 'number') {
     uiScale = prefs.uiScale;
   }
-  if (prefs.layout && layouts.includes(prefs.layout)) {
-    currentLayoutIndex = layouts.indexOf(prefs.layout);
-  }
   setTheme(currentThemeIndex);
-  setLayout(currentLayoutIndex);
+  updateScale();
 }
 
 const settingsButton = document.getElementById('settings-button');
@@ -2793,10 +2776,7 @@ themeToggle.addEventListener('click', () => {
 // UI scale buttons
 let uiScale = 1;
 const updateScale = () => {
-  const baseScale = body.classList.contains('layout-landscape')
-    ? uiScale * 1.25
-    : uiScale;
-  document.documentElement.style.setProperty('--ui-scale', baseScale);
+  document.documentElement.style.setProperty('--ui-scale', uiScale);
   savePreference('uiScale', uiScale);
   updateMenuHeight();
 };
@@ -2807,42 +2787,6 @@ document.getElementById('scale-dec').addEventListener('click', () => {
 document.getElementById('scale-inc').addEventListener('click', () => {
   uiScale = Math.min(2, uiScale + 0.1);
   updateScale();
-});
-
-// Layout toggle
-const layoutToggle = document.getElementById('layout-toggle');
-const layouts = ['landscape', 'portrait', 'auto'];
-const layoutIcons = {
-  landscape:
-    '<svg viewBox="0 0 24 24"><rect x="2" y="6" width="20" height="12" rx="2" ry="2"/></svg>',
-  portrait:
-    '<svg viewBox="0 0 24 24"><rect x="6" y="2" width="12" height="20" rx="2" ry="2"/></svg>',
-  auto:
-    '<svg viewBox="0 0 24 24"><rect x="6" y="2" width="12" height="20" rx="2" ry="2"/><rect x="2" y="6" width="20" height="12" rx="2" ry="2"/></svg>'
-};
-let currentLayoutIndex = layouts.indexOf(
-  [...body.classList].find(c => c.startsWith('layout-')).replace('layout-', '')
-);
-const setLayout = index => {
-  body.classList.remove('layout-landscape', 'layout-portrait', 'layout-auto');
-  const layout = layouts[index];
-  body.classList.add(`layout-${layout}`);
-  layoutToggle.innerHTML = layoutIcons[layout];
-  savePreference('layout', layout);
-  updateScale();
-  if (screen.orientation) {
-    if (layout === 'landscape') {
-      screen.orientation.lock('landscape').catch(() => {});
-    } else if (layout === 'portrait') {
-      screen.orientation.lock('portrait').catch(() => {});
-    } else if (screen.orientation.unlock) {
-      screen.orientation.unlock();
-    }
-  }
-};
-layoutToggle.addEventListener('click', () => {
-  currentLayoutIndex = (currentLayoutIndex + 1) % layouts.length;
-  setLayout(currentLayoutIndex);
 });
 
 // Dropdown menu

--- a/style.css
+++ b/style.css
@@ -28,19 +28,6 @@ body {
   overflow-x: hidden;
 }
 
-body.layout-landscape,
-body.layout-portrait {
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  min-height: 100vh;
-  overflow-x: hidden;
-}
-
-body.layout-auto {
-  display: block;
-}
-
 #app {
   position: relative;
   display: flex;
@@ -555,9 +542,6 @@ body.theme-dark .top-menu button {
     align-items: flex-start;
   }
 
-  body.layout-portrait .stats-resource-grid {
-    grid-template-columns: 1fr;
-  }
 
   .character-profile {
     display: flex;
@@ -574,10 +558,6 @@ body.theme-dark .top-menu button {
     width: 100%;
   }
 
-  body.layout-landscape .profile-grid {
-    grid-template-columns: auto 1fr;
-    align-items: start;
-  }
 
   .portrait-section {
     display: flex;
@@ -591,18 +571,12 @@ body.theme-dark .top-menu button {
     align-items: flex-start;
   }
 
-  body.layout-portrait .character-creation {
-    align-items: stretch;
-  }
 
   .cc-top-row {
     display: flex;
     align-items: flex-start;
   }
 
-  body.layout-portrait .cc-top-row {
-    flex-direction: column;
-  }
 
   .progress-container {
     display: flex;
@@ -617,10 +591,6 @@ body.theme-dark .top-menu button {
     align-items: flex-start;
   }
 
-  body.layout-portrait .progress-container {
-    margin-right: 0;
-    margin-bottom: 0.5rem;
-  }
 
   .progress-step {
     display: flex;
@@ -1192,9 +1162,6 @@ body.theme-dark .top-menu button {
 .slot-item {
   flex: 1;
 }
-
-/* Orientation layouts removed: top menu remains horizontal for all layouts */
-
 #map-container {
   position: fixed;
   top: var(--menu-height);


### PR DESCRIPTION
## Summary
- Remove layout toggle button and orientation forcing logic
- Simplify layout handling to rely on screen dimensions and auto detection
- Clean up unused orientation-specific CSS

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf91ff2af88325b24c701f347bd886