### PR TITLE
Add missing animal and plant entries

### DIFF
--- a/data/animals.json
+++ b/data/animals.json
@@ -128,6 +128,38 @@
     "narrative": ""
   },
   {
+    "id": "barbary-ape",
+    "common_name": "Barbary ape",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "barnacle-goose",
     "common_name": "Barnacle goose",
     "taxon_group": "bird",
@@ -384,6 +416,38 @@
     "narrative": ""
   },
   {
+    "id": "burbot",
+    "common_name": "Burbot",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "bustard",
     "common_name": "Bustard",
     "taxon_group": "bird",
@@ -395,6 +459,38 @@
     ],
     "diet": [
       "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "buzzard",
+    "common_name": "Buzzard",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
     ],
     "domestication": {
       "domesticated": false
@@ -534,6 +630,38 @@
       "aggressive": false,
       "territorial": false,
       "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "carp-bream",
+    "common_name": "Carp bream",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
     },
     "edibility": {
       "edible": true,
@@ -832,6 +960,70 @@
     "butchering_age": "6 months"
   },
   {
+    "id": "chub",
+    "common_name": "Chub",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "civet",
+    "common_name": "Civet",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "clam",
     "common_name": "Clam",
     "taxon_group": "mollusk",
@@ -1120,6 +1312,38 @@
     "narrative": ""
   },
   {
+    "id": "cuckoo",
+    "common_name": "Cuckoo",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "cuttlefish",
     "common_name": "Cuttlefish",
     "taxon_group": "mollusk",
@@ -1139,6 +1363,38 @@
       "aggressive": false,
       "territorial": false,
       "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "dace",
+    "common_name": "Dace",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
     },
     "edibility": {
       "edible": true,
@@ -1730,6 +1986,38 @@
     "narrative": ""
   },
   {
+    "id": "eelpout",
+    "common_name": "Eelpout",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "elephant",
     "common_name": "Elephant",
     "taxon_group": "mammal",
@@ -1781,6 +2069,38 @@
       "aggressive": false,
       "territorial": false,
       "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "ermine",
+    "common_name": "Ermine",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
     },
     "edibility": {
       "edible": true,
@@ -1866,6 +2186,38 @@
     ],
     "habitats": [
       "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "flamingo",
+    "common_name": "Flamingo",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
     ],
     "diet": [
       "omnivore"
@@ -2029,6 +2381,38 @@
     ],
     "diet": [
       "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "genet",
+    "common_name": "Genet",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
     ],
     "domestication": {
       "domesticated": false
@@ -2257,6 +2641,38 @@
     "butchering_age": "8 months"
   },
   {
+    "id": "goshawk",
+    "common_name": "Goshawk",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "grayling",
     "common_name": "Grayling",
     "taxon_group": "fish",
@@ -2268,6 +2684,38 @@
     ],
     "diet": [
       "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "great-spotted-woodpecker",
+    "common_name": "Great spotted woodpecker",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
     ],
     "domestication": {
       "domesticated": false
@@ -2385,6 +2833,38 @@
     "narrative": ""
   },
   {
+    "id": "guinea-fowl",
+    "common_name": "Guinea fowl",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "gull",
     "common_name": "Gull",
     "taxon_group": "bird",
@@ -2428,6 +2908,38 @@
     ],
     "diet": [
       "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "hagfish",
+    "common_name": "Hagfish",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "scavenger"
     ],
     "domestication": {
       "domesticated": false
@@ -2513,6 +3025,38 @@
     "narrative": ""
   },
   {
+    "id": "harrier",
+    "common_name": "Harrier",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "hawk",
     "common_name": "Hawk",
     "taxon_group": "bird",
@@ -2532,6 +3076,38 @@
       "aggressive": false,
       "territorial": false,
       "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "hedge-sparrow",
+    "common_name": "Hedge sparrow",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
     },
     "edibility": {
       "edible": true,
@@ -2705,6 +3281,38 @@
     "butchering_age": "1 year"
   },
   {
+    "id": "hoopoe",
+    "common_name": "Hoopoe",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "horse",
     "common_name": "Horse",
     "taxon_group": "mammal",
@@ -2804,6 +3412,38 @@
     "narrative": ""
   },
   {
+    "id": "iberian-lynx",
+    "common_name": "Iberian lynx",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "ibex",
     "common_name": "Ibex",
     "taxon_group": "mammal",
@@ -2836,6 +3476,38 @@
     "narrative": ""
   },
   {
+    "id": "ibis",
+    "common_name": "Ibis",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "jackdaw",
     "common_name": "Jackdaw",
     "taxon_group": "bird",
@@ -2847,6 +3519,70 @@
     ],
     "diet": [
       "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "jellyfish",
+    "common_name": "Jellyfish",
+    "taxon_group": "other",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "kestrel",
+    "common_name": "Kestrel",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
     ],
     "domestication": {
       "domesticated": false
@@ -2996,6 +3732,38 @@
     "narrative": ""
   },
   {
+    "id": "loach",
+    "common_name": "Loach",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "lobster",
     "common_name": "Lobster",
     "taxon_group": "crustacean",
@@ -3124,6 +3892,38 @@
     "narrative": ""
   },
   {
+    "id": "mallard",
+    "common_name": "Mallard",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "marten",
     "common_name": "Marten",
     "taxon_group": "mammal",
@@ -3143,6 +3943,102 @@
       "aggressive": false,
       "territorial": false,
       "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "merlin-falcon",
+    "common_name": "Merlin falcon",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "mink",
+    "common_name": "Mink",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "minnow",
+    "common_name": "Minnow",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
     },
     "edibility": {
       "edible": true,
@@ -3415,6 +4311,38 @@
     "narrative": ""
   },
   {
+    "id": "nightjar",
+    "common_name": "Nightjar",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "octopus",
     "common_name": "Octopus",
     "taxon_group": "mollusk",
@@ -3434,6 +4362,38 @@
       "aggressive": false,
       "territorial": false,
       "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "osprey",
+    "common_name": "Osprey",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
     },
     "edibility": {
       "edible": true,
@@ -3575,6 +4535,38 @@
     "narrative": ""
   },
   {
+    "id": "peacock",
+    "common_name": "Peacock",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "peafowl",
     "common_name": "Peafowl",
     "taxon_group": "bird",
@@ -3661,6 +4653,38 @@
       "aggressive": false,
       "territorial": false,
       "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "peregrine-falcon",
+    "common_name": "Peregrine falcon",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
     },
     "edibility": {
       "edible": true,
@@ -3852,6 +4876,70 @@
       "aggressive": false,
       "territorial": false,
       "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "pikeperch",
+    "common_name": "Pikeperch",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "pintail",
+    "common_name": "Pintail",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
     },
     "edibility": {
       "edible": true,
@@ -4135,6 +5223,38 @@
     "narrative": ""
   },
   {
+    "id": "red-kite",
+    "common_name": "Red kite",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "reindeer",
     "common_name": "Reindeer",
     "taxon_group": "mammal",
@@ -4186,6 +5306,38 @@
       "aggressive": false,
       "territorial": false,
       "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "rudd",
+    "common_name": "Rudd",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
     },
     "edibility": {
       "edible": true,
@@ -4545,6 +5697,38 @@
     "butchering_age": "1 year"
   },
   {
+    "id": "shoveler",
+    "common_name": "Shoveler",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "shrew",
     "common_name": "Shrew",
     "taxon_group": "mammal",
@@ -4769,6 +5953,38 @@
     "narrative": ""
   },
   {
+    "id": "sparrowhawk",
+    "common_name": "Sparrowhawk",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "squid",
     "common_name": "Squid",
     "taxon_group": "mollusk",
@@ -4865,6 +6081,38 @@
     "narrative": ""
   },
   {
+    "id": "starfish",
+    "common_name": "Starfish",
+    "taxon_group": "other",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "starling",
     "common_name": "Starling",
     "taxon_group": "bird",
@@ -4876,6 +6124,102 @@
     ],
     "diet": [
       "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "stickleback",
+    "common_name": "Stickleback",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "stoat",
+    "common_name": "Stoat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "stork",
+    "common_name": "Stork",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "carnivore"
     ],
     "domestication": {
       "domesticated": false
@@ -4980,6 +6324,38 @@
       "aggressive": false,
       "territorial": false,
       "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "teal",
+    "common_name": "Teal",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
     },
     "edibility": {
       "edible": true,
@@ -5185,6 +6561,38 @@
     "narrative": ""
   },
   {
+    "id": "turkey",
+    "common_name": "Turkey",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "turtle-dove",
     "common_name": "Turtle dove",
     "taxon_group": "bird",
@@ -5281,6 +6689,38 @@
     "narrative": ""
   },
   {
+    "id": "wels-catfish",
+    "common_name": "Wels catfish",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "whale",
     "common_name": "Whale",
     "taxon_group": "mammal",
@@ -5313,6 +6753,38 @@
     "narrative": ""
   },
   {
+    "id": "white-pelican",
+    "common_name": "White pelican",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "whitefish",
     "common_name": "Whitefish",
     "taxon_group": "fish",
@@ -5324,6 +6796,70 @@
     ],
     "diet": [
       "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "whooper-swan",
+    "common_name": "Whooper swan",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "wigeon",
+    "common_name": "Wigeon",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "omnivore"
     ],
     "domestication": {
       "domesticated": false
@@ -5452,6 +6988,38 @@
     ],
     "diet": [
       "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "wren",
+    "common_name": "Wren",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
     ],
     "domestication": {
       "domesticated": false

--- a/data/plants.json
+++ b/data/plants.json
@@ -30,6 +30,21 @@
     "narrative": ""
   },
   {
+    "id": "alder-buckthorn",
+    "common_name": "Alder buckthorn",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "algae",
     "common_name": "Algae",
     "growth_form": "algae",
@@ -40,6 +55,36 @@
       "wetland"
     ],
     "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "alisma",
