### PR TITLE
Remove unused code and parameters

### DIFF
--- a/assets/data/singing_songs.ts
+++ b/assets/data/singing_songs.ts
@@ -111,9 +111,6 @@ const BUFF_REGEN: Omit<Song,"id">[] = [
 ];
 
 /* ========================= Elemental Songs (unique mechanics) ========================= */
-
-const ELEMENTS: Element[] = ["Stone","Water","Wind","Fire","Ice","Thunder","Dark","Light"];
-
 /** @33 — Elemental Overtures: periodic **pulses** with unique side effects (not resist/weakness/infusion/shield) */
 const ELEMENTAL_OVERTURES_33: Omit<Song,"id">[] = [
   {

--- a/assets/data/summoning_proficiency.ts
+++ b/assets/data/summoning_proficiency.ts
@@ -143,7 +143,7 @@ export const SUMMON_CFG: SummoningProgressionConfig = {
 
 /* ========================= Internal helpers ========================= */
 
-function rng(cfg: SummoningProgressionConfig, override?: () => number) {
+function rng(override?: () => number) {
   return override ?? Math.random;
 }
 
@@ -214,7 +214,7 @@ export function gainSummoningProficiency(input: SummoningGainInput, cfg: Summoni
     P, cap, actorLevel, enemyLevelAvg, context, thresholds
   } = input;
 
-  const R = rng(cfg, input.rng);
+  const R = rng(input.rng);
   const W_ctx = cfg.contextWeight[context];
   if (W_ctx <= 0) return r2(P);
 

--- a/assets/data/summons.ts
+++ b/assets/data/summons.ts
@@ -114,8 +114,6 @@ function applyAttrVariance(base: number, attrs: Record<Attr, number>, keys: Attr
   return base * factor;
 }
 
-const clamp0 = (x:number)=>Math.max(0,x);
-
 /* ========================= The Summon List (24 entries) ========================= */
 
 function mkUnlock(form: Form): UnlockCondition {

--- a/assets/data/timing_engine.ts
+++ b/assets/data/timing_engine.ts
@@ -288,7 +288,6 @@ export class TimingEngine {
   advance(dtMs: Ms, getMember?: (id:Id)=>{ resources:{HP:number;MP:number;Stamina:number;HPMax:number;MPMax:number;StaminaMax:number}}|undefined) {
     if (dtMs <= 0) return;
 
-    const prev = this.clock.now;
     this.clock.advance(dtMs);
 
     // Flush any scheduled completions


### PR DESCRIPTION
## Summary
- remove unused element array from singing songs data
- drop unused RNG config parameter and adjust call site
- delete redundant helpers in summons list and timing engine

## Testing
- `npx tsc --noEmit --noUnusedLocals --noUnusedParameters`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c437e69f248325852fcb03a6c6776d