### PR TITLE
feat: add zoom controls to character creation

### DIFF
--- a/script.js
+++ b/script.js
@@ -1750,11 +1750,14 @@ function showCharacterUI() {
   const zoomDec = document.getElementById('portrait-zoom-dec');
   const zoomInc = document.getElementById('portrait-zoom-inc');
   const zoomReset = document.getElementById('portrait-zoom-reset');
+  const zoomControls = document.querySelector('.portrait-zoom');
   let portraitZoom = 1;
 
   function updatePortraitZoom() {
     portraitImg.style.transform = `scale(${portraitZoom})`;
     zoomReset.textContent = `${Math.round(portraitZoom * 100)}%`;
+    const offset = portraitImg.offsetHeight * (portraitZoom - 1);
+    zoomControls.style.marginTop = `${offset}px`;
   }
 
   zoomDec.addEventListener('click', () => {
@@ -1772,7 +1775,8 @@ function showCharacterUI() {
     updatePortraitZoom();
   });
 
-  updatePortraitZoom();
+  if (portraitImg.complete) updatePortraitZoom();
+  else portraitImg.addEventListener('load', updatePortraitZoom);
   document.getElementById('delete-character').addEventListener('click', () => {
     delete currentProfile.characters[c.id];
     currentProfile.lastCharacter = null;
@@ -2193,6 +2197,7 @@ function startCharacterCreation() {
   };
 
   let step = saved.step || 0;
+  let ccPortraitZoom = 1;
   renderStep();
 
   async function renderStep() {
@@ -2347,7 +2352,14 @@ function startCharacterCreation() {
             inputHTML = `
               <div class="character-carousel wheel-selector">
                 <button class="character-arrow left" aria-label="Previous">&#x2039;</button>
-                <img class="character-option" src="${src}" alt="Character">
+                <div class="portrait-wrapper">
+                  <img class="character-option" src="${src}" alt="Character">
+                  <div class="portrait-zoom">
+                    <button id="portrait-zoom-dec" class="portrait-zoom-dec" aria-label="Zoom out">-</button>
+                    <button id="portrait-zoom-reset" class="portrait-zoom-reset" aria-label="Reset zoom">100%</button>
+                    <button id="portrait-zoom-inc" class="portrait-zoom-inc" aria-label="Zoom in">+</button>
+                  </div>
+                </div>
                 <button class="character-arrow right" aria-label="Next">&#x203A;</button>
               </div>`;
           }
@@ -2449,6 +2461,7 @@ function startCharacterCreation() {
           const change = dir => {
             index = (index + dir + files.length) % files.length;
             character.characterImage = files[index];
+            ccPortraitZoom = 1;
             localStorage.setItem(
               TEMP_CHARACTER_KEY,
               JSON.stringify({ step, character })
@@ -2461,6 +2474,37 @@ function startCharacterCreation() {
           document
             .querySelector('.character-arrow.right')
             .addEventListener('click', () => change(1));
+
+          const portraitImg = document.querySelector('.character-option');
+          const zoomDec = document.getElementById('portrait-zoom-dec');
+          const zoomInc = document.getElementById('portrait-zoom-inc');
+          const zoomReset = document.getElementById('portrait-zoom-reset');
+          const zoomControls = document.querySelector('.portrait-zoom');
+
+          function updateZoom() {
+            portraitImg.style.transform = `scale(${ccPortraitZoom})`;
+            zoomReset.textContent = `${Math.round(ccPortraitZoom * 100)}%`;
+            const offset = portraitImg.offsetHeight * (ccPortraitZoom - 1);
+            zoomControls.style.marginTop = `${offset}px`;
+          }
+
+          zoomDec.addEventListener('click', () => {
+            ccPortraitZoom = Math.max(0.1, ccPortraitZoom - 0.1);
+            updateZoom();
+          });
+
+          zoomInc.addEventListener('click', () => {
+            ccPortraitZoom += 0.1;
+            updateZoom();
+          });
+
+          zoomReset.addEventListener('click', () => {
+            ccPortraitZoom = 1;
+            updateZoom();
+          });
+
+          if (portraitImg.complete) updateZoom();
+          else portraitImg.addEventListener('load', updateZoom);
         }
       } else if (field.type === 'select') {
         document.querySelectorAll('.option-button').forEach(btn => {

--- a/style.css
+++ b/style.css
@@ -427,8 +427,7 @@ body.theme-dark .top-menu button {
   }
 
   .portrait-zoom button {
-    width: 3rem;
-    height: 3rem;
+    height: 2rem;
     background: transparent;
     border: 2px solid var(--foreground);
     color: var(--foreground);
@@ -437,6 +436,7 @@ body.theme-dark .top-menu button {
     justify-content: center;
     cursor: pointer;
     font-size: 1rem;
+    padding: 0 0.5rem;
   }
 
   .portrait-zoom button:hover {
@@ -445,10 +445,14 @@ body.theme-dark .top-menu button {
 
   .portrait-zoom-dec,
   .portrait-zoom-inc {
+    width: 2rem;
+    height: 2rem;
     border-radius: 50%;
+    padding: 0;
   }
 
   .portrait-zoom-reset {
+    height: 2rem;
     border-radius: 0.25rem;
   }
 


### PR DESCRIPTION
## Summary
- add portrait zoom controls to character creation images
- keep zoom controls anchored to image bottom while scaling
- shrink zoom button dimensions for consistent sizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc4824d348325be5e83686d6ac8ba