+    "common_name": "Alisma",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "almond",
+    "common_name": "Almond",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
     "edible": true,
     "byproducts": [],
     "narrative": ""
@@ -150,6 +195,21 @@
     ],
     "rotation_relationships": "Orchards with legume ground cover enrich soil",
     "fallow_notes": "Prune annually; replant after 25 years to rejuvenate grove"
+  },
+  {
+    "id": "arrowhead",
+    "common_name": "Arrowhead",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
   },
   {
     "id": "ash",
@@ -330,6 +390,36 @@
     "narrative": ""
   },
   {
+    "id": "bird-cherry",
+    "common_name": "Bird cherry",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "bitter-orange",
+    "common_name": "Bitter orange",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "blackberries",
     "common_name": "Blackberries",
     "growth_form": "shrub",
@@ -390,6 +480,21 @@
     "narrative": ""
   },
   {
+    "id": "boxwood",
+    "common_name": "Boxwood",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "bracken-fern",
     "common_name": "Bracken fern",
     "growth_form": "herb",
@@ -420,6 +525,21 @@
     "narrative": ""
   },
   {
+    "id": "buckthorn",
+    "common_name": "Buckthorn",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "buckwheat",
     "common_name": "Buckwheat",
     "growth_form": "grass",
@@ -430,6 +550,21 @@
       "farmland"
     ],
     "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "bulrush",
