### PR TITLE
fix: preserve filter toggle icon aspect ratio

### DIFF
--- a/style.css
+++ b/style.css
@@ -1299,6 +1299,7 @@ body.theme-dark .top-menu button {
 .filter-toggle img {
   width: 4rem;
   height: 4rem;
+  object-fit: contain;
 }
 .element-icon,
 .school-icon {


### PR DESCRIPTION
## Summary
- ensure spellbook filter toggle icons keep their natural aspect ratio

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0948e30b8832581a4ddc8a65a219f