### PR TITLE
fix: anchor portrait zoom to prevent overlap

### DIFF
--- a/style.css
+++ b/style.css
@@ -315,7 +315,6 @@ button:not(:disabled):hover,
   width: auto;
   height: auto;
   object-fit: contain;
-  transform-origin: center;
 }
 
 .no-character {
@@ -419,6 +418,10 @@ body.theme-dark .top-menu button {
     flex-direction: column;
     align-items: center;
     gap: 0.5rem;
+  }
+
+  .portrait-wrapper img {
+    transform-origin: top;
   }
 
   .portrait-zoom {


### PR DESCRIPTION
## Summary
- anchor portrait images to scale from the top to avoid menu overlap when zooming

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc78629048325b603a33b3ec83704