### PR TITLE
feat: double top menu icon size

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@
   --hp-color: #ff0000;
   --mp-color: #0000ff;
   --stamina-color: #00ff00;
-  --menu-button-size: 2.5rem;
+  --menu-button-size: 5rem;
   --menu-height: calc(var(--menu-button-size) + 4px);
 }
 


### PR DESCRIPTION
## Summary
- enlarge top menu icons by doubling the menu button size

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68c23c09faf083259e2d5405307319d7