### PR TITLE
fix: prevent initial zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <title>Text RPG</title>
   <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
## Summary
- prevent mobile browsers from auto zooming past intended scale

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfaf4e8b0083258b08a7971c5740f6