### PR TITLE
Use On/Off icons for spellbook filter

### DIFF
--- a/script.js
+++ b/script.js
@@ -1857,8 +1857,10 @@ function showSpellbookUI() {
 
   let filterHtml = '<div class="spellbook-filters">';
   const masterCls = allFiltersActive ? 'filter-toggle' : 'filter-toggle off';
-  const masterLabel = allFiltersActive ? 'ON' : 'OFF';
-  filterHtml += `<button class="${masterCls}" data-filter-type="all">${masterLabel}</button>`;
+  const masterIcon = allFiltersActive
+    ? '<img src="assets/images/icons/Magic/On.png" alt="Filters On" />'
+    : '<img src="assets/images/icons/Magic/Off.png" alt="Filters Off" />';
+  filterHtml += `<button class="${masterCls}" data-filter-type="all" aria-label="Toggle Filters">${masterIcon}</button>`;
   if (unlockedElements.size) {
     filterHtml += '<div class="filter-group">';
     elementOrder.forEach(el => {

--- a/style.css
+++ b/style.css
@@ -1284,19 +1284,21 @@ body.theme-dark .top-menu button {
   filter: grayscale(1);
 }
 
-.spellbook-filters > .filter-toggle.off {
-  filter: grayscale(1) drop-shadow(0 0 0.75rem var(--foreground));
-}
-
 .filter-toggle.off:hover {
   filter: grayscale(1) drop-shadow(0 0 0.5rem var(--foreground));
 }
 
+.spellbook-filters > .filter-toggle:not(.off) {
+  filter: drop-shadow(0 0 0.5rem var(--foreground));
+}
+
+.spellbook-filters > .filter-toggle:not(.off):hover {
+  filter: drop-shadow(0 0 0.75rem var(--foreground));
+}
+
 .filter-toggle img {
-  max-width: 4rem;
-  max-height: 4rem;
-  width: auto;
-  height: auto;
+  width: 4rem;
+  height: 4rem;
 }
 .element-icon,
 .school-icon {


### PR DESCRIPTION
## Summary
- Swap master spellbook filter text for On/Off icons
- Add hover and active glow effects to filter icons
- Enforce consistent sizing for all filter toggle icons

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c09056c2588325a8c4e247e4a4906f