### PR TITLE
Add placeholder entries for missing animals and plants

### DIFF
--- a/data/animals.json
+++ b/data/animals.json
@@ -1,5 +1,320 @@
 [
   {
+    "id": "ant",
+    "common_name": "Ant",
+    "taxon_group": "insect",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "badger",
+    "common_name": "Badger",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "bear",
+    "common_name": "Bear",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "bison",
+    "common_name": "Bison",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "boar",
+    "common_name": "Boar",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "camel",
+    "common_name": "Camel",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hot_desert"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "carp",
+    "common_name": "Carp",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "lakes"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "cat",
+    "common_name": "Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "cattle",
+    "common_name": "Cattle",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "chicken",
     "common_name": "Chicken",
     "alt_names": [
@@ -80,6 +395,216 @@
     "narrative": "Common yard fowl scratching at dawn for seeds and beetles; prized for steady eggs and a pot on cold nights."
   },
   {
+    "id": "cod",
+    "common_name": "Cod",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "crane",
+    "common_name": "Crane",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "deer",
+    "common_name": "Deer",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "dog",
+    "common_name": "Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "donkey",
+    "common_name": "Donkey",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "dove",
+    "common_name": "Dove",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "draft-horse",
     "common_name": "Draft Horse",
     "alt_names": [
@@ -140,5 +665,1195 @@
     },
     "size_class": "large",
     "narrative": "Broad of shoulder and steady of gait, these giants pull the village’s weight from furrow to market."
+  },
+  {
+    "id": "duck",
+    "common_name": "Duck",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "eagle",
+    "common_name": "Eagle",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "cliffs"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "earthworm",
+    "common_name": "Earthworm",
+    "taxon_group": "annelid",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "diet": [
+      "detritivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "eel",
+    "common_name": "Eel",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "elk",
+    "common_name": "Elk",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "falcon",
+    "common_name": "Falcon",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "fox",
+    "common_name": "Fox",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "frog",
+    "common_name": "Frog",
+    "taxon_group": "amphibian",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "goat",
+    "common_name": "Goat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "goose",
+    "common_name": "Goose",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "hare",
+    "common_name": "Hare",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "hawk",
+    "common_name": "Hawk",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "hedgehog",
+    "common_name": "Hedgehog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "herring",
+    "common_name": "Herring",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "honeybee",
+    "common_name": "Honeybee",
+    "taxon_group": "insect",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "horse",
+    "common_name": "Horse",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "lynx",
+    "common_name": "Lynx",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "mouse",
+    "common_name": "Mouse",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "mule",
+    "common_name": "Mule",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "owl",
+    "common_name": "Owl",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "peafowl",
+    "common_name": "Peafowl",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "pig",
+    "common_name": "Pig",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "pigeon",
+    "common_name": "Pigeon",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "rabbit",
+    "common_name": "Rabbit",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "rat",
+    "common_name": "Rat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "sheep",
+    "common_name": "Sheep",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "snail",
+    "common_name": "Snail",
+    "taxon_group": "mollusk",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "snake",
+    "common_name": "Snake",
+    "taxon_group": "reptile",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "squirrel",
+    "common_name": "Squirrel",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "swan",
+    "common_name": "Swan",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "lakes"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "toad",
+    "common_name": "Toad",
+    "taxon_group": "amphibian",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "trout",
+    "common_name": "Trout",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "wildcat",
+    "common_name": "Wildcat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "wolf",
+    "common_name": "Wolf",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ]
+    },
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
   }
 ]

