### PR TITLE
Expand creature and crop data with lifecycle fields

### DIFF
--- a/data/animals.json
+++ b/data/animals.json
@@ -2,143 +2,108 @@
   {
     "id": "chicken",
     "common_name": "Chicken",
-    "alt_names": [
-      "Domestic fowl"
-    ],
+    "alt_names": ["Domestic fowl"],
     "taxon_group": "bird",
-    "regions": [
-      "terrestrial",
-      "urban"
-    ],
-    "habitats": [
-      "farmland",
-      "urban",
-      "meadow",
-      "deciduous_forest"
-    ],
-    "diet": [
-      "omnivore",
-      "insectivore"
-    ],
-    "food_sources": [
-      "seeds",
-      "kitchen scraps",
-      "insects",
-      "worms"
-    ],
-    "domestication": {
-      "domesticated": true,
-      "trainable": false,
-      "draft_or_mount": false,
-      "notes": "Kept for eggs and meat; easy to pen."
-    },
-    "behavior": {
-      "aggressive": false,
-      "territorial": false,
-      "risk_to_humans": "none",
-      "nocturnal": false
-    },
-    "edibility": {
-      "edible": true,
-      "parts": [
-        "meat",
-        "eggs"
-      ]
-    },
-    "disease_risks": [
-      "parasites"
-    ],
+    "regions": ["terrestrial","urban"],
+    "habitats": ["farmland","urban","meadow","deciduous_forest"],
+    "diet": ["omnivore","insectivore"],
+    "food_sources": ["seeds","kitchen scraps","insects","worms"],
+    "domestication": {"domesticated": true, "trainable": false, "draft_or_mount": false, "notes": "Kept for eggs and meat; easy to pen."},
+    "behavior": {"aggressive": false, "territorial": false, "risk_to_humans": "none", "nocturnal": false},
+    "edibility": {"edible": true, "parts": ["meat","eggs"]},
+    "disease_risks": ["parasites"],
     "byproducts": [
-      {
-        "type": "egg",
-        "notes": "Daily in season",
-        "yield_unit": "pcs/week",
-        "avg_yield": 5,
-        "harvest_method": "domesticated"
-      },
-      {
-        "type": "meat",
-        "yield_unit": "kg",
-        "harvest_method": "either"
-      },
-      {
-        "type": "feather",
-        "harvest_method": "either"
-      },
-      {
-        "type": "bone",
-        "harvest_method": "either"
-      }
+      {"type": "egg", "notes": "Daily in season", "yield_unit": "pcs/week", "avg_yield": 5, "harvest_method": "domesticated"},
+      {"type": "meat", "yield_unit": "kg", "harvest_method": "either"},
+      {"type": "feather", "harvest_method": "either"},
+      {"type": "bone", "harvest_method": "either"}
     ],
-    "gendered": {
-      "male": "rooster",
-      "female": "hen",
-      "juvenile": "chick",
-      "collective": "flock"
-    },
+    "gendered": {"male": "rooster", "female": "hen", "juvenile": "chick", "collective": "flock"},
     "size_class": "small",
-    "narrative": "Common yard fowl scratching at dawn for seeds and beetles; prized for steady eggs and a pot on cold nights."
+    "mating_season": "spring (March–May)",
+    "gestation_period": "21 days",
+    "reproduction_notes": "Hens lay clutches of a dozen eggs; broody hens hatch in three weeks.",
+    "production_cycles": {"egg_laying_frequency": "nearly daily in spring and summer", "milk_production_duration": "", "wool_shearing_cycle": ""},
+    "butchering_age": "6–12 months for table birds",
+    "narrative": "From sunrise the village flock struts between huts, scratching dung heaps for beetles and spilled grain. Hens fill wicker baskets with eggs that tithe collectors count by the dozen, while roosters rule dunghill thrones and crow warnings at strangers. Winter feed is dear, so culls happen before Yule, and gossip claims poachers earn whipping posts for stealing church birds. Children charm tame hens with crumbs, yet tales tell of witches who borrow a black rooster for midnight rites. Come feast days, a plump capon simmered with herbs marks prosperity."
   },
   {
     "id": "draft-horse",
     "common_name": "Draft Horse",
-    "alt_names": [
-      "Cart horse",
-      "Plow horse"
-    ],
+    "alt_names": ["Cart horse","Plow horse"],
     "taxon_group": "mammal",
-    "regions": [
-      "terrestrial",
-      "urban"
-    ],
-    "habitats": [
-      "farmland",
-      "urban",
-      "meadow"
-    ],
-    "diet": [
-      "herbivore"
-    ],
-    "food_sources": [
-      "hay",
-      "oats",
-      "pasture grasses"
-    ],
-    "domestication": {
-      "domesticated": true,
-      "trainable": true,
-      "draft_or_mount": true,
-      "notes": "Harnessed for plow, cart, and mill."
-    },
-    "behavior": {
-      "aggressive": false,
-      "territorial": false,
-      "risk_to_humans": "low"
-    },
-    "edibility": {
-      "edible": false
-    },
+    "regions": ["terrestrial","urban"],
+    "habitats": ["farmland","urban","meadow"],
+    "diet": ["herbivore"],
+    "food_sources": ["hay","oats","pasture grasses"],
+    "domestication": {"domesticated": true, "trainable": true, "draft_or_mount": true, "notes": "Harnessed for plow, cart, and mill."},
+    "behavior": {"aggressive": false, "territorial": false, "risk_to_humans": "low"},
+    "edibility": {"edible": false},
     "byproducts": [
-      {
-        "type": "labor",
-        "notes": "Draft power"
-      },
-      {
-        "type": "hide",
-        "harvest_method": "wild"
-      },
-      {
-        "type": "bone",
-        "harvest_method": "wild"
-      }
+      {"type": "labor", "notes": "Draft power"},
+      {"type": "hide", "harvest_method": "wild"},
+      {"type": "bone", "harvest_method": "wild"}
     ],
-    "gendered": {
-      "male": "stallion",
-      "female": "mare",
-      "juvenile": "foal",
-      "collective": "team"
-    },
+    "gendered": {"male": "stallion", "female": "mare", "juvenile": "foal", "collective": "team"},
     "size_class": "large",
-    "narrative": "Broad of shoulder and steady of gait, these giants pull the village’s weight from furrow to market."
+    "mating_season": "late spring (April–June)",
+    "gestation_period": "340 days",
+    "reproduction_notes": "Mares foal once every other year when feed is plentiful.",
+    "production_cycles": {"egg_laying_frequency": "", "milk_production_duration": "6 months after foaling", "wool_shearing_cycle": ""},
+    "butchering_age": "15 years if lamed",
+    "narrative": "Broad-chested horses pull the plows that bite new furrows each spring, their iron-shod hooves churning mire to fertile loam. Guild charters decree which farms may hire them, and millers keep a stable for carts bearing grain and ale casks. A lame beast sells for glue and leather, so villagers bless harness bells against ill luck. Come autumn fairs, breeders parade towering stallions, demanding silver from nobles seeking war mounts. When famine strikes, whispers spread of desperate folk stewing horseflesh, a grim meal that invites clerical censure yet keeps freezing families alive."
+  },
+  {
+    "id": "arctic-hare",
+    "common_name": "Arctic Hare",
+    "alt_names": ["Polar hare"],
+    "taxon_group": "mammal",
+    "regions": ["polar_ice"],
+    "habitats": ["arctic_tundra","snowfields"],
+    "diet": ["herbivore"],
+    "food_sources": ["lichen","willow twigs","moss"],
+    "domestication": {"domesticated": false, "trainable": false, "draft_or_mount": false, "notes": "Hunted for meat and fur"},
+    "behavior": {"aggressive": false, "territorial": false, "risk_to_humans": "none", "nocturnal": false, "migratory": true},
+    "edibility": {"edible": true, "parts": ["meat"], "preparation_notes": "Stewed with root vegetables", "taboo_or_restricted": false},
+    "disease_risks": ["tularemia"],
+    "byproducts": [
+      {"type": "meat", "yield_unit": "kg", "avg_yield": 3, "harvest_method": "wild"},
+      {"type": "fur", "yield_unit": "pelt", "avg_yield": 1, "harvest_method": "wild"}
+    ],
+    "gendered": {"male": "buck", "female": "doe", "juvenile": "leveret", "collective": "drove"},
+    "size_class": "small",
+    "mating_season": "late winter (February–March)",
+    "gestation_period": "50 days",
+    "reproduction_notes": "2–4 leverets per litter; multiple litters during the brief summer.",
+    "production_cycles": {"egg_laying_frequency": "", "milk_production_duration": "1 month", "wool_shearing_cycle": ""},
+    "butchering_age": "first summer after birth",
+    "narrative": "Snowshoe-fast hares skim wind-scoured tundra, turning blue shadows as auroras dance overhead. Hunters stalk their tracks when meat runs thin, snaring them with rawhide lines and blessing pelts for warmth. The white fur fetches coin in southern fairs, so smugglers lurk on sled trails despite patrols by the jarl’s men. Folktales warn that spirits of starving winters ride in hare shapes to test hospitality; refusing a share curses a household with blight. When spring melts drifts, leverets scatter and disappear, leaving barren hills until the first flurries whisper their return."
+  },
+  {
+    "id": "river-carp",
+    "common_name": "River Carp",
+    "alt_names": ["Common carp"],
+    "taxon_group": "fish",
+    "regions": ["aquatic"],
+    "habitats": ["rivers","lakes","ponds"],
+    "diet": ["omnivore","detritivore"],
+    "food_sources": ["algae","insects","detritus"],
+    "domestication": {"domesticated": true, "trainable": false, "draft_or_mount": false, "notes": "Raised in monastery ponds"},
+    "behavior": {"aggressive": false, "territorial": false, "risk_to_humans": "none", "nocturnal": false, "migratory": false},
+    "edibility": {"edible": true, "parts": ["meat","roe"], "preparation_notes": "Smoked or stewed", "taboo_or_restricted": false},
+    "disease_risks": ["parasites"],
+    "byproducts": [
+      {"type": "meat", "yield_unit": "kg", "avg_yield": 2, "harvest_method": "domesticated"},
+      {"type": "egg", "notes": "Roe prized for feasts", "yield_unit": "g", "avg_yield": 200, "harvest_method": "domesticated"},
+      {"type": "bone", "harvest_method": "either"}
+    ],
+    "gendered": {"male": "milt", "female": "roe", "juvenile": "fry", "collective": "school"},
+    "size_class": "medium",
+    "mating_season": "spring (April–May)",
+    "gestation_period": "5 days",
+    "reproduction_notes": "Females scatter thousands of eggs among reeds; few survive to adulthood.",
+    "production_cycles": {"egg_laying_frequency": "once yearly in spring", "milk_production_duration": "", "wool_shearing_cycle": ""},
+    "butchering_age": "2 years in ponds",
+    "narrative": "Monastic ponds teem with sluggish carp fattened on barley mash, their scales flashing bronze beneath the water’s skin. On fasting days the brethren net them for stew, selling surplus at market where fishmongers bargain hard. Local law fines those who poach from abbey ponds, yet hungry peasants sneak at night, believing the carp grant luck if swallowed whole. Each spring, swollen rivers flood the ponds and release a breeding run; children gather stranded fry in baskets to restock. Merchants prize cured carp as cheap sustenance for long caravan roads."
   }
 ]

