### PR TITLE
Use icon graphics for top menu buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,24 +9,20 @@
 <body class="theme-light">
   <div id="app">
 <nav class="top-menu">
-  <button id="menu-button" aria-label="Menu">☰</button>
+  <button id="menu-button" aria-label="Menu">
+    <img src="assets/images/icons/Menu.png" alt="Menu">
+  </button>
   <button id="back-button" aria-label="Back" style="display:none;">
     <svg viewBox="0 0 24 24">
       <path d="M15 19l-7-7 7-7v14z" />
     </svg>
   </button>
   <button id="character-button" aria-label="Character" style="display:none;">
-    <svg viewBox="0 0 24 24">
-      <circle cx="12" cy="8" r="4" />
-      <path d="M4 20c0-4 4-6 8-6s8 2 8 6" />
-    </svg>
+    <img id="character-icon" src="assets/images/icons/Character Menu Male.png" alt="Character">
   </button>
   <div class="settings-group">
     <button id="settings-button" aria-label="Settings">
-      <svg viewBox="0 0 24 24">
-        <circle cx="12" cy="12" r="3" />
-        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9A1.65 1.65 0 0 0 10.51 3.09V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9A1.65 1.65 0 0 0 20.91 10.51H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-      </svg>
+      <img src="assets/images/icons/Settings.png" alt="Settings">
     </button>
     <div id="settings-panel">
       <button id="theme-toggle" aria-label="Toggle theme"></button>

--- a/script.js
+++ b/script.js
@@ -2953,8 +2953,19 @@ function toggleCityMap(btn) {
 
 
 function updateCharacterButton() {
-  characterButton.style.display = currentCharacter ? 'inline-flex' : 'none';
-  if (!currentCharacter) mapContainer.style.display = 'none';
+  if (!currentCharacter) {
+    characterButton.style.display = 'none';
+    mapContainer.style.display = 'none';
+    return;
+  }
+  const iconFile = currentCharacter.sex === 'Male'
+    ? 'Character Menu Male.png'
+    : 'Character Menu Female.png';
+  const characterIcon = document.getElementById('character-icon');
+  if (characterIcon) {
+    characterIcon.src = `assets/images/icons/${iconFile}`;
+  }
+  characterButton.style.display = 'inline-flex';
 }
 
 menuButton.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -79,13 +79,19 @@ main {
     cursor: pointer;
   }
 
-  .top-menu button svg {
+  .top-menu button svg,
+  .top-menu button img {
     width: 70%;
     height: 70%;
+    display: block;
+  }
+  .top-menu button img {
+    object-fit: contain;
+  }
+  .top-menu button svg {
     stroke: currentColor;
     stroke-width: 2;
     fill: none;
-    display: block;
   }
   #back-button svg {
     width: 80%;


### PR DESCRIPTION
## Summary
- Swap menu, character, and settings buttons to use PNG icons from the icons folder
- Show gender-specific character icon and hide the button when no character is loaded
- Support image icons in top-menu styles

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b6530f788325adfe3f02115cfe2c