### PR TITLE
Expand quest structure and helper utilities

### DIFF
--- a/assets/data/locations.js
+++ b/assets/data/locations.js
@@ -1,3 +1,4 @@
+import { questHelper } from "./questHelper.js";
 const MAP_BASE_PATH = "assets/images/Maps";
 export function createLocation(name, mapFile, description = "") {
     return {
@@ -13,11 +14,12 @@ export function createLocation(name, mapFile, description = "") {
             resources: { domestic: [], exports: [], imports: [] },
         },
         population: undefined,
+        quests: [],
         questBoards: {},
     };
 }
 function createQuest(title, description, opts = {}) {
-    return Object.assign({ title, description }, opts);
+    return questHelper(Object.assign({ title, description }, opts));
 }
 function addQuestBoards(loc) {
     var _a;
@@ -76,6 +78,8 @@ function addQuestBoards(loc) {
     });
     loc.questBoards = boards;
     loc.pointsOfInterest.buildings.push(...Object.keys(boards));
+    const allQuests = Object.values(boards).reduce((arr, q) => arr.concat(q), []);
+    loc.quests.push(...allQuests);
 }
 const WAVES_BREAK = Object.assign(Object.assign({}, createLocation("Wave's Break", "Wave's Break.png", `The City of Wave's Break
 

--- a/assets/data/locations.ts
+++ b/assets/data/locations.ts
@@ -1,3 +1,4 @@
+import { questHelper } from "./questHelper.js";
 const MAP_BASE_PATH = "assets/images/Maps";
 
 export interface Location {
@@ -28,12 +29,19 @@ export interface Location {
     districts: Record<string, { estimate: number; notes: string }>;
     hinterland?: { estimate: number; notes: string };
   };
+  quests: Quest[];
   questBoards: Record<string, Quest[]>;
 }
 
 export interface Quest {
   title: string;
   description: string;
+  location: string | null;
+  requirements: string[] | null;
+  conditions: string[] | null;
+  timeline: string | null;
+  risks: string[] | null;
+  reward: string | null;
   repeatable?: boolean;
   highPriority?: boolean;
   requiresCheckIn?: boolean;
@@ -57,6 +65,7 @@ export function createLocation(
       resources: { domestic: [], exports: [], imports: [] },
     },
     population: undefined,
+    quests: [],
     questBoards: {},
   };
 }
@@ -66,7 +75,7 @@ function createQuest(
   description: string,
   opts: Partial<Quest> = {},
 ): Quest {
-  return { title, description, ...opts };
+  return questHelper({ title, description, ...opts }) as Quest;
 }
 
 function addQuestBoards(loc: Location) {
@@ -163,6 +172,11 @@ function addQuestBoards(loc: Location) {
 
   loc.questBoards = boards;
   loc.pointsOfInterest.buildings.push(...Object.keys(boards));
+  const allQuests: Quest[] = Object.values(boards).reduce(
+    (arr: Quest[], q) => arr.concat(q),
+    [] as Quest[],
+  );
+  loc.quests.push(...allQuests);
 }
 
 const WAVES_BREAK: Location = {

--- a/assets/data/questHelper.js
+++ b/assets/data/questHelper.js
@@ -1,0 +1,12 @@
+export const QUEST_FIELDS = ['title','description','location','requirements','conditions','timeline','risks','reward'];
+
+export function questHelper(details) {
+  const quest = { ...details };
+  QUEST_FIELDS.forEach(field => {
+    if (quest[field] === undefined) {
+      console.warn(`Quest missing ${field}`);
+      quest[field] = null;
+    }
+  });
+  return quest;
+}

--- a/assets/data/questHelper.ts
+++ b/assets/data/questHelper.ts
@@ -1,0 +1,13 @@
+export type QuestField = 'title' | 'description' | 'location' | 'requirements' | 'conditions' | 'timeline' | 'risks' | 'reward';
+
+export function questHelper(details: Record<string, any>) {
+  const required: QuestField[] = ['title','description','location','requirements','conditions','timeline','risks','reward'];
+  const quest: Record<string, any> = { ...details };
+  required.forEach(field => {
+    if (quest[field] === undefined) {
+      console.warn(`Quest missing ${field}`);
+      quest[field] = null;
+    }
+  });
+  return quest;
+}

--- a/script.js
+++ b/script.js
@@ -2088,7 +2088,15 @@ function showQuestBoardDetails(boardName) {
   if (quests.length) {
     html += '<ul class="quest-list">';
     quests.forEach(q => {
-      html += `<li class="quest-item"><h3>${q.title}</h3><p>${q.description}</p></li>`;
+      html += `<li class="quest-item"><h3>${q.title}</h3><p>${q.description}</p>`;
+      html += '<ul class="quest-meta">';
+      if (q.location) html += `<li><strong>Location:</strong> ${q.location}</li>`;
+      if (q.requirements) html += `<li><strong>Requirements:</strong> ${Array.isArray(q.requirements) ? q.requirements.join(', ') : q.requirements}</li>`;
+      if (q.conditions) html += `<li><strong>Conditions:</strong> ${Array.isArray(q.conditions) ? q.conditions.join(', ') : q.conditions}</li>`;
+      if (q.timeline) html += `<li><strong>Timeline:</strong> ${q.timeline}</li>`;
+      if (q.risks) html += `<li><strong>Risks:</strong> ${Array.isArray(q.risks) ? q.risks.join(', ') : q.risks}</li>`;
+      if (q.reward) html += `<li><strong>Reward:</strong> ${q.reward}</li>`;
+      html += '</ul></li>';
     });
     html += '</ul>';
   } else {


### PR DESCRIPTION
## Summary
- include quest list and helper-driven quest creation in location data
- enrich Quest objects with requirements, conditions, timeline, risks and reward fields
- show full quest details on quest board view

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68c0a1926b848325857a25a87127ee1a