### PR TITLE
feat: add image prompt templates

### DIFF
--- a/assets/data/image_prompts.js
+++ b/assets/data/image_prompts.js
@@ -1,0 +1,37 @@
+export const BASE_IMAGE_PROMPT_TEMPLATE = 'Full body portrait of a {sex} {race}{skinDesc}, {hair} hair and {eyes} eyes, {height} tall, standing in {location}';
+export const ADDON_IMAGE_PROMPT_TEMPLATE = 'Picture Theme: {themeText}.';
+
+export function getRacePrompt(race) {
+  switch (race) {
+    case 'Elf':
+      return 'with slender build and pointed ears';
+    case 'Dark Elf':
+      return 'with slender build, dark aura, and pointed ears';
+    case 'Dwarf':
+      return 'with a stocky build and a braided beard';
+    case 'Cait Sith':
+      return 'with feline ears, whiskers, and a tail';
+    case 'Salamander':
+      return 'with a reptilian tail, horns, and sturdy build';
+    case 'Gnome':
+      return 'with a small frame and inquisitive eyes';
+    case 'Halfling':
+      return 'with short, nimble stature and curly hair';
+    default:
+      return '';
+  }
+}
+
+export function buildImagePrompt({ sex, race, skinDesc, hair, eyes, height, location, themeText }) {
+  const base = BASE_IMAGE_PROMPT_TEMPLATE
+    .replace('{sex}', sex.toLowerCase())
+    .replace('{race}', race.toLowerCase())
+    .replace('{skinDesc}', skinDesc ? ` with ${skinDesc}` : '')
+    .replace('{hair}', hair)
+    .replace('{eyes}', eyes)
+    .replace('{height}', height)
+    .replace('{location}', location);
+  const racePart = getRacePrompt(race);
+  const addon = ADDON_IMAGE_PROMPT_TEMPLATE.replace('{themeText}', themeText);
+  return racePart ? `${base}, ${racePart}. ${addon}` : `${base}. ${addon}`;
+}

--- a/script.js
+++ b/script.js
@@ -21,6 +21,7 @@ import { CITY_NAV } from "./assets/data/city_nav.js";
 import { themeColors } from "./assets/data/theme_colors.js";
 import { getThemeDescription } from "./assets/data/theme_descriptions.js";
 import { getRaceColors } from "./assets/data/race_colors.js";
+import { buildImagePrompt } from "./assets/data/image_prompts.js";
 import { DEFAULT_NAMES } from "./assets/data/names.js";
 import { WAVES_BREAK_BACKSTORIES } from "./assets/data/waves_break_backstories.js";
 import {
@@ -2584,7 +2585,16 @@ async function generateCharacterImage(character) {
   const eyes = character.eyeColor || raceCombo?.eyes || 'brown';
   const height = character.height ? formatHeight(character.height) : 'average height';
   const themeText = `${pictureTheme.join(', ')}${descriptor ? ' – ' + descriptor : ''}`;
-  const prompt = `Full body portrait of a ${character.sex.toLowerCase()} ${character.race.toLowerCase()}${skinDesc ? \` with ${skinDesc}\` : ''}, ${hair} hair and ${eyes} eyes, ${height} tall, standing in ${location}. Picture Theme: ${themeText}.`;
+  const prompt = buildImagePrompt({
+    sex: character.sex,
+    race: character.race,
+    skinDesc,
+    hair,
+    eyes,
+    height,
+    location,
+    themeText
+  });
   let apiKey = localStorage.getItem('openaiApiKey');
   if (!apiKey) {
     apiKey = prompt('Enter OpenAI API key:');


### PR DESCRIPTION
## Summary
- add base and addon prompt templates with race-specific descriptors
- use the new templates for character portrait generation

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `node -e "import('./assets/data/image_prompts.js').then(m=>console.log(m.BASE_IMAGE_PROMPT_TEMPLATE && m.ADDON_IMAGE_PROMPT_TEMPLATE ? 'loaded' : 'fail')).catch(e=>{console.error(e); process.exit(1);});"`


------
https://chatgpt.com/codex/tasks/task_e_68bfa121ef948325b03efdb5e33f8afc