### PR TITLE
Resize spellbook icon and uppercase filter toggle

### DIFF
--- a/script.js
+++ b/script.js
@@ -1852,7 +1852,7 @@ function showSpellbookUI() {
 
   let filterHtml = '<div class="spellbook-filters">';
   const masterCls = allFiltersActive ? 'filter-toggle' : 'filter-toggle off';
-  const masterLabel = allFiltersActive ? 'Off' : 'On';
+  const masterLabel = allFiltersActive ? 'ON' : 'OFF';
   filterHtml += `<button class="${masterCls}" data-filter-type="all">${masterLabel}</button>`;
   if (unlockedElements.size) {
     filterHtml += '<div class="filter-group">';

--- a/style.css
+++ b/style.css
@@ -1240,7 +1240,7 @@ body.theme-dark .top-menu button {
 .spellbook-list h1 {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .spellbook-filters {
@@ -1322,8 +1322,15 @@ body.theme-dark .top-menu button {
 
 .spellbook-icon {
   margin-right: 0;
-  max-width: 4rem;
-  max-height: 4rem;
+  width: 10rem;
+  height: 10rem;
+}
+
+@media (orientation: portrait) {
+  .spellbook-icon {
+    width: 5rem;
+    height: 5rem;
+  }
 }
 
 .icon {


### PR DESCRIPTION
## Summary
- Enlarge spellbook icon to 10rem in landscape and 5rem in portrait and left-align with spell list
- Display ON/OFF in uppercase and show ON when no filters are applied

## Testing
- ⚠️ `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c041847f388325b2dc9e732cfe743a