--- a/data/plants.json
+++ b/data/plants.json
@@ -11,12 +11,16 @@
     "medicinal": false,
     "toxic": false,
     "culinary_uses": ["stew","pickle","pottage"],
-    "byproducts": [
-      { "type": "leaf", "yield_unit": "heads/season", "avg_yield": 3, "harvest_season": "autumn" }
-    ],
+    "byproducts": [{"type": "leaf", "yield_unit": "heads/season", "avg_yield": 3, "harvest_season": "autumn"}],
     "seasonality": "Sown spring; heads in late summer to autumn.",
-    "narrative": "Humble greens bound in tight heads; a staple for broth pots, salted barrels, and winter fare.",
-    "tiers": { "food_tier": ["Low Inn","Common","Fine","High Table"] }
+    "sowing_season": "early spring (March–April)",
+    "harvest_season": "late summer to autumn (August–October)",
+    "growth_duration": "120 days",
+    "companion_crops": ["onions","dill"],
+    "rotation_relationships": "Follows legumes; precedes root crops",
+    "fallow_notes": "Beds rest a season after heavy feeding",
+    "narrative": "From tiny seedlings set in spring, cabbages swell into tight green drums guarding villages against winter hunger. Women gather leaves after first frost, shredding them into vats that guild coopers seal with brine, spawning barrels of sourkraut that fetch taxes in coin. Worms and blight strike hard in wet years, so fields are ringed with marigolds and ash. Old wives mutter that burying a cabbage stump wards off pox, though priests scoff. When famine hits, thieves raid cabbage patches by moonlight, risking stocks and hunger-driven justice.",
+    "tiers": {"food_tier": ["Low Inn","Common","Fine","High Table"]}
   },
   {
     "id": "chanterelle",
@@ -31,12 +35,16 @@
     "medicinal": false,
     "toxic": false,
     "foraging_notes": "Fruiting after rains; avoid false look-alikes.",
-    "byproducts": [
-      { "type": "mushroom", "yield_unit": "basket", "harvest_season": "summer" }
-    ],
+    "byproducts": [{"type": "mushroom", "yield_unit": "basket", "harvest_season": "summer"}],
     "seasonality": "Summer to early autumn after wet weather.",
-    "narrative": "Golden trumpets rising from leaf-litter; a forest prize with a rich, peppery scent.",
-    "tiers": { "food_tier": ["Low Inn","Common","Fine","High Table"] }
+    "sowing_season": "spores spread in autumn",
+    "harvest_season": "mid-summer to early autumn (July–September)",
+    "growth_duration": "60 days from spore to fruit",
+    "companion_crops": ["oak","spruce"],
+    "rotation_relationships": "uncultivated; appears in mature forests",
+    "fallow_notes": "",
+    "narrative": "After warm rains the forest floor sprouts golden trumpets that glimmer like coin among leaf litter. Woodcutters whisper directions in exchange for ale, for guild foresters levy harsh fines on unmarked baskets. Nobles crave the peppery flesh at autumn banquets, so poachers creep at dawn to gather before patrols. Folklore claims fae leave chanterelles as trail markers for those who aid lost travelers; ignore them and you wake to a ring of toadstools around your bed. Spoiled mushrooms sicken greedy pickers, teaching caution amid the damp shadows.",
+    "tiers": {"food_tier": ["Low Inn","Common","Fine","High Table"]}
   },
   {
     "id": "apple-tree",
@@ -51,12 +59,18 @@
     "toxic": false,
     "culinary_uses": ["fruit","cider","pie"],
     "byproducts": [
-      { "type": "fruit", "yield_unit": "dozen", "harvest_season": "autumn" },
-      { "type": "wood", "notes": "hardwood" }
+      {"type": "fruit", "yield_unit": "dozen", "harvest_season": "autumn"},
+      {"type": "wood", "notes": "hardwood"}
     ],
     "seasonality": "Blossom in spring; fruit in late summer to autumn.",
-    "narrative": "Boughs bow with sweet red fruit come harvest, filling cellars and press alike.",
-    "tiers": { "food_tier": ["Low Inn","Common","Fine","High Table"] }
+    "sowing_season": "grafted in late winter or early spring",
+    "harvest_season": "late summer to autumn (August–October)",
+    "growth_duration": "5 years to first fruit",
+    "companion_crops": ["clover","garlic"],
+    "rotation_relationships": "perennial orchards; ground cropped with legumes or grazed",
+    "fallow_notes": "replanting beds rest one year",
+    "narrative": "Orchards ring hamlets with sweet blossom each spring, drawing bees whose hives the lord claims by tithe. Applewood presses groan come harvest as villagers churn cider for wages and winter stores. Children scramble up branches despite watchmen's threats, chasing the legend that a red apple eaten atop the tallest tree grants true love. Thieves covet dried rings and brandy casks, so guild factors seal cellars. When late frost kills blossom, prices soar and desperate folk trade heirlooms for a barrel. In good years, surplus fruit feeds swine and wandering pilgrims alike.",
+    "tiers": {"food_tier": ["Low Inn","Common","Fine","High Table"]}
   },
   {
     "id": "peppercorn",
@@ -70,12 +84,16 @@
     "medicinal": false,
     "toxic": false,
     "culinary_uses": ["spice"],
-    "byproducts": [
-      { "type": "spice", "yield_unit": "sack", "harvest_season": "summer" }
-    ],
+    "byproducts": [{"type": "spice", "yield_unit": "sack", "harvest_season": "summer"}],
     "seasonality": "Harvested when berries redden, then dried.",
-    "narrative": "Dried berries from far-off vines, black and biting on the tongue; dear in any market.",
-    "tiers": { "luxury_tier": ["Common","Fine","Luxury","Arcane"] }
+    "sowing_season": "spring (March–April) in tropics",
+    "harvest_season": "summer (June–August)",
+    "growth_duration": "3 years to full yield",
+    "companion_crops": ["coffee","cardamom"],
+    "rotation_relationships": "climbs support trees, replaces spent vines every 7 years",
+    "fallow_notes": "soil left fallow two years after vine removal",
+    "narrative": "Pepper vines climb damp posts along coastal plantations, their berries turning from green to blood-red under monsoon sun. Merchants guilds guard the spice road fiercely; smugglers caught with untaxed sacks face branding. In manor kitchens, a single pinch seasons stews and signals wealth, while apothecaries grind pepper with honey for winter chills. Sailors swear the vines arose from dragon's breath, and carrying a pouch wards off seasickness. Crop failure during storms drives prices skyward, sparking dockside riots. Priests forbid pepper on fast days, yet nobles sprinkle it anyway, claiming the sharp heat cleanses sin.",
+    "tiers": {"luxury_tier": ["Common","Fine","Luxury","Arcane"]}
   },
   {
     "id": "saffron",
@@ -89,11 +107,41 @@
     "medicinal": false,
     "toxic": false,
     "culinary_uses": ["spice"],
-    "byproducts": [
-      { "type": "spice", "yield_unit": "dram", "harvest_season": "autumn" }
-    ],
+    "byproducts": [{"type": "spice", "yield_unit": "dram", "harvest_season": "autumn"}],
     "seasonality": "Blooms in autumn, stigmas gathered by hand.",
-    "narrative": "Crimson threads dearer than gold, lending hue and scent to royal fare.",
-    "tiers": { "luxury_tier": ["Common","Fine","Luxury","Arcane"] }
+    "sowing_season": "late summer (August–September)",
+    "harvest_season": "autumn (October–November)",
+    "growth_duration": "90 days",
+    "companion_crops": ["garlic","onions"],
+    "rotation_relationships": "follows cereals to suppress weeds",
+    "fallow_notes": "beds fallow every fourth year to regain vigor",
+    "narrative": "Each autumn crocus fields purple the hills as farmers rise before dawn to pluck crimson stigmas with chilled fingers. Three tiny threads flavor a pot, so caravans guard their chests well, and counterfeiters risk the gallows. Apothecaries praise saffron for brightening melancholy, while superstition says a sachet beneath the pillow wards nightmares. Guild law reserves first harvest for the duke’s table, driving smugglers to hollow loaves with hidden strands. Bad weather can ruin a season, forcing villages to choose between seed corn and spice, a gamble whispered over evening fires.",
+    "tiers": {"luxury_tier": ["Common","Fine","Luxury","Arcane"]}
+  },
+  {
+    "id": "rice",
+    "common_name": "Rice",
+    "growth_form": "grass",
+    "regions": ["wetlands_transitional","aquatic_fresh"],
+    "habitats": ["wetland","farmland","riverlands"],
+    "cultivated": true,
+    "edible": true,
+    "edible_parts": ["grain"],
+    "medicinal": false,
+    "toxic": false,
+    "culinary_uses": ["porridge","rice wine","flatbread"],
+    "byproducts": [
+      {"type": "grain", "yield_unit": "kg", "avg_yield": 300, "harvest_season": "autumn"},
+      {"type": "fiber", "notes": "straw for thatched roofs and mats", "yield_unit": "kg", "avg_yield": 500, "harvest_season": "autumn"}
+    ],
+    "seasonality": "Flooded paddies in spring; harvest in autumn",
+    "sowing_season": "spring (April–May)",
+    "harvest_season": "autumn (September–October)",
+    "growth_duration": "150 days",
+    "companion_crops": ["duckweed"],
+    "rotation_relationships": "follows pulse crops; paddies drained for barley in dry years",
+    "fallow_notes": "fields lie dry every third year to leech salts",
+    "narrative": "Rice paddies shimmer like mirrors, tamed by dikes that village elders open with carved keys each spring. Planters wade barefoot, pressing seedlings in lines while croaking frogs herald monsoon coming. Ducks forage among the shoots, eating pests and serving as living offerings to the water spirits who guard the levees. The grain feeds armies and tax collectors alike, yet drought or broken embankments invite famine and rebellion. Harvest feasts include rice wine and sticky cakes shared with travelers, but taking water out of turn earns exile, a punishment dreaded more than hunger.",
+    "tiers": {"food_tier": ["Low Inn","Common","Fine","High Table"]}
   }
 ]