+    "common_name": "Bulrush",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
     "edible": true,
     "byproducts": [],
     "narrative": ""
@@ -524,6 +659,21 @@
     "narrative": ""
   },
   {
+    "id": "carrageen-moss",
+    "common_name": "Carrageen moss",
+    "growth_form": "seaweed",
+    "regions": [
+      "aquatic_salt"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "carrot",
     "common_name": "Carrot",
     "alt_names": [],
@@ -599,6 +749,21 @@
     "id": "cedar",
     "common_name": "Cedar",
     "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "chaga",
+    "common_name": "Chaga",
+    "growth_form": "fungus",
     "regions": [
       "terrestrial"
     ],
@@ -750,6 +915,21 @@
     "narrative": ""
   },
   {
+    "id": "citron",
+    "common_name": "Citron",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "cloudberry",
     "common_name": "Cloudberry",
     "growth_form": "shrub",
@@ -773,6 +953,21 @@
     ],
     "habitats": [
       "grassland"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "clubmoss",
+    "common_name": "Clubmoss",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
     ],
     "cultivated": false,
     "edible": true,
@@ -825,6 +1020,21 @@
     "narrative": ""
   },
   {
+    "id": "coral-fungus",
+    "common_name": "Coral fungus",
+    "growth_form": "fungus",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "coriander",
     "common_name": "Coriander",
     "growth_form": "herb",
@@ -835,6 +1045,51 @@
       "farmland"
     ],
     "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "cornelian-cherry",
