### PR TITLE
Expand image prompt theme details

### DIFF
--- a/assets/data/image_prompts.js
+++ b/assets/data/image_prompts.js
@@ -1,5 +1,5 @@
 export const BASE_IMAGE_PROMPT_TEMPLATE = "A hyper-detailed fantasy Anime-style full-body portrait of a handsome {sex} {race} dressed in tantalizing, tasteful garb in front of a neutral gray background. Reference facial features from the most attractive {sexPlural}. Human proportionality for height is about 7.5 heads tall. Hair: {hair}. Skin: {skin} with light freckles. Eyes: {eyes}. Clothing is vibrant, complementary colors contrasting hair and skin tones with accents, trim, and accessories. Dynamic composition, ultra high definition, delicate details. No hat. No weapon.";
-export const ADDON_IMAGE_PROMPT_TEMPLATE = "Picture Theme: {theme} — {colors}.";
+export const ADDON_IMAGE_PROMPT_TEMPLATE = "Picture Theme: {themeName} — {themeDesc} — {colors}.";
 
 export function getRacePrompt(race) {
   switch (race) {
@@ -22,7 +22,7 @@ export function getRacePrompt(race) {
   }
 }
 
-export function buildImagePrompt({ sex, sexPlural, race, hair, skin, eyes, theme, colors }) {
+export function buildImagePrompt({ sex, sexPlural, race, hair, skin, eyes, themeName, themeDesc, colors }) {
   const base = BASE_IMAGE_PROMPT_TEMPLATE
     .replace('{sex}', sex.toLowerCase())
     .replace('{race}', race.toLowerCase())
@@ -32,7 +32,8 @@ export function buildImagePrompt({ sex, sexPlural, race, hair, skin, eyes, theme
     .replace('{eyes}', eyes);
   const racePart = getRacePrompt(race);
   const addon = ADDON_IMAGE_PROMPT_TEMPLATE
-    .replace('{theme}', theme)
+    .replace('{themeName}', themeName)
+    .replace('{themeDesc}', themeDesc)
     .replace('{colors}', colors);
   return racePart ? `${base} ${racePart}. ${addon}` : `${base} ${addon}`;
 }

--- a/script.js
+++ b/script.js
@@ -2581,7 +2581,8 @@ async function generateCharacterImage(character) {
   const hair = character.hairColor || raceCombo?.hair || 'brown';
   const eyes = character.eyeColor || raceCombo?.eyes || 'brown';
   const sexPlural = character.sex === 'Male' ? 'men' : 'women';
-  const theme = descriptor || character.theme || '';
+  const themeName = character.theme || '';
+  const themeDesc = descriptor || '';
   const colors = pictureTheme.join(', ');
   const prompt = buildImagePrompt({
     sex: character.sex,
@@ -2590,7 +2591,8 @@ async function generateCharacterImage(character) {
     hair,
     skin,
     eyes,
-    theme,
+    themeName,
+    themeDesc,
     colors
   });
   let apiKey = localStorage.getItem('openaiApiKey');


### PR DESCRIPTION
## Summary
- Include theme name and description placeholders in image prompt template
- Pass theme name and description into `buildImagePrompt`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa9131d848325b3cfb8bf7ac7d590