--- a/dist/indexes/animals.byDiet.json
+++ b/dist/indexes/animals.byDiet.json
@@ -1,14 +1,18 @@
 {
   "herbivore": [
-    "draft-horse"
+    "draft-horse",
+    "arctic-hare"
   ],
   "carnivore": [],
   "omnivore": [
-    "chicken"
+    "chicken",
+    "river-carp"
   ],
   "insectivore": [
     "chicken"
   ],
-  "detritivore": [],
+  "detritivore": [
+    "river-carp"
+  ],
   "filter_feeder": []
 }

--- a/dist/indexes/animals.byHabitat.json
+++ b/dist/indexes/animals.byHabitat.json
@@ -1,27 +1,88 @@
 {
-  "coastal": [],
-  "riverlands": [],
-  "lake": [],
-  "wetland": [],
-  "grassland": [
+  "deep_sea": [],
+  "open_ocean": [],
+  "coral_reefs": [],
+  "kelp_forests": [],
+  "continental_shelves": [],
+  "estuaries": [],
+  "ocean_shores": [],
+  "rivers": [
+    "river-carp"
+  ],
+  "streams": [],
+  "lakes": [
+    "river-carp"
+  ],
+  "ponds": [
+    "river-carp"
+  ],
+  "springs": [],
+  "swamps": [],
+  "marshes": [],
+  "bogs": [],
+  "fens": [],
+  "floodplains": [],
+  "mangroves": [],
+  "brackish_marshlands": [],
+  "tidal_flats": [],
+  "tropical_rainforest": [],
+  "temperate_rainforest": [],
+  "deciduous_forest": [
+    "chicken"
+  ],
+  "boreal_forest": [],
+  "dry_forest": [],
+  "savanna": [],
+  "prairie": [],
+  "steppe": [],
+  "pampas": [],
+  "meadow": [
     "chicken",
     "draft-horse"
   ],
+  "hot_desert": [],
+  "cold_desert": [],
+  "semi_arid_scrublands": [],
+  "alpine_tundra": [],
+  "montane_forest": [],
+  "cliffs": [],
+  "scree_slopes": [],
+  "arctic_tundra": [
+    "arctic-hare"
+  ],
+  "subarctic_tundra": [],
+  "permafrost_zones": [],
+  "beaches": [],
+  "coastal_dunes": [],
+  "lagoons": [],
+  "barrier_islands": [],
+  "limestone_caves": [],
+  "lava_tubes": [],
+  "underground_rivers": [],
+  "underground_lakes": [],
+  "karst_systems": [],
+  "pack_ice": [],
+  "ice_shelves": [],
+  "glaciers": [],
+  "snowfields": [
+    "arctic-hare"
+  ],
+  "polar_deserts": [],
+  "volcanic_regions": [],
+  "geothermal_springs": [],
+  "high_altitude_plateaus": [],
+  "hyper_arid_salt_basins": [],
   "farmland": [
     "chicken",
     "draft-horse"
   ],
-  "forest": [
-    "chicken"
-  ],
-  "hills": [
-    "draft-horse"
-  ],
-  "mountains": [],
-  "desert": [],
-  "tundra": [],
+  "forest": [],
+  "grassland": [],
+  "hills": [],
   "urban": [
     "chicken",
     "draft-horse"
-  ]
+  ],
+  "riverlands": [],
+  "wetland": []
 }