+    "common_name": "Cornelian cherry",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "cotton-grass",
+    "common_name": "Cotton grass",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "crab-apple",
+    "common_name": "Crab apple",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
     "edible": true,
     "byproducts": [],
     "narrative": ""
@@ -915,6 +1170,21 @@
     "narrative": ""
   },
   {
+    "id": "date-palm",
+    "common_name": "Date palm",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "desert"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "datura",
     "common_name": "Datura",
     "growth_form": "herb",
@@ -923,6 +1193,21 @@
     ],
     "habitats": [
       "grassland"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "dewberry-bramble",
+    "common_name": "Dewberry bramble",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
     ],
     "cultivated": false,
     "edible": true,
@@ -1143,6 +1428,21 @@
     ],
     "habitats": [
       "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "frogbit",
+    "common_name": "Frogbit",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland"
     ],
     "cultivated": false,
     "edible": true,
@@ -1403,6 +1703,21 @@
     "narrative": ""
   },
   {
+    "id": "hornwort",
+    "common_name": "Hornwort",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "lake"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "horsetail",
     "common_name": "Horsetail",
     "growth_form": "herb",
@@ -1428,6 +1743,36 @@
       "farmland"
     ],
     "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "ink-cap",
+    "common_name": "Ink cap",
+    "growth_form": "mushroom",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "ivy",
+    "common_name": "Ivy",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
     "edible": true,
     "byproducts": [],
     "narrative": ""
@@ -1624,6 +1969,36 @@
     "narrative": ""
   },
   {
+    "id": "liverwort",
+    "common_name": "Liverwort",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "lotus",
+    "common_name": "Lotus",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "lake"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "lovage",
     "common_name": "Lovage",
     "growth_form": "herb",
@@ -1684,6 +2059,21 @@
     "narrative": ""
   },
   {
+    "id": "marsh-marigold",
+    "common_name": "Marsh marigold",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "meadowsweet",
     "common_name": "Meadowsweet",
     "growth_form": "herb",
@@ -1714,6 +2104,21 @@
     "narrative": ""
   },
   {
+    "id": "milkcap",
+    "common_name": "Milkcap mushrooms",
+    "growth_form": "mushroom",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "millet",
     "common_name": "Millet",
     "growth_form": "grass",
@@ -1739,6 +2144,21 @@
       "farmland"
     ],
     "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "mistletoe",
+    "common_name": "Mistletoe",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
     "edible": true,
     "byproducts": [],
     "narrative": ""
@@ -2213,6 +2633,21 @@
     "narrative": ""
   },
   {
+    "id": "pistachio",
+    "common_name": "Pistachio",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "plane-tree",
     "common_name": "Plane tree",
     "growth_form": "tree",
@@ -2258,6 +2693,36 @@
     "narrative": ""
   },
   {
+    "id": "pomegranate",
+    "common_name": "Pomegranate",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "pondweed",
+    "common_name": "Pondweed",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "lake"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "poplar",
     "common_name": "Poplar",
     "growth_form": "tree",
@@ -2291,6 +2756,21 @@
     "id": "porcini",
     "common_name": "Porcini",
     "growth_form": "mushroom",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "privet",
+    "common_name": "Privet",
+    "growth_form": "shrub",
     "regions": [
       "terrestrial"
     ],
@@ -2358,6 +2838,66 @@
       "farmland"
     ],
     "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "red-dulse",