--- a/data/plants.json
+++ b/data/plants.json
@@ -1,99 +1,1124 @@
 [
   {
-    "id": "cabbage",
-    "common_name": "Cabbage",
+    "id": "angelica",
+    "common_name": "Angelica",
     "growth_form": "herb",
-    "regions": ["terrestrial","urban"],
-    "habitats": ["farmland","urban","grassland"],
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
     "cultivated": true,
     "edible": true,
-    "edible_parts": ["leaf"],
-    "medicinal": false,
-    "toxic": false,
-    "culinary_uses": ["stew","pickle","pottage"],
     "byproducts": [
-      { "type": "leaf", "yield_unit": "heads/season", "avg_yield": 3, "harvest_season": "autumn" }
+      {
+        "type": "other"
+      }
     ],
-    "seasonality": "Sown spring; heads in late summer to autumn.",
-    "narrative": "Humble greens bound in tight heads; a staple for broth pots, salted barrels, and winter fare.",
-    "tiers": { "food_tier": ["Low Inn","Common","Fine","High Table"] }
-  },
-  {
-    "id": "chanterelle",
-    "common_name": "Chanterelle",
-    "alt_names": ["Golden chanterelle"],
-    "growth_form": "mushroom",
-    "regions": ["terrestrial"],
-    "habitats": ["forest","hills"],
-    "cultivated": false,
-    "edible": true,
-    "edible_parts": ["mushroom"],
-    "medicinal": false,
-    "toxic": false,
-    "foraging_notes": "Fruiting after rains; avoid false look-alikes.",
-    "byproducts": [
-      { "type": "mushroom", "yield_unit": "basket", "harvest_season": "summer" }
-    ],
-    "seasonality": "Summer to early autumn after wet weather.",
-    "narrative": "Golden trumpets rising from leaf-litter; a forest prize with a rich, peppery scent.",
-    "tiers": { "food_tier": ["Low Inn","Common","Fine","High Table"] }
+    "narrative": ""
   },
   {
     "id": "apple-tree",
     "common_name": "Apple Tree",
     "growth_form": "tree",
-    "regions": ["terrestrial","urban"],
-    "habitats": ["farmland","forest","urban","hills"],
+    "regions": [
+      "terrestrial",
+      "urban"
+    ],
+    "habitats": [
+      "farmland",
+      "forest",
+      "urban",
+      "hills"
+    ],
     "cultivated": true,
     "edible": true,
-    "edible_parts": ["fruit"],
+    "edible_parts": [
+      "fruit"
+    ],
     "medicinal": false,
     "toxic": false,
-    "culinary_uses": ["fruit","cider","pie"],
+    "culinary_uses": [
+      "fruit",
+      "cider",
+      "pie"
+    ],
     "byproducts": [
-      { "type": "fruit", "yield_unit": "dozen", "harvest_season": "autumn" },
-      { "type": "wood", "notes": "hardwood" }
+      {
+        "type": "fruit",
+        "yield_unit": "dozen",
+        "harvest_season": "autumn"
+      },
+      {
+        "type": "wood",
+        "notes": "hardwood"
+      }
     ],
     "seasonality": "Blossom in spring; fruit in late summer to autumn.",
     "narrative": "Boughs bow with sweet red fruit come harvest, filling cellars and press alike.",
-    "tiers": { "food_tier": ["Low Inn","Common","Fine","High Table"] }
+    "tiers": {
+      "food_tier": [
+        "Low Inn",
+        "Common",
+        "Fine",
+        "High Table"
+      ]
+    }
+  },
+  {
+    "id": "barley",
+    "common_name": "Barley",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "beets",
+    "common_name": "Beets",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "blackberries",
+    "common_name": "Blackberries",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "broad-beans",
+    "common_name": "Broad beans",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "buckwheat",
+    "common_name": "Buckwheat",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "cabbage",
+    "common_name": "Cabbage",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial",
+      "urban"
+    ],
+    "habitats": [
+      "farmland",
+      "urban",
+      "grassland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "edible_parts": [
+      "leaf"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "culinary_uses": [
+      "stew",
+      "pickle",
+      "pottage"
+    ],
+    "byproducts": [
+      {
+        "type": "leaf",
+        "yield_unit": "heads/season",
+        "avg_yield": 3,
+        "harvest_season": "autumn"
+      }
+    ],
+    "seasonality": "Sown spring; heads in late summer to autumn.",
+    "narrative": "Humble greens bound in tight heads; a staple for broth pots, salted barrels, and winter fare.",
+    "tiers": {
+      "food_tier": [
+        "Low Inn",
+        "Common",
+        "Fine",
+        "High Table"
+      ]
+    }
+  },
+  {
+    "id": "carrots",
+    "common_name": "Carrots",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "chamomile",
+    "common_name": "Chamomile",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "chanterelle",
+    "common_name": "Chanterelle",
+    "alt_names": [
+      "Golden chanterelle"
+    ],
+    "growth_form": "mushroom",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "hills"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "edible_parts": [
+      "mushroom"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Fruiting after rains; avoid false look-alikes.",
+    "byproducts": [
+      {
+        "type": "mushroom",
+        "yield_unit": "basket",
+        "harvest_season": "summer"
+      }
+    ],
+    "seasonality": "Summer to early autumn after wet weather.",
+    "narrative": "Golden trumpets rising from leaf-litter; a forest prize with a rich, peppery scent.",
+    "tiers": {
+      "food_tier": [
+        "Low Inn",
+        "Common",
+        "Fine",
+        "High Table"
+      ]
+    }
+  },
+  {
+    "id": "cherries",
+    "common_name": "Cherries",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "chestnuts",
+    "common_name": "Chestnuts",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "chickpeas",
+    "common_name": "Chickpeas",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "figs",
+    "common_name": "Figs",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "flax",
+    "common_name": "Flax",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "garlic",
+    "common_name": "Garlic",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "grapes",
+    "common_name": "Grapes",
+    "growth_form": "vine",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "hazelnuts",
+    "common_name": "Hazelnuts",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "hemp",
+    "common_name": "Hemp",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "lavender",
+    "common_name": "Lavender",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "leeks",
+    "common_name": "Leeks",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "lentils",
+    "common_name": "Lentils",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "millet",
+    "common_name": "Millet",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "mint",
+    "common_name": "Mint",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "mulberries",
+    "common_name": "Mulberries",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "mustard",
+    "common_name": "Mustard",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "oats",
+    "common_name": "Oats",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "olives",
+    "common_name": "Olives",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "onions",
+    "common_name": "Onions",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "parsnips",
+    "common_name": "Parsnips",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "pears",
+    "common_name": "Pears",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "peas",
+    "common_name": "Peas",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
   },
   {
     "id": "peppercorn",
     "common_name": "Peppercorns",
     "growth_form": "vine",
-    "regions": ["terrestrial"],
-    "habitats": ["forest","farmland"],
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "farmland"
+    ],
     "cultivated": true,
     "edible": true,
-    "edible_parts": ["seed"],
+    "edible_parts": [
+      "seed"
+    ],
     "medicinal": false,
     "toxic": false,
-    "culinary_uses": ["spice"],
+    "culinary_uses": [
+      "spice"
+    ],
     "byproducts": [
-      { "type": "spice", "yield_unit": "sack", "harvest_season": "summer" }
+      {
+        "type": "spice",
+        "yield_unit": "sack",
+        "harvest_season": "summer"
+      }
     ],
     "seasonality": "Harvested when berries redden, then dried.",
     "narrative": "Dried berries from far-off vines, black and biting on the tongue; dear in any market.",
-    "tiers": { "luxury_tier": ["Common","Fine","Luxury","Arcane"] }
+    "tiers": {
+      "luxury_tier": [
+        "Common",
+        "Fine",
+        "Luxury",
+        "Arcane"
+      ]
+    }
+  },
+  {
+    "id": "plums",
+    "common_name": "Plums",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "poppy",
+    "common_name": "Poppy",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "quinces",
+    "common_name": "Quinces",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "radishes",
+    "common_name": "Radishes",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "raspberries",
+    "common_name": "Raspberries",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "rosemary",
+    "common_name": "Rosemary",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "rue",
+    "common_name": "Rue",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "rye",
+    "common_name": "Rye",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
   },
   {
     "id": "saffron",
     "common_name": "Saffron",
     "growth_form": "herb",
-    "regions": ["terrestrial"],
-    "habitats": ["farmland","hills"],
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "hills"
+    ],
     "cultivated": true,
     "edible": true,
-    "edible_parts": ["flower"],
+    "edible_parts": [
+      "flower"
+    ],
     "medicinal": false,
     "toxic": false,
-    "culinary_uses": ["spice"],
+    "culinary_uses": [
+      "spice"
+    ],
     "byproducts": [
-      { "type": "spice", "yield_unit": "dram", "harvest_season": "autumn" }
+      {
+        "type": "spice",
+        "yield_unit": "dram",
+        "harvest_season": "autumn"
+      }
     ],
     "seasonality": "Blooms in autumn, stigmas gathered by hand.",
     "narrative": "Crimson threads dearer than gold, lending hue and scent to royal fare.",
-    "tiers": { "luxury_tier": ["Common","Fine","Luxury","Arcane"] }
+    "tiers": {
+      "luxury_tier": [
+        "Common",
+        "Fine",
+        "Luxury",
+        "Arcane"
+      ]
+    }
+  },
+  {
+    "id": "sage",
+    "common_name": "Sage",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "shallots",
+    "common_name": "Shallots",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "spelt",
+    "common_name": "Spelt",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "st-johns-wort",
+    "common_name": "St. John's Wort",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "strawberries",
+    "common_name": "Strawberries",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "thyme",
+    "common_name": "Thyme",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "turnips",
+    "common_name": "Turnips",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "walnuts",
+    "common_name": "Walnuts",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "wheat",
+    "common_name": "Wheat",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "yarrow",
+    "common_name": "Yarrow",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "other"
+      }
+    ],
+    "narrative": ""
   }
 ]

