### PR TITLE
Reduce navigation icon spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -214,7 +214,7 @@ main {
   padding: 0.5rem 1rem;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.25rem;
   border: none;
   background: var(--background);
   color: var(--foreground);
@@ -733,7 +733,7 @@ body.theme-dark .top-menu button {
   .navigation .option-grid {
     flex-direction: row;
     flex-wrap: wrap;
-    gap: 1rem;
+    gap: 0.5rem;
     align-items: center;
   }
 
@@ -741,7 +741,7 @@ body.theme-dark .top-menu button {
     display: flex;
     justify-content: flex-start;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.25rem;
     margin: 0.5rem 0;
   }
 
@@ -771,7 +771,7 @@ body.theme-dark .top-menu button {
   .navigation .nav-item {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.25rem;
   }
 
     .navigation .nav-item button {
@@ -831,7 +831,7 @@ body.theme-dark .top-menu button {
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 1rem;
+    gap: 0.5rem;
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary
- Halve spacing for navigation option grids, headers and items to tighten building, location and district icons
- Reduce character menu icon spacing for a more compact layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbab6cedc8325add14d62bdc79886