+    "common_name": "Red dulse",
+    "growth_form": "seaweed",
+    "regions": [
+      "aquatic_salt"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "reed-canary-grass",
+    "common_name": "Reed canary grass",
+    "growth_form": "grass",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "reed-sweet-grass",
+    "common_name": "Reed sweet-grass",
+    "growth_form": "grass",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "reindeer-moss",
+    "common_name": "Reindeer moss",
+    "growth_form": "lichen",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "tundra"
+    ],
+    "cultivated": false,
     "edible": true,
     "byproducts": [],
     "narrative": ""
@@ -2433,6 +2973,21 @@
       "farmland"
     ],
     "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "russula",
+    "common_name": "Russula mushrooms",
+    "growth_form": "mushroom",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
     "edible": true,
     "byproducts": [],
     "narrative": ""
@@ -2594,6 +3149,21 @@
     "narrative": ""
   },
   {
+    "id": "sea-buckthorn",
+    "common_name": "Sea buckthorn",
+    "growth_form": "shrub",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "sea-kale",
     "common_name": "Sea kale",
     "growth_form": "herb",
@@ -2609,9 +3179,54 @@
     "narrative": ""
   },
   {
+    "id": "sea-lettuce",
+    "common_name": "Sea lettuce",
+    "growth_form": "seaweed",
+    "regions": [
+      "aquatic_salt"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "sedges",
+    "common_name": "Sedges",
+    "growth_form": "grass",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "service-tree",
     "common_name": "Service tree",
     "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "shaggy-mane",
+    "common_name": "Shaggy mane",
+    "growth_form": "mushroom",
     "regions": [
       "terrestrial"
     ],
@@ -2669,6 +3284,36 @@
     "narrative": ""
   },
   {
+    "id": "spindle-tree",
+    "common_name": "Spindle tree",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "spirulina",
+    "common_name": "Spirulina",
+    "growth_form": "algae",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "lake"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "spruce",
     "common_name": "Spruce",
     "growth_form": "tree",
@@ -2714,6 +3359,21 @@
     "narrative": ""
   },
   {
+    "id": "strawberry-tree",
+    "common_name": "Strawberry tree",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "tarragon",
     "common_name": "Tarragon",
     "growth_form": "herb",
@@ -2747,6 +3407,21 @@
     "id": "truffle",
     "common_name": "Truffle",
     "growth_form": "mushroom",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "turkey-tail",
+    "common_name": "Turkey tail",
+    "growth_form": "fungus",
     "regions": [
       "terrestrial"
     ],
@@ -2967,6 +3642,21 @@
     }
   },
   {
+    "id": "white-water-lily",
+    "common_name": "White water lily",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "lake"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
     "id": "wild-celery",
     "common_name": "Wild celery",
     "growth_form": "herb",
@@ -2984,6 +3674,21 @@
   {
     "id": "wild-olive",
     "common_name": "Olive tree",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "wild-pear",
+    "common_name": "Wild pear",
     "growth_form": "tree",
     "regions": [
       "terrestrial"
@@ -3037,6 +3742,21 @@
       "farmland"
     ],
     "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "yellow-water-lily",
+    "common_name": "Yellow water lily",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "lake"
+    ],
+    "cultivated": false,
     "edible": true,
     "byproducts": [],
     "narrative": ""


### PR DESCRIPTION
## Summary
- add 49 animal records such as great spotted woodpecker, white pelican, Iberian lynx and hagfish
- add 47 plant and fungus records including alder buckthorn, pomegranate, white water lily and sea lettuce

## Testing
- `npm test`
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68c5052f3d488325a42a18dac3512835