### PR TITLE
feat: add lifecycle datasets for animals and plants

### DIFF
--- a/data/animals_lifecycle.json
+++ b/data/animals_lifecycle.json
@@ -1,0 +1,144 @@
+[
+  {
+    "id": "chicken",
+    "common_name": "Chicken",
+    "alt_names": ["Domestic fowl"],
+    "taxon_group": "bird",
+    "regions": ["terrestrial"],
+    "habitats": ["farmland","grassland"],
+    "diet": ["omnivore","insectivore"],
+    "food_sources": ["grain","insects","kitchen scraps"],
+    "domestication": {
+      "domesticated": true,
+      "trainable": false,
+      "draft_or_mount": false,
+      "notes": "Kept primarily for eggs and meat"
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low",
+      "nocturnal": false,
+      "migratory": false
+    },
+    "edibility": {
+      "edible": true,
+      "parts": ["meat","egg"],
+      "preparation_notes": "Cook thoroughly to avoid illness",
+      "taboo_or_restricted": false
+    },
+    "disease_risks": ["avian influenza"],
+    "byproducts": [
+      {
+        "type": "egg",
+        "notes": "Hens lay almost daily in warm seasons",
+        "yield_unit": "count",
+        "avg_yield": 280,
+        "harvest_method": "domesticated"
+      },
+      {
+        "type": "meat",
+        "notes": "Dressed weight from a six-month bird",
+        "yield_unit": "kg",
+        "avg_yield": 1.8,
+        "harvest_method": "either"
+      },
+      {
+        "type": "feather",
+        "notes": "Collected after natural molting",
+        "yield_unit": "g",
+        "avg_yield": 50,
+        "harvest_method": "domesticated"
+      }
+    ],
+    "gendered": {
+      "male": "rooster",
+      "female": "hen",
+      "juvenile": "chick",
+      "collective": "flock"
+    },
+    "size_class": "small",
+    "mating_season": "spring",
+    "gestation_period": "",
+    "incubation_period": "21 days",
+    "reproduction_notes": "Hens produce unfertilized eggs year-round; roosters needed for chicks",
+    "production_cycles": {
+      "egg_laying_frequency": "nearly daily",
+      "milk_production_duration": "",
+      "wool_shearing_cycle": ""
+    },
+    "butchering_age": "6 months",
+    "narrative": "The barnyard chicken scratches through village yards from dawn, clucking in constant search of grain and grubs. Hens settle into roosts at dusk, guarded by notoriously irritable roosters. In spring the birds grow prized for their nearly daily eggs, and monks in the nearby abbey barter for surplus to temper their fasting. Yet a law forbids slaughtering laying hens before Midsummer, ensuring steady trade but drawing poachers who try to snatch prized champions for cockfights. Folklore claims their crowing wards off marsh spirits, so villagers place woven charms in each coop."
+  },
+  {
+    "id": "draft-horse",
+    "common_name": "Draft Horse",
+    "alt_names": ["Shire"],
+    "taxon_group": "mammal",
+    "regions": ["terrestrial"],
+    "habitats": ["farmland","grassland","forest"],
+    "diet": ["herbivore","grazer"],
+    "food_sources": ["hay","pasture grasses","grain"],
+    "domestication": {
+      "domesticated": true,
+      "trainable": true,
+      "draft_or_mount": true,
+      "notes": "Bred for hauling heavy wagons and plows"
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate",
+      "nocturnal": false,
+      "migratory": false
+    },
+    "edibility": {
+      "edible": true,
+      "parts": ["meat","milk"],
+      "preparation_notes": "Meat often stewed; milk fermented as kumis",
+      "taboo_or_restricted": true
+    },
+    "disease_risks": ["glanders"],
+    "byproducts": [
+      {
+        "type": "hide",
+        "notes": "Tanned into durable leather",
+        "yield_unit": "kg",
+        "avg_yield": 40,
+        "harvest_method": "either"
+      },
+      {
+        "type": "bone",
+        "notes": "Leg bones carved into tools",
+        "yield_unit": "kg",
+        "avg_yield": 15,
+        "harvest_method": "either"
+      },
+      {
+        "type": "milk",
+        "notes": "Mares milked for foal; surplus fermented",
+        "yield_unit": "L",
+        "avg_yield": 5,
+        "harvest_method": "domesticated"
+      }
+    ],
+    "gendered": {
+      "male": "stallion",
+      "female": "mare",
+      "juvenile": "foal",
+      "collective": "team"
+    },
+    "size_class": "large",
+    "mating_season": "spring",
+    "gestation_period": "11 months",
+    "incubation_period": "",
+    "reproduction_notes": "Foals born late winter after spring breeding",
+    "production_cycles": {
+      "egg_laying_frequency": "",
+      "milk_production_duration": "6 months for foal",
+      "wool_shearing_cycle": ""
+    },
+    "butchering_age": "4 years",
+    "narrative": "Towering draft horses haul merchant caravans across the kingdom's plains. Calm but immense, they move slowly until spurred, then drag wagons over muddy roads with relentless patience. Foals whelped in spring are raised by teamsters' guilds who auction the best pairs only once a year, drawing nobles and smugglers alike. Rumors say that a royal edict forbids exporting bloodlines abroad, yet black-market breeders secretly ferry mares through forest passes, risking steep fines and confiscated tack. Old legends warn that disrespecting such beasts invites wagon wheels to splinter at crossroads."
+  }
+]

