### PR TITLE
Reduce district map icon size and fix portrait overlay

### DIFF
--- a/script.js
+++ b/script.js
@@ -1379,8 +1379,8 @@ function showNavigation() {
         const accessible = new Set(districts.map(d => d.name).concat(pos.district));
         const fontSize =
           parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
-        // Each district icon button is 10rem square, so space nodes accordingly
-        const size = 10 * fontSize;
+        // Each district icon button is 5rem square, so space nodes accordingly
+        const size = 5 * fontSize;
         const nodes = allNames.map(name => {
           const coords = layout.positions[name] || [0, 0];
           const [row, col] = coords;

--- a/style.css
+++ b/style.css
@@ -845,6 +845,15 @@ body.theme-dark .top-menu button {
     z-index: 1;
   }
 
+  .navigation .district-map .nav-item button {
+    width: 5rem;
+    height: 5rem;
+  }
+
+  .navigation .district-map .nav-item button span.nav-icon {
+    font-size: 4rem;
+  }
+
   .navigation .district-map .district-connections {
     position: absolute;
     top: 0;


### PR DESCRIPTION
## Summary
- shrink district topology icons to 5rem and recalc spacing for connection lines
- add CSS for smaller district map buttons and icons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb19e2a748325bd99b78c292369f4