--- a/dist/indexes/plants.byHabitat.json
+++ b/dist/indexes/plants.byHabitat.json
@@ -1,32 +1,90 @@
 {
-  "coastal": [],
-  "riverlands": [],
-  "lake": [],
-  "wetland": [],
-  "grassland": [
-    "cabbage"
-  ],
+  "deep_sea": [],
+  "open_ocean": [],
+  "coral_reefs": [],
+  "kelp_forests": [],
+  "continental_shelves": [],
+  "estuaries": [],
+  "ocean_shores": [],
+  "rivers": [],
+  "streams": [],
+  "lakes": [],
+  "ponds": [],
+  "springs": [],
+  "swamps": [],
+  "marshes": [],
+  "bogs": [],
+  "fens": [],
+  "floodplains": [],
+  "mangroves": [],
+  "brackish_marshlands": [],
+  "tidal_flats": [],
+  "tropical_rainforest": [],
+  "temperate_rainforest": [],
+  "deciduous_forest": [],
+  "boreal_forest": [],
+  "dry_forest": [],
+  "savanna": [],
+  "prairie": [],
+  "steppe": [],
+  "pampas": [],
+  "meadow": [],
+  "hot_desert": [],
+  "cold_desert": [],
+  "semi_arid_scrublands": [],
+  "alpine_tundra": [],
+  "montane_forest": [],
+  "cliffs": [],
+  "scree_slopes": [],
+  "arctic_tundra": [],
+  "subarctic_tundra": [],
+  "permafrost_zones": [],
+  "beaches": [],
+  "coastal_dunes": [],
+  "lagoons": [],
+  "barrier_islands": [],
+  "limestone_caves": [],
+  "lava_tubes": [],
+  "underground_rivers": [],
+  "underground_lakes": [],
+  "karst_systems": [],
+  "pack_ice": [],
+  "ice_shelves": [],
+  "glaciers": [],
+  "snowfields": [],
+  "polar_deserts": [],
+  "volcanic_regions": [],
+  "geothermal_springs": [],
+  "high_altitude_plateaus": [],
+  "hyper_arid_salt_basins": [],
   "farmland": [
     "cabbage",
     "apple-tree",
     "peppercorn",
-    "saffron"
+    "saffron",
+    "rice"
   ],
   "forest": [
     "chanterelle",
     "apple-tree",
     "peppercorn"
   ],
+  "grassland": [
+    "cabbage"
+  ],
   "hills": [
     "chanterelle",
     "apple-tree",
     "saffron"
   ],
-  "mountains": [],
-  "desert": [],
-  "tundra": [],
   "urban": [
     "cabbage",
     "apple-tree"
+  ],
+  "riverlands": [
+    "rice"
+  ],
+  "wetland": [
+    "rice"
   ]
 }