--- a/data/plants_lifecycle.json
+++ b/data/plants_lifecycle.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "apple-tree",
+    "common_name": "Apple Tree",
+    "alt_names": [],
+    "growth_form": "tree",
+    "regions": ["terrestrial"],
+    "habitats": ["farmland","forest"],
+    "cultivated": true,
+    "edible": true,
+    "edible_parts": ["fruit"],
+    "medicinal": false,
+    "toxic": true,
+    "toxicity_notes": "Seeds contain cyanogenic glycosides; avoid large quantities",
+    "culinary_uses": ["fresh eating","cider","baking"],
+    "foraging_notes": "Grafted varieties persist in abandoned orchards",
+    "byproducts": [
+      {
+        "type": "timber",
+        "notes": "Pruned branches and old trunks used for carving and smoke",
+        "yield_unit": "kg",
+        "avg_yield": 30,
+        "harvest_season": "winter"
+      },
+      {
+        "type": "fodder",
+        "notes": "Fallen leaves fed to livestock",
+        "yield_unit": "kg",
+        "avg_yield": 20,
+        "harvest_season": "autumn"
+      }
+    ],
+    "seasonality": "Deciduous; flowers in spring, fruit ripens in autumn",
+    "sowing_season": "spring",
+    "harvest_season": "autumn",
+    "growth_duration": "5 years to first fruit",
+    "companion_crops": ["chives","clover"],
+    "rotation_relationships": "Orchards with legume ground cover enrich soil",
+    "fallow_notes": "Prune annually; replant after 25 years to rejuvenate grove",
+    "narrative": "Apple trees line the valley's terraces, their spring blossoms drawing bees from miles away. Farmers graft favored varieties onto hardy rootstock, tending the orchard for five years before the first true harvest. In autumn, the Fruit-Tenders Guild inspects every barrel of cider and collects a tithe, punishing smuggling with confiscation of presses. Local folklore says that burying a wormy apple beneath your doorstep wards off roving spirits, so villagers trade bruised fruit at market despite the guild's complaints. Some elders claim the practice keeps winter famine at bay.",
+    "tiers": {
+      "food_tier": ["common","fine","high table"],
+      "luxury_tier": []
+    }
+  },
+  {
+    "id": "saffron",
+    "common_name": "Saffron Crocus",
+    "alt_names": ["Autumn crocus"],
+    "growth_form": "herb",
+    "regions": ["terrestrial"],
+    "habitats": ["farmland","semi_arid_scrublands"],
+    "cultivated": true,
+    "edible": true,
+    "edible_parts": ["flower"],
+    "medicinal": true,
+    "toxic": false,
+    "toxicity_notes": "",
+    "culinary_uses": ["spice"],
+    "foraging_notes": "Harvest stigmas at dawn before petals close",
+    "byproducts": [
+      {
+        "type": "dye",
+        "notes": "Petals yield a faint yellow dye",
+        "yield_unit": "g",
+        "avg_yield": 2,
+        "harvest_season": "autumn"
+      }
+    ],
+    "seasonality": "Blooms in autumn after summer dormancy",
+    "sowing_season": "summer",
+    "harvest_season": "autumn",
+    "growth_duration": "8 weeks from sprout to harvest",
+    "companion_crops": ["grapes"],
+    "rotation_relationships": "Rotate with cereals to prevent soil exhaustion",
+    "fallow_notes": "Fields rest after four years of continuous saffron",
+    "narrative": "Autumn-blooming saffron crocus carpets terraced hillsides in a haze of purple. Each dawn, pickers pluck the three crimson stigmas by hand, racing the sun before petals wilt. Merchant caravans purchase the threads at a premium, yet the Harvesters' Consortium restricts sales to licensed factors, punishing unsanctioned trade. Legends whisper that a single stolen bulb carries a decade of misfortune, so poachers work under masks and false names. During lean winters, villages hoard dried strands to spice thin porridge. Some alchemists barter secret cures for a pinch of the spice.",
+    "tiers": {
+      "food_tier": ["high table"],
+      "luxury_tier": ["luxury","arcane"]
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add animals_lifecycle.json with extended lifecycle and production info for chicken and draft horse
- add plants_lifecycle.json covering apple trees and saffron crocus with farming details and narratives

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4ef0375dc83258430d000185c1f6d