### PR TITLE
Use icons for settings panel controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,9 +25,15 @@
       <img src="assets/images/icons/Settings.png" alt="Settings">
     </button>
     <div id="settings-panel">
-      <button id="theme-toggle" aria-label="Toggle theme"></button>
-      <button id="scale-dec" aria-label="Decrease UI size">-</button>
-      <button id="scale-inc" aria-label="Increase UI size">+</button>
+      <button id="theme-toggle" aria-label="Toggle theme">
+        <img src="assets/images/icons/Theme.png" alt="Theme">
+      </button>
+      <button id="scale-dec" aria-label="Decrease UI size">
+        <img src="assets/images/icons/Minus.png" alt="Decrease">
+      </button>
+      <button id="scale-inc" aria-label="Increase UI size">
+        <img src="assets/images/icons/Plus.png" alt="Increase">
+      </button>
     </div>
   </div>
   </nav>

--- a/script.js
+++ b/script.js
@@ -2885,14 +2885,6 @@ settingsButton.addEventListener('click', () => {
 // Theme toggle
 const themeToggle = document.getElementById('theme-toggle');
 const themes = ['light', 'dark', 'sepia'];
-const themeIcons = {
-  light:
-    '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="4"/><line x1="12" y1="20" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="4" y2="12"/><line x1="20" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>',
-  dark:
-    '<svg viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>',
-  sepia:
-    '<svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="5"/><rect x="11" y="13" width="2" height="8"/></svg>'
-};
 let currentThemeIndex = themes.indexOf(
   [...body.classList].find(c => c.startsWith('theme-')).replace('theme-', '')
 );
@@ -2900,7 +2892,6 @@ const setTheme = index => {
   body.classList.remove('theme-light', 'theme-dark', 'theme-sepia');
   const theme = themes[index];
   body.classList.add(`theme-${theme}`);
-  themeToggle.innerHTML = themeIcons[theme];
   savePreference('theme', theme);
 };
 themeToggle.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -72,8 +72,6 @@ main {
     background: none;
     color: var(--menu-color-light);
     -webkit-text-stroke: 1px var(--menu-color-dark);
-    filter: none;
-    transition: filter 0.3s ease;
     cursor: pointer;
   }
 
@@ -82,6 +80,8 @@ main {
     width: 70%;
     height: 70%;
     display: block;
+    filter: none;
+    transition: filter 0.3s ease;
   }
   .top-menu button img {
     object-fit: contain;
@@ -97,22 +97,15 @@ main {
     stroke: none;
     fill: currentColor;
   }
-  #menu-button,
-  #back-button,
-  #scale-dec,
-  #scale-inc {
-    -webkit-text-stroke: 0;
-    line-height: 1;
-  }
+#menu-button,
+#back-button,
+#scale-dec,
+#scale-inc {
+  -webkit-text-stroke: 0;
+  line-height: 1;
+}
 
-  #scale-dec,
-  #scale-inc {
-    font-size: calc(var(--menu-button-size) * 0.9);
-  }
-
-  body.theme-dark #menu-button,
-  body.theme-dark #scale-dec,
-  body.theme-dark #scale-inc {
+  body.theme-dark #menu-button {
     color: var(--menu-color-dark);
   }
 
@@ -120,8 +113,10 @@ main {
     color: #555555;
   }
 
-.top-menu button:hover,
-.top-menu button:active {
+.top-menu button:hover svg,
+.top-menu button:hover img,
+.top-menu button:active svg,
+.top-menu button:active img {
   filter: drop-shadow(0 0 4px rgba(0,0,0,0.5));
 }
 


### PR DESCRIPTION
## Summary
- Replace text theme and scale controls with repository icons
- Apply drop-shadow hover effect to individual icons to avoid square borders
- Remove inline SVG theme icons from script

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c214e894908325a79fade3d70b1c63