--- a/scripts/addMissingEntries.js
+++ b/scripts/addMissingEntries.js
@@ -1,0 +1,117 @@
+import { readFile, writeFile } from 'fs/promises';
+import slugify from 'slugify';
+
+const animalsList = [
+  // missing animals
+  { name: 'Cattle', taxon: 'mammal', habitat: 'farmland', domesticated: true, diet: 'herbivore' },
+  { name: 'Sheep', taxon: 'mammal', habitat: 'farmland', domesticated: true, diet: 'herbivore' },
+  { name: 'Goat', taxon: 'mammal', habitat: 'farmland', domesticated: true, diet: 'herbivore' },
+  { name: 'Pig', taxon: 'mammal', habitat: 'farmland', domesticated: true, diet: 'omnivore' },
+  { name: 'Duck', taxon: 'bird', habitat: 'farmland', domesticated: true, diet: 'omnivore' },
+  { name: 'Goose', taxon: 'bird', habitat: 'farmland', domesticated: true, diet: 'omnivore' },
+  { name: 'Donkey', taxon: 'mammal', habitat: 'farmland', domesticated: true, diet: 'herbivore' },
+  { name: 'Dog', taxon: 'mammal', habitat: 'urban', domesticated: true, diet: 'omnivore' },
+  { name: 'Cat', taxon: 'mammal', habitat: 'urban', domesticated: true, diet: 'carnivore' },
+  { name: 'Honeybee', taxon: 'insect', habitat: 'farmland', domesticated: true, diet: 'herbivore' },
+  { name: 'Deer', taxon: 'mammal', habitat: 'forest', domesticated: false, diet: 'herbivore' },
+  { name: 'Rabbit', taxon: 'mammal', habitat: 'farmland', domesticated: true, diet: 'herbivore' },
+  { name: 'Horse', taxon: 'mammal', habitat: 'farmland', domesticated: true, diet: 'herbivore' },
+  { name: 'Mule', taxon: 'mammal', habitat: 'farmland', domesticated: true, diet: 'herbivore' },
+  { name: 'Falcon', taxon: 'bird', habitat: 'forest', domesticated: false, diet: 'carnivore' },
+  { name: 'Pigeon', taxon: 'bird', habitat: 'urban', domesticated: true, diet: 'herbivore' },
+  { name: 'Dove', taxon: 'bird', habitat: 'forest', domesticated: false, diet: 'herbivore' },
+  { name: 'Boar', taxon: 'mammal', habitat: 'forest', domesticated: false, diet: 'omnivore' },
+  { name: 'Hare', taxon: 'mammal', habitat: 'forest', domesticated: false, diet: 'herbivore' },
+  { name: 'Bear', taxon: 'mammal', habitat: 'forest', domesticated: false, diet: 'omnivore' },
+  { name: 'Wolf', taxon: 'mammal', habitat: 'forest', domesticated: false, diet: 'carnivore' },
+  { name: 'Fox', taxon: 'mammal', habitat: 'forest', domesticated: false, diet: 'carnivore' },
+  { name: 'Carp', taxon: 'fish', habitat: 'lakes', domesticated: false, diet: 'omnivore' },
+  { name: 'Trout', taxon: 'fish', habitat: 'rivers', domesticated: false, diet: 'carnivore' },
+  { name: 'Herring', taxon: 'fish', habitat: 'open_ocean', domesticated: false, diet: 'omnivore' },
+  { name: 'Cod', taxon: 'fish', habitat: 'open_ocean', domesticated: false, diet: 'carnivore' },
+  { name: 'Eel', taxon: 'fish', habitat: 'rivers', domesticated: false, diet: 'carnivore' },
+  { name: 'Swan', taxon: 'bird', habitat: 'lakes', domesticated: false, diet: 'herbivore' },
+  { name: 'Rat', taxon: 'mammal', habitat: 'urban', domesticated: false, diet: 'omnivore' },
+  { name: 'Mouse', taxon: 'mammal', habitat: 'urban', domesticated: false, diet: 'omnivore' },
+  { name: 'Hedgehog', taxon: 'mammal', habitat: 'forest', domesticated: false, diet: 'insectivore' },
+  { name: 'Badger', taxon: 'mammal', habitat: 'forest', domesticated: false, diet: 'omnivore' },
+  { name: 'Lynx', taxon: 'mammal', habitat: 'forest', domesticated: false, diet: 'carnivore' },
+  { name: 'Wildcat', taxon: 'mammal', habitat: 'forest', domesticated: false, diet: 'carnivore' },
+  { name: 'Squirrel', taxon: 'mammal', habitat: 'forest', domesticated: false, diet: 'herbivore' },
+  { name: 'Elk', taxon: 'mammal', habitat: 'forest', domesticated: false, diet: 'herbivore' },
+  { name: 'Bison', taxon: 'mammal', habitat: 'grassland', domesticated: false, diet: 'herbivore' },
+  { name: 'Camel', taxon: 'mammal', habitat: 'hot_desert', domesticated: true, diet: 'herbivore' },
+  { name: 'Peafowl', taxon: 'bird', habitat: 'farmland', domesticated: true, diet: 'omnivore' },
+  { name: 'Crane', taxon: 'bird', habitat: 'marshes', domesticated: false, diet: 'omnivore' },
+  { name: 'Owl', taxon: 'bird', habitat: 'forest', domesticated: false, diet: 'carnivore' },
+  { name: 'Hawk', taxon: 'bird', habitat: 'forest', domesticated: false, diet: 'carnivore' },
+  { name: 'Eagle', taxon: 'bird', habitat: 'cliffs', domesticated: false, diet: 'carnivore' },
+  { name: 'Snake', taxon: 'reptile', habitat: 'forest', domesticated: false, diet: 'carnivore' },
+  { name: 'Frog', taxon: 'amphibian', habitat: 'marshes', domesticated: false, diet: 'insectivore' },
+  { name: 'Toad', taxon: 'amphibian', habitat: 'marshes', domesticated: false, diet: 'insectivore' },
+  { name: 'Snail', taxon: 'mollusk', habitat: 'forest', domesticated: false, diet: 'herbivore' },
+  { name: 'Earthworm', taxon: 'annelid', habitat: 'farmland', domesticated: false, diet: 'detritivore' },
+  { name: 'Ant', taxon: 'insect', habitat: 'forest', domesticated: false, diet: 'omnivore' },
+];
+
+const plantNames = [
+  'Wheat','Barley','Rye','Oats','Spelt','Millet','Buckwheat',
+  'Peas','Lentils','Broad beans','Chickpeas','Onions','Garlic','Leeks','Shallots','Turnips','Carrots','Parsnips','Beets','Radishes','Pears','Plums','Cherries','Quinces','Grapes','Figs','Olives','Mulberries','Strawberries','Raspberries','Blackberries','Hazelnuts','Walnuts','Chestnuts','Flax','Hemp','Mustard','Poppy','Sage','Rosemary','Thyme','Mint','Lavender','Rue','Yarrow','Chamomile','Angelica','St. John\'s Wort'];
+
+const grasses = new Set(['Wheat','Barley','Rye','Oats','Spelt','Millet','Buckwheat']);
+const vines = new Set(['Grapes']);
+const shrubs = new Set(['Strawberries','Raspberries','Blackberries']);
+const trees = new Set(['Pears','Plums','Cherries','Quinces','Figs','Olives','Mulberries','Hazelnuts','Walnuts','Chestnuts']);
+
+(async () => {
+  const animalData = JSON.parse(await readFile('data/animals.json','utf-8'));
+  const animalIds = new Set(animalData.map(a => a.id));
+  for (const a of animalsList) {
+    const id = slugify(a.name, { lower: true, strict: true });
+    if (animalIds.has(id)) continue;
+    animalData.push({
+      id,
+      common_name: a.name,
+      taxon_group: a.taxon,
+      regions: a.taxon === 'fish' ? ['aquatic'] : ['terrestrial'],
+      habitats: [a.habitat],
+      diet: [a.diet],
+      domestication: { domesticated: a.domesticated },
+      behavior: { aggressive: false, territorial: false, risk_to_humans: a.domesticated ? 'low' : 'moderate' },
+      edibility: { edible: true, parts: ['meat'] },
+      byproducts: [{ type: 'other' }],
+      gendered: {},
+      narrative: ''
+    });
+    animalIds.add(id);
+  }
+  animalData.sort((x,y)=>x.id.localeCompare(y.id));
+  await writeFile('data/animals.json', JSON.stringify(animalData, null, 2));
+
+  const plantData = JSON.parse(await readFile('data/plants.json','utf-8'));
+  const plantIds = new Set(plantData.map(p => p.id));
+  for (const name of plantNames) {
+    const id = slugify(name, { lower: true, strict: true });
+    if (plantIds.has(id)) continue;
+    let growth_form = 'herb';
+    if (grasses.has(name)) growth_form = 'grass';
+    else if (vines.has(name)) growth_form = 'vine';
+    else if (shrubs.has(name)) growth_form = 'shrub';
+    else if (trees.has(name)) growth_form = 'tree';
+    plantData.push({
+      id,
+      common_name: name,
+      growth_form,
+      regions: ['terrestrial'],
+      habitats: ['farmland'],
+      cultivated: true,
+      edible: true,
+      byproducts: [{ type: 'other' }],
+      narrative: ''
+    });
+    plantIds.add(id);
+  }
+  plantData.sort((x,y)=>x.id.localeCompare(y.id));
+  await writeFile('data/plants.json', JSON.stringify(plantData, null, 2));
+})();
+


### PR DESCRIPTION
## Summary
- populate animal and plant databases with entries for items missing from supplied lists
- add script to generate placeholder records for new animals and plants

## Testing
- `npm run validate`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4f6e7592c83258ec8fdd1535e0e05