### PR TITLE
refactor: update image prompt templates

### DIFF
--- a/assets/data/image_prompts.js
+++ b/assets/data/image_prompts.js
@@ -1,5 +1,5 @@
-export const BASE_IMAGE_PROMPT_TEMPLATE = 'Full body portrait of a {sex} {race}{skinDesc}, {hair} hair and {eyes} eyes, {height} tall, standing in {location}';
-export const ADDON_IMAGE_PROMPT_TEMPLATE = 'Picture Theme: {themeText}.';
+export const BASE_IMAGE_PROMPT_TEMPLATE = "A hyper-detailed fantasy Anime-style full-body portrait of a handsome {sex} {race} dressed in tantalizing, tasteful garb in front of a neutral gray background. Reference facial features from the most attractive {sexPlural}. Human proportionality for height is about 7.5 heads tall. Hair: {hair}. Skin: {skin} with light freckles. Eyes: {eyes}. Clothing is vibrant, complementary colors contrasting hair and skin tones with accents, trim, and accessories. Dynamic composition, ultra high definition, delicate details. No hat. No weapon.";
+export const ADDON_IMAGE_PROMPT_TEMPLATE = "Picture Theme: {theme} — {colors}.";
 
 export function getRacePrompt(race) {
   switch (race) {
@@ -22,16 +22,17 @@ export function getRacePrompt(race) {
   }
 }
 
-export function buildImagePrompt({ sex, race, skinDesc, hair, eyes, height, location, themeText }) {
+export function buildImagePrompt({ sex, sexPlural, race, hair, skin, eyes, theme, colors }) {
   const base = BASE_IMAGE_PROMPT_TEMPLATE
     .replace('{sex}', sex.toLowerCase())
     .replace('{race}', race.toLowerCase())
-    .replace('{skinDesc}', skinDesc ? ` with ${skinDesc}` : '')
+    .replace('{sexPlural}', sexPlural.toLowerCase())
     .replace('{hair}', hair)
-    .replace('{eyes}', eyes)
-    .replace('{height}', height)
-    .replace('{location}', location);
+    .replace('{skin}', skin)
+    .replace('{eyes}', eyes);
   const racePart = getRacePrompt(race);
-  const addon = ADDON_IMAGE_PROMPT_TEMPLATE.replace('{themeText}', themeText);
-  return racePart ? `${base}, ${racePart}. ${addon}` : `${base}. ${addon}`;
+  const addon = ADDON_IMAGE_PROMPT_TEMPLATE
+    .replace('{theme}', theme)
+    .replace('{colors}', colors);
+  return racePart ? `${base} ${racePart}. ${addon}` : `${base} ${addon}`;
 }

--- a/script.js
+++ b/script.js
@@ -2571,34 +2571,27 @@ function startCharacterCreation() {
 }
 
 async function generateCharacterImage(character) {
-  const location = character.location || 'a small town plaza';
   const themeEntry = themeColors.find(t => t.name === character.theme);
   const pictureTheme = themeEntry ? themeEntry.colors : ['beige', 'gray', 'white'];
   const descriptor = getThemeDescription(character.theme);
   const raceCombo = themeEntry ? getRaceColors(character.race, themeEntry.index) : null;
 
   const skinColor = character.skinColor || raceCombo?.skin;
-  let skinDesc = skinColor ? `${skinColor} skin` : '';
-  if (character.race === 'Cait Sith') {
-    const accent = character.accentColor || raceCombo?.accent;
-    if (accent) skinDesc += ` and ${accent} accents`;
-  } else if (character.race === 'Salamander') {
-    const scales = character.scaleColor || raceCombo?.scales;
-    if (scales) skinDesc += ` and ${scales} scales`;
-  }
+  const skin = skinColor || '';
   const hair = character.hairColor || raceCombo?.hair || 'brown';
   const eyes = character.eyeColor || raceCombo?.eyes || 'brown';
-  const height = character.height ? formatHeight(character.height) : 'average height';
-  const themeText = `${pictureTheme.join(', ')}${descriptor ? ' – ' + descriptor : ''}`;
+  const sexPlural = character.sex === 'Male' ? 'men' : 'women';
+  const theme = descriptor || character.theme || '';
+  const colors = pictureTheme.join(', ');
   const prompt = buildImagePrompt({
     sex: character.sex,
+    sexPlural,
     race: character.race,
-    skinDesc,
     hair,
+    skin,
     eyes,
-    height,
-    location,
-    themeText
+    theme,
+    colors
   });
   let apiKey = localStorage.getItem('openaiApiKey');
   if (!apiKey) {


### PR DESCRIPTION
## Summary
- overhaul base and addon image prompt templates for richer descriptions
- update buildImagePrompt to accept sex plural, skin, theme, and colors
- adjust image generation to supply new fields and drop obsolete ones

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa6e7d9b48325a1b052e6ea7323c9