--- a/dist/indexes/plants.byTier.json
+++ b/dist/indexes/plants.byTier.json
@@ -3,22 +3,26 @@
     "Low Inn": [
       "cabbage",
       "chanterelle",
-      "apple-tree"
+      "apple-tree",
+      "rice"
     ],
     "Common": [
       "cabbage",
       "chanterelle",
-      "apple-tree"
+      "apple-tree",
+      "rice"
     ],
     "Fine": [
       "cabbage",
       "chanterelle",
-      "apple-tree"
+      "apple-tree",
+      "rice"
     ],
     "High Table": [
       "cabbage",
       "chanterelle",
-      "apple-tree"
+      "apple-tree",
+      "rice"
     ]
   },
   "luxury": {

--- a/schemas/animal.schema.json
+++ b/schemas/animal.schema.json
@@ -158,6 +158,19 @@
       }
     },
     "size_class": {"type": "string", "enum": ["tiny","small","medium","large","huge"]},
+    "mating_season": {"type": "string"},
+    "gestation_period": {"type": "string"},
+    "reproduction_notes": {"type": "string"},
+    "production_cycles": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "egg_laying_frequency": {"type": "string"},
+        "milk_production_duration": {"type": "string"},
+        "wool_shearing_cycle": {"type": "string"}
+      }
+    },
+    "butchering_age": {"type": "string"},
     "narrative": {"type": "string"}
   }
 }

