### PR TITLE
Replace Spellbook header icon and highlight ON filter

### DIFF
--- a/script.js
+++ b/script.js
@@ -1880,7 +1880,7 @@ function showSpellbookUI() {
 
   html += filterHtml;
 
-  html += '<div class="spellbook-list"><h1><span class="spellbook-icon">📖</span>Spellbook</h1>';
+  html += '<div class="spellbook-list"><h1><img src="assets/images/icons/Magic/Spellbook.png" alt="Spellbook" class="spellbook-icon"></h1>';
   if (filtered.length) {
     html += '<ul class="spell-list">';
     filtered.forEach(spell => {

--- a/style.css
+++ b/style.css
@@ -1240,6 +1240,7 @@ body.theme-dark .top-menu button {
 .spellbook-list h1 {
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 
 .spellbook-filters {
@@ -1263,6 +1264,10 @@ body.theme-dark .top-menu button {
 
 .filter-toggle.off {
   filter: grayscale(1);
+}
+
+.spellbook-filters > .filter-toggle.off {
+  filter: grayscale(1) drop-shadow(0 0 0.75rem var(--foreground));
 }
 
 .filter-toggle.off:hover {
@@ -1316,7 +1321,9 @@ body.theme-dark .top-menu button {
 }
 
 .spellbook-icon {
-  margin-right: 0.25rem;
+  margin-right: 0;
+  max-width: 4rem;
+  max-height: 4rem;
 }
 
 .icon {


### PR DESCRIPTION
## Summary
- Use dedicated Spellbook.png for the spellbook page header
- Add glow effect to the master ON filter toggle for better visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c031b7f7048325958f67c3d1033e67