### PR TITLE
Refine Seastone Arena and district map visuals

### DIFF
--- a/assets/data/city_nav.js
+++ b/assets/data/city_nav.js
@@ -145,7 +145,7 @@ export const CITY_NAV = {
             { name: "Quayside Greens Market", type: "building", target: "Quayside Greens Market", icon: "assets/images/icons/waves_break/Quayside Greens Market.png" },
             { name: "Dockside Exchange Plaza", type: "building", target: "Dockside Exchange Plaza", icon: "assets/images/icons/waves_break/Dockside Exchange Plaza.png" },
             { name: "Saltroot Remedies", type: "building", target: "Saltroot Remedies", icon: "assets/images/icons/waves_break/Saltroot Remedies.png" },
-            { name: "Seastone Arena", type: "building", target: "Seastone Arena", icon: "assets/images/icons/waves_break/Default.png" },
+            { name: "Seastone Arena", type: "building", target: "Seastone Arena", icon: "assets/images/icons/waves_break/Seastone Arena.png" },
             { name: "Tern Harbor Commons", type: "building", target: "Tern Harbor Commons", icon: "assets/images/icons/waves_break/Tern Harbor Commons.png" },
               { name: "The Port District", type: "district", target: "The Port District", icon: "assets/images/icons/waves_break/Port District.png" },
               { name: "The Lower Gardens", type: "district", target: "The Lower Gardens", icon: "assets/images/icons/waves_break/Lower Gardens District.png" },
@@ -590,7 +590,8 @@ Dockhands haul pungent barrels destined for lamps and fertilized fields.`,
       },
       "Seastone Arena": {
         travelPrompt: "Exit to",
-        description: `Carved basalt walls ring a sand-strewn pit where fighters trade blows.
+        description: `You shoulder through the throng and emerge into Seastone Arena.
+        Carved basalt walls ring a sand-strewn pit where fighters trade blows.
         Crowds roar as bets change hands and champions chase fleeting glory.`,
         exits: [ { name: "Little Terns", target: "Little Terns" } ],
         interactions: []

--- a/script.js
+++ b/script.js
@@ -1367,6 +1367,7 @@ function showNavigation() {
         name: pt.name,
         prompt,
         icon: pt.icon,
+        extraClass: pt.extraClass,
       });
     };
     const groups = [];
@@ -1379,8 +1380,10 @@ function showNavigation() {
         const accessible = new Set(districts.map(d => d.name).concat(pos.district));
         const fontSize =
           parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
-        // Each district icon button is 5rem square, so space nodes accordingly
-        const size = 5 * fontSize;
+        const isLandscape = window.innerWidth > window.innerHeight;
+        const iconRem = isLandscape ? 10 : 4.5;
+        // Each district icon button is iconRem rem square, so space nodes accordingly
+        const size = iconRem * fontSize;
         const nodes = allNames.map(name => {
           const coords = layout.positions[name] || [0, 0];
           const [row, col] = coords;
@@ -1412,7 +1415,9 @@ function showNavigation() {
           `<div class="district-map" style="width:${width}px;height:${height}px;"><svg class="district-connections" width="${width}" height="${height}">${lines}</svg>${nodes.join('')}</div>`,
         ];
       }
-      const neighborButtons = districts.map(makeButton);
+      const neighborButtons = districts.map(d =>
+        makeButton({ ...d, extraClass: 'connected-district' })
+      );
       const currentButton = createNavItem({
         type: 'district',
         target: pos.district,

--- a/style.css
+++ b/style.css
@@ -815,6 +815,15 @@ body.theme-dark .top-menu button {
       line-height: 1;
     }
 
+  .navigation .nav-item.connected-district button {
+    width: calc(10rem - 2.5rem);
+    height: calc(10rem - 2.5rem);
+  }
+
+  .navigation .nav-item.connected-district button span.nav-icon {
+    font-size: calc(8rem - 2.5rem);
+  }
+
   .navigation .nav-item.current-district button {
     pointer-events: none;
     cursor: default;
@@ -853,12 +862,12 @@ body.theme-dark .top-menu button {
   }
 
   .navigation .district-map .nav-item button {
-    width: 5rem;
-    height: 5rem;
+    width: 10rem;
+    height: 10rem;
   }
 
   .navigation .district-map .nav-item button span.nav-icon {
-    font-size: 4rem;
+    font-size: 8rem;
   }
 
   .navigation .district-map .district-connections {
@@ -897,6 +906,15 @@ body.theme-dark .top-menu button {
     .navigation .nav-item button span.nav-icon,
     .navigation .district-map .nav-item button span.nav-icon {
       font-size: 3.5rem;
+    }
+
+    .navigation .nav-item.connected-district button {
+      width: calc(4.5rem - 1rem);
+      height: calc(4.5rem - 1rem);
+    }
+
+    .navigation .nav-item.connected-district button span.nav-icon {
+      font-size: calc(3.5rem - 1rem);
     }
   }
 


### PR DESCRIPTION
## Summary
- Link Seastone Arena to its unique icon and enrich its description with an action-focused opening.
- Scale district map icons to 10rem on landscape and resize connectors accordingly.
- Shrink inline connected district icons when the map is hidden for clearer navigation.

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68c044458ccc832596bc7d1b1d497d9a