--- a/schemas/plant.schema.json
+++ b/schemas/plant.schema.json
@@ -34,6 +34,12 @@
       }
     },
     "seasonality": {"type": "string"},
+    "sowing_season": {"type": "string"},
+    "harvest_season": {"type": "string"},
+    "growth_duration": {"type": "string"},
+    "companion_crops": {"type": "array", "items": {"type": "string"}},
+    "rotation_relationships": {"type": "string"},
+    "fallow_notes": {"type": "string"},
     "narrative": {"type": "string"},
     "tiers": {
       "type": "object",

--- a/src/types/animals.ts
+++ b/src/types/animals.ts
@@ -47,5 +47,14 @@ export interface Animal {
   byproducts: AnimalByproduct[];
   gendered: GenderedNames;
   size_class?: "tiny"|"small"|"medium"|"large"|"huge";
+  mating_season?: string;
+  gestation_period?: string;
+  reproduction_notes?: string;
+  production_cycles?: {
+    egg_laying_frequency?: string;
+    milk_production_duration?: string;
+    wool_shearing_cycle?: string;
+  };
+  butchering_age?: string;
   narrative: string;
 }

--- a/src/types/biomes.ts
+++ b/src/types/biomes.ts
@@ -40,7 +40,7 @@ export const HABITATS = [
   ...POLAR_ICE_HABITATS,
   ...EXTREME_HABITATS,
   // Anthropogenic or legacy categories
-  "farmland","forest","grassland","hills","urban",
+  "farmland","forest","grassland","hills","urban","riverlands","wetland",
 ] as const;
 export type Habitat = typeof HABITATS[number];
 

--- a/src/types/plants.ts
+++ b/src/types/plants.ts
@@ -25,6 +25,12 @@ export interface Plant {
   foraging_notes?: string;
   byproducts: PlantByproduct[];
   seasonality?: string;
+  sowing_season?: string;
+  harvest_season?: string;
+  growth_duration?: string;
+  companion_crops?: string[];
+  rotation_relationships?: string;
+  fallow_notes?: string;
   narrative: string;
   tiers?: {
     food_tier?: FoodTier[];


### PR DESCRIPTION
## Summary
- extend animal and plant schemas with lifecycle and farming fields
- enrich animal entries and add arctic hare and river carp
- add rice crop and upgrade existing plants with sowing and harvest info

## Testing
- `npm test`
- `npm run validate`
- `npm run build:indexes`


------
https://chatgpt.com/codex/tasks/task_e_68c4ca1815c08325898085f31837a1ee