### PR TITLE
Reduce navigation button size in portrait orientation

### DIFF
--- a/style.css
+++ b/style.css
@@ -869,6 +869,19 @@ body.theme-dark .top-menu button {
     box-shadow: 0 0 0 2px #2e8b57;
   }
 
+  @media (orientation: portrait) {
+    .navigation .nav-header .nav-icon,
+    .navigation .nav-header button,
+    .navigation .nav-item button {
+      width: 5rem;
+      height: 5rem;
+    }
+
+    .navigation .nav-item button span.nav-icon {
+      font-size: 4rem;
+    }
+  }
+
   .location-select,
   .race-select {
     display: flex;


### PR DESCRIPTION
## Summary
- Shrink navigation button dimensions to 5rem when the display is in portrait orientation for improved mobile usability

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf963f34488325b539fb88bced4aa8