### PR TITLE
Refactor image prompt generation into utility

### DIFF
--- a/assets/data/image_prompts.js
+++ b/assets/data/image_prompts.js
@@ -1,5 +1,11 @@
-export const BASE_IMAGE_PROMPT_TEMPLATE = "A hyper-detailed fantasy Anime-style full-body portrait of a handsome {sex} {race} dressed in tantalizing, tasteful garb in front of a neutral gray background. Reference facial features from the most attractive {sexPlural}. Human proportionality for height is about 7.5 heads tall. Hair: {hair}. Skin: {skin} with light freckles. Eyes: {eyes}. Clothing is vibrant, complementary colors contrasting hair and skin tones with accents, trim, and accessories. Dynamic composition, ultra high definition, delicate details. No hat. No weapon.";
-export const ADDON_IMAGE_PROMPT_TEMPLATE = "Picture Theme: {themeName} — {themeDesc} — {colors}.";
+import { themeColors, getThemeColors } from "./theme_colors.js";
+import { getThemeDescription } from "./theme_descriptions.js";
+import { getRaceColors } from "./race_colors.js";
+
+export const BASE_IMAGE_PROMPT_TEMPLATE =
+  "A hyper-detailed fantasy Anime-style full-body portrait of a handsome {sex} {race} dressed in tantalizing, tasteful garb in front of a neutral gray background. Reference facial features from the most attractive {sexPlural}. Human proportionality for height is about 7.5 heads tall. Hair: {hair}. Skin: {skin} with light freckles. Eyes: {eyes}. Clothing is vibrant, complementary colors contrasting hair and skin tones with accents, trim, and accessories. Dynamic composition, ultra high definition, delicate details. No hat. No weapon.";
+export const ADDON_IMAGE_PROMPT_TEMPLATE =
+  "Picture Theme: {themeName} — {themeDesc} — {colors}.";
 
 export function getRacePrompt(race) {
   switch (race) {
@@ -36,4 +42,32 @@ export function buildImagePrompt({ sex, sexPlural, race, hair, skin, eyes, theme
     .replace('{themeDesc}', themeDesc)
     .replace('{colors}', colors);
   return racePart ? `${base} ${racePart}. ${addon}` : `${base} ${addon}`;
+}
+
+export function composeImagePrompt(character) {
+  const themeIndex = themeColors.find(t => t.name === character.theme)?.index;
+  const pictureTheme = getThemeColors(themeIndex);
+  const descriptor = getThemeDescription(character.theme);
+  const raceCombo = themeIndex ? getRaceColors(character.race, themeIndex) : null;
+
+  const skinColor = character.skinColor || raceCombo?.skin;
+  const skin = skinColor || '';
+  const hair = character.hairColor || raceCombo?.hair || 'brown';
+  const eyes = character.eyeColor || raceCombo?.eyes || 'brown';
+  const sexPlural = character.sex === 'Male' ? 'men' : 'women';
+  const themeName = character.theme || '';
+  const themeDesc = descriptor || '';
+  const colors = pictureTheme.join(', ');
+
+  return buildImagePrompt({
+    sex: character.sex,
+    sexPlural,
+    race: character.race,
+    hair,
+    skin,
+    eyes,
+    themeName,
+    themeDesc,
+    colors,
+  });
 }

--- a/script.js
+++ b/script.js
@@ -18,10 +18,7 @@ import { WEAPON_SLOTS, ARMOR_SLOTS, TRINKET_SLOTS } from "./assets/data/equipmen
 import { LOCATIONS } from "./assets/data/locations.js";
 import { HYBRID_RELATIONS } from "./assets/data/hybrid_relations.js";
 import { CITY_NAV } from "./assets/data/city_nav.js";
-import { themeColors, getThemeColors } from "./assets/data/theme_colors.js";
-import { getThemeDescription } from "./assets/data/theme_descriptions.js";
-import { getRaceColors } from "./assets/data/race_colors.js";
-import { buildImagePrompt } from "./assets/data/image_prompts.js";
+import { composeImagePrompt } from "./assets/data/image_prompts.js";
 import { DEFAULT_NAMES } from "./assets/data/names.js";
 import { WAVES_BREAK_BACKSTORIES } from "./assets/data/waves_break_backstories.js";
 import {
@@ -2571,30 +2568,7 @@ function startCharacterCreation() {
 }
 
 async function generateCharacterImage(character) {
-  const themeIndex = themeColors.find(t => t.name === character.theme)?.index;
-  const pictureTheme = getThemeColors(themeIndex);
-  const descriptor = getThemeDescription(character.theme);
-  const raceCombo = themeIndex ? getRaceColors(character.race, themeIndex) : null;
-
-  const skinColor = character.skinColor || raceCombo?.skin;
-  const skin = skinColor || '';
-  const hair = character.hairColor || raceCombo?.hair || 'brown';
-  const eyes = character.eyeColor || raceCombo?.eyes || 'brown';
-  const sexPlural = character.sex === 'Male' ? 'men' : 'women';
-  const themeName = character.theme || '';
-  const themeDesc = descriptor || '';
-  const colors = pictureTheme.join(', ');
-  const prompt = buildImagePrompt({
-    sex: character.sex,
-    sexPlural,
-    race: character.race,
-    hair,
-    skin,
-    eyes,
-    themeName,
-    themeDesc,
-    colors
-  });
+  const prompt = composeImagePrompt(character);
   let apiKey = localStorage.getItem('openaiApiKey');
   if (!apiKey) {
     apiKey = prompt('Enter OpenAI API key:');


### PR DESCRIPTION
## Summary
- add `composeImagePrompt` to gather theme, race, and color details then build an image prompt
- refactor character image generator to rely on `composeImagePrompt`

## Testing
- `node --input-type=module -e "import('./assets/data/image_prompts.js').then(m=>console.log(m.composeImagePrompt({sex:'Male',race:'Human',theme:'Knight / Paladin'}))).catch(err=>console.error(err))"`


------
https://chatgpt.com/codex/tasks/task_e_68bfacdde76083259b6cdd9325886ea9