### PR TITLE
Add missing fauna and flora entries

### DIFF
--- a/data/animals.json
+++ b/data/animals.json
@@ -1,5 +1,41 @@
 [
   {
+    "id": "allis-shad",
+    "common_name": "Allis shad",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "anchovy",
     "common_name": "Anchovy",
     "taxon_group": "fish",
@@ -64,6 +100,42 @@
     "narrative": ""
   },
   {
+    "id": "arctic-char",
+    "common_name": "Arctic char",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "lakes"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "ass",
     "common_name": "Wild donkey",
     "taxon_group": "mammal",
@@ -92,6 +164,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "aurochs",
+    "common_name": "Aurochs",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -156,6 +264,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "barbel",
+    "common_name": "Barbel",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -288,6 +432,42 @@
     "narrative": ""
   },
   {
+    "id": "bezoar-goat",
+    "common_name": "Bezoar goat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hills"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "bison",
     "common_name": "Bison",
     "taxon_group": "mammal",
@@ -384,6 +564,42 @@
     "narrative": ""
   },
   {
+    "id": "bleak",
+    "common_name": "Bleak",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "boar",
     "common_name": "Boar",
     "taxon_group": "mammal",
@@ -412,6 +628,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "brill",
+    "common_name": "Brill",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -1120,6 +1372,78 @@
     "narrative": ""
   },
   {
+    "id": "common-swift",
+    "common_name": "Common swift",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "conger-eel",
+    "common_name": "Conger eel",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "coot",
     "common_name": "Coot",
     "taxon_group": "bird",
@@ -1344,6 +1668,42 @@
     "narrative": ""
   },
   {
+    "id": "curlew",
+    "common_name": "Curlew",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "cuttlefish",
     "common_name": "Cuttlefish",
     "taxon_group": "mollusk",
@@ -1372,6 +1732,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "dab",
+    "common_name": "Dab",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -2114,6 +2510,42 @@
     "narrative": ""
   },
   {
+    "id": "eurasian-jay",
+    "common_name": "Eurasian jay",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "falcon",
     "common_name": "Falcon",
     "taxon_group": "bird",
@@ -2146,6 +2578,42 @@
     "narrative": ""
   },
   {
+    "id": "fallow-deer",
+    "common_name": "Fallow deer",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "ferret",
     "common_name": "Ferret",
     "taxon_group": "mammal",
@@ -2174,6 +2642,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "fieldfare",
+    "common_name": "Fieldfare",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -2306,6 +2810,42 @@
     "narrative": ""
   },
   {
+    "id": "freshwater-crayfish",
+    "common_name": "Freshwater crayfish",
+    "taxon_group": "crustacean",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "frog",
     "common_name": "Frog",
     "taxon_group": "amphibian",
@@ -2332,6 +2872,34 @@
         "meat"
       ],
       "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "gall-wasp-oak-gall",
+    "common_name": "Gall wasp (oak gall)",
+    "taxon_group": "insect",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
     },
     "byproducts": [],
     "gendered": {},
@@ -2366,6 +2934,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "garfish",
+    "common_name": "Garfish",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -2522,6 +3126,42 @@
     "butchering_age": "1 year"
   },
   {
+    "id": "golden-plover",
+    "common_name": "Golden plover",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "goldfinch",
     "common_name": "Goldfinch",
     "taxon_group": "bird",
@@ -2639,6 +3279,42 @@
       "wool_shearing_cycle": ""
     },
     "butchering_age": "8 months"
+  },
+  {
+    "id": "goose-barnacle",
+    "common_name": "Goose barnacle",
+    "taxon_group": "crustacean",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "ocean_shores"
+    ],
+    "diet": [
+      "detritivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
   },
   {
     "id": "goshawk",
@@ -2769,6 +3445,42 @@
     "narrative": ""
   },
   {
+    "id": "grey-mullet",
+    "common_name": "Grey mullet",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "greylag-goose",
     "common_name": "Greylag goose",
     "taxon_group": "bird",
@@ -2829,6 +3541,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "gudgeon",
+    "common_name": "Gudgeon",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -2957,6 +3705,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "hake",
+    "common_name": "Hake",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -3508,6 +4292,42 @@
     "narrative": ""
   },
   {
+    "id": "ide-orfe",
+    "common_name": "Ide (orfe)",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "jackdaw",
     "common_name": "Jackdaw",
     "taxon_group": "bird",
@@ -3572,6 +4392,34 @@
     "narrative": ""
   },
   {
+    "id": "kermes-scale-insect",
+    "common_name": "Kermes (scale insect)",
+    "taxon_group": "insect",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "kestrel",
     "common_name": "Kestrel",
     "taxon_group": "bird",
@@ -3600,6 +4448,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "kingfisher",
+    "common_name": "Kingfisher",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -3636,6 +4520,42 @@
     "narrative": ""
   },
   {
+    "id": "lapwing",
+    "common_name": "Lapwing",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "lark",
     "common_name": "Lark",
     "taxon_group": "bird",
@@ -3662,6 +4582,34 @@
         "meat"
       ],
       "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "leech",
+    "common_name": "Leech",
+    "taxon_group": "annelid",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "swamps"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
     },
     "byproducts": [],
     "gendered": {},
@@ -3696,6 +4644,78 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "limpet",
+    "common_name": "Limpet",
+    "taxon_group": "mollusk",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "ocean_shores"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "ling",
+    "common_name": "Ling",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -4084,6 +5104,42 @@
     "narrative": ""
   },
   {
+    "id": "monkfish-angler",
+    "common_name": "Monkfish (angler)",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "moorhen",
     "common_name": "Moorhen",
     "taxon_group": "bird",
@@ -4144,6 +5200,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "mouflon",
+    "common_name": "Mouflon",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hills"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -4243,6 +5335,78 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "murex-purple-dye",
+    "common_name": "Murex (purple dye)",
+    "taxon_group": "mollusk",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "ocean_shores"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "musk-ox",
+    "common_name": "Musk ox",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "arctic_tundra"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -4698,6 +5862,42 @@
     "narrative": ""
   },
   {
+    "id": "periwinkle",
+    "common_name": "Periwinkle",
+    "taxon_group": "mollusk",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "ocean_shores"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "pheasant",
     "common_name": "Pheasant",
     "taxon_group": "bird",
@@ -4953,6 +6153,42 @@
     "narrative": ""
   },
   {
+    "id": "plaice",
+    "common_name": "Plaice",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "polecat",
     "common_name": "Polecat",
     "taxon_group": "mammal",
@@ -4981,6 +6217,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "pollock",
+    "common_name": "Pollock",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -5223,6 +6495,42 @@
     "narrative": ""
   },
   {
+    "id": "razor-clam",
+    "common_name": "Razor clam",
+    "taxon_group": "mollusk",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "tidal_flats"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "red-kite",
     "common_name": "Red kite",
     "taxon_group": "bird",
@@ -5315,6 +6623,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "roe-deer",
+    "common_name": "Roe deer",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -5537,6 +6881,34 @@
         "meat"
       ],
       "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "sea-sponge",
+    "common_name": "Sea sponge",
+    "taxon_group": "other",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "coral_reefs"
+    ],
+    "diet": [
+      "detritivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
     },
     "byproducts": [],
     "gendered": {},
@@ -5793,6 +7165,34 @@
     "narrative": ""
   },
   {
+    "id": "silkworm",
+    "common_name": "Silkworm",
+    "taxon_group": "insect",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "smelt",
     "common_name": "Smelt",
     "taxon_group": "fish",
@@ -5889,6 +7289,42 @@
     "narrative": ""
   },
   {
+    "id": "snipe",
+    "common_name": "Snipe",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "sole",
     "common_name": "Sole",
     "taxon_group": "fish",
@@ -5917,6 +7353,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "song-thrush",
+    "common_name": "Song thrush",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -5981,6 +7453,114 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "spider-crab",
+    "common_name": "Spider crab",
+    "taxon_group": "crustacean",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "ocean_shores"
+    ],
+    "diet": [
+      "scavenger"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "spiny-dogfish",
+    "common_name": "Spiny dogfish",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "sprat",
+    "common_name": "Sprat",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -6433,6 +8013,42 @@
     "narrative": ""
   },
   {
+    "id": "thornback-ray",
+    "common_name": "Thornback ray",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "tiger",
     "common_name": "Tiger",
     "taxon_group": "mammal",
@@ -6625,6 +8241,42 @@
     "narrative": ""
   },
   {
+    "id": "twaite-shad",
+    "common_name": "Twaite shad",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "walrus",
     "common_name": "Walrus",
     "taxon_group": "mammal",
@@ -6753,6 +8405,42 @@
     "narrative": ""
   },
   {
+    "id": "whelk",
+    "common_name": "Whelk",
+    "taxon_group": "mollusk",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "ocean_shores"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
     "id": "white-pelican",
     "common_name": "White pelican",
     "taxon_group": "bird",
@@ -6813,6 +8501,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "whiting",
+    "common_name": "Whiting",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },
@@ -7005,6 +8729,42 @@
       "preparation_notes": "Cook thoroughly."
     },
     "byproducts": [],
+    "gendered": {},
+    "narrative": ""
+  },
+  {
+    "id": "woodcock",
+    "common_name": "Woodcock",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat"
+      }
+    ],
     "gendered": {},
     "narrative": ""
   },

--- a/data/plants.json
+++ b/data/plants.json
@@ -15,6 +15,25 @@
     "narrative": ""
   },
   {
+    "id": "agrimony",
+    "common_name": "Agrimony",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "alder",
     "common_name": "Alder",
     "growth_form": "tree",
@@ -197,6 +216,25 @@
     "fallow_notes": "Prune annually; replant after 25 years to rejuvenate grove"
   },
   {
+    "id": "apricot",
+    "common_name": "Apricot",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "arrowhead",
     "common_name": "Arrowhead",
     "growth_form": "herb",
@@ -300,6 +338,25 @@
     }
   },
   {
+    "id": "basil",
+    "common_name": "Basil",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "bay-laurel",
     "common_name": "Bay laurel",
     "growth_form": "tree",
@@ -360,6 +417,25 @@
     "narrative": ""
   },
   {
+    "id": "betony",
+    "common_name": "Betony",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "bilberry",
     "common_name": "Bilberry",
     "growth_form": "shrub",
@@ -387,6 +463,25 @@
     "cultivated": false,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "birch-polypore",
+    "common_name": "Birch polypore",
+    "growth_form": "mushroom",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "mushroom"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -450,6 +545,25 @@
     "narrative": ""
   },
   {
+    "id": "blackthorn-sloe",
+    "common_name": "Blackthorn (sloe)",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "bladderwrack",
     "common_name": "Bladderwrack",
     "growth_form": "seaweed",
@@ -477,6 +591,25 @@
     "cultivated": false,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "borage",
+    "common_name": "Borage",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -522,6 +655,25 @@
     "cultivated": true,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "broom-scotch-broom",
+    "common_name": "Broom (scotch broom)",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hills"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -825,6 +977,25 @@
     }
   },
   {
+    "id": "chard",
+    "common_name": "Chard",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "cherries",
     "common_name": "Cherries",
     "growth_form": "tree",
@@ -915,6 +1086,25 @@
     "narrative": ""
   },
   {
+    "id": "chives",
+    "common_name": "Chives",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "citron",
     "common_name": "Citron",
     "growth_form": "tree",
@@ -957,6 +1147,25 @@
     "cultivated": false,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "club-rush-schoenoplectus",
+    "common_name": "Club-rush (Schoenoplectus)",
+    "growth_form": "grass",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "fiber"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -1017,6 +1226,25 @@
     "cultivated": false,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "common-reed-phragmites",
+    "common_name": "Common reed (Phragmites)",
+    "growth_form": "grass",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "fiber"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -1155,6 +1383,25 @@
     "narrative": ""
   },
   {
+    "id": "damson",
+    "common_name": "Damson",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "dandelion",
     "common_name": "Dandelion",
     "growth_form": "herb",
@@ -1197,6 +1444,25 @@
     "cultivated": false,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "death-cap",
+    "common_name": "Death cap",
+    "growth_form": "mushroom",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "mushroom"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -1275,6 +1541,44 @@
     "narrative": ""
   },
   {
+    "id": "eelgrass-zostera",
+    "common_name": "Eelgrass (Zostera)",
+    "growth_form": "grass",
+    "regions": [
+      "aquatic_salt"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "einkorn",
+    "common_name": "Einkorn",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "grain"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "elder",
     "common_name": "Elder",
     "growth_form": "tree",
@@ -1305,6 +1609,44 @@
     "narrative": ""
   },
   {
+    "id": "emmer",
+    "common_name": "Emmer",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "grain"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "ergot-rye-fungus",
+    "common_name": "Ergot (rye fungus)",
+    "growth_form": "fungus",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "mushroom"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "fennel",
     "common_name": "Fennel",
     "growth_form": "herb",
@@ -1317,6 +1659,25 @@
     "cultivated": true,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "fenugreek",
+    "common_name": "Fenugreek",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "seed"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -1418,6 +1779,25 @@
       ],
       "luxury_tier": []
     }
+  },
+  {
+    "id": "fly-agaric",
+    "common_name": "Fly agaric",
+    "growth_form": "mushroom",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "mushroom"
+      }
+    ],
+    "narrative": ""
   },
   {
     "id": "foxglove",
@@ -1538,6 +1918,25 @@
     "narrative": ""
   },
   {
+    "id": "gorse-furze",
+    "common_name": "Gorse (furze)",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hills"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "grapes",
     "common_name": "Grapes",
     "growth_form": "vine",
@@ -1613,6 +2012,25 @@
     "narrative": ""
   },
   {
+    "id": "heather-ling",
+    "common_name": "Heather (ling)",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hills"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "hemp",
     "common_name": "Hemp",
     "growth_form": "herb",
@@ -1670,6 +2088,25 @@
     "cultivated": false,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "hops",
+    "common_name": "Hops",
+    "growth_form": "vine",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -1883,6 +2320,25 @@
     "narrative": ""
   },
   {
+    "id": "lemon",
+    "common_name": "Lemon",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "lentil",
     "common_name": "Lentil",
     "alt_names": [],
@@ -1954,6 +2410,44 @@
     "narrative": ""
   },
   {
+    "id": "licorice",
+    "common_name": "Licorice",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "root"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "linden-lime-tree",
+    "common_name": "Linden (lime tree)",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "flower"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "lingonberry",
     "common_name": "Lingonberry",
     "growth_form": "shrub",
@@ -2014,6 +2508,25 @@
     "narrative": ""
   },
   {
+    "id": "madder",
+    "common_name": "Madder",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "dye"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "mandrake",
     "common_name": "Mandrake",
     "growth_form": "herb",
@@ -2059,6 +2572,25 @@
     "narrative": ""
   },
   {
+    "id": "marjoram",
+    "common_name": "Marjoram",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "marsh-marigold",
     "common_name": "Marsh marigold",
     "growth_form": "herb",
@@ -2071,6 +2603,25 @@
     "cultivated": false,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "marshmallow-althaea",
+    "common_name": "Marshmallow (Althaea)",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "root"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -2254,6 +2805,25 @@
     "narrative": ""
   },
   {
+    "id": "nigella-black-cumin",
+    "common_name": "Nigella (black cumin)",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "seed"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "oats",
     "common_name": "Oats",
     "growth_form": "grass",
@@ -2400,6 +2970,44 @@
     "narrative": ""
   },
   {
+    "id": "orchil-lichen-roccella",
+    "common_name": "Orchil lichen (Roccella)",
+    "growth_form": "lichen",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "dye"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "oregano",
+    "common_name": "Oregano",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "oyster-mushroom",
     "common_name": "Oyster Mushroom",
     "alt_names": [
@@ -2464,6 +3072,25 @@
     "cultivated": false,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "parsley",
+    "common_name": "Parsley",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -2538,6 +3165,25 @@
       ],
       "luxury_tier": []
     }
+  },
+  {
+    "id": "peach",
+    "common_name": "Peach",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      }
+    ],
+    "narrative": ""
   },
   {
     "id": "pears",
@@ -2798,6 +3444,25 @@
     "narrative": ""
   },
   {
+    "id": "purslane",
+    "common_name": "Purslane",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "quinces",
     "common_name": "Quinces",
     "growth_form": "tree",
@@ -2825,6 +3490,25 @@
     "cultivated": true,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "ramsons-wild-garlic",
+    "common_name": "Ramsons (wild garlic)",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -2900,6 +3584,25 @@
     "cultivated": false,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "rice",
+    "common_name": "Rice",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "grain"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -3119,6 +3822,44 @@
     "narrative": ""
   },
   {
+    "id": "salad-burnet",
+    "common_name": "Salad burnet",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "salsify",
+    "common_name": "Salsify",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "root"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "samphire",
     "common_name": "Samphire",
     "growth_form": "herb",
@@ -3254,6 +3995,25 @@
     "narrative": ""
   },
   {
+    "id": "skirret",
+    "common_name": "Skirret",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "root"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "sorrel",
     "common_name": "Sorrel",
     "growth_form": "herb",
@@ -3281,6 +4041,25 @@
     "cultivated": true,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "spinach",
+    "common_name": "Spinach",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -3344,6 +4123,25 @@
     "narrative": ""
   },
   {
+    "id": "stone-pine-pine-nuts",
+    "common_name": "Stone pine (pine nuts)",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "seed"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "strawberries",
     "common_name": "Strawberries",
     "growth_form": "shrub",
@@ -3374,6 +4172,63 @@
     "narrative": ""
   },
   {
+    "id": "sweet-flag-acorus-calamus",
+    "common_name": "Sweet flag (Acorus calamus)",
+    "growth_form": "herb",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "root"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "sweet-gale-bog-myrtle",
+    "common_name": "Sweet gale (bog myrtle)",
+    "growth_form": "shrub",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "tansy",
+    "common_name": "Tansy",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "tarragon",
     "common_name": "Tarragon",
     "growth_form": "herb",
@@ -3401,6 +4256,25 @@
     "cultivated": true,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "tinder-fungus-amadou",
+    "common_name": "Tinder fungus (amadou)",
+    "growth_form": "fungus",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "mushroom"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -3567,6 +4441,25 @@
     "narrative": ""
   },
   {
+    "id": "water-chestnut-trapa-natans",
+    "common_name": "Water chestnut (Trapa natans)",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "lake"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "nut"
+      }
+    ],
+    "narrative": ""
+  },
+  {
     "id": "watercress",
     "common_name": "Watercress",
     "growth_form": "herb",
@@ -3579,6 +4472,25 @@
     "cultivated": false,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "weld-dyers-rocket",
+    "common_name": "Weld (dyer’s rocket)",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "dye"
+      }
+    ],
     "narrative": ""
   },
   {
@@ -3714,6 +4626,44 @@
     "cultivated": false,
     "edible": true,
     "byproducts": [],
+    "narrative": ""
+  },
+  {
+    "id": "woad",
+    "common_name": "Woad",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "dye"
+      }
+    ],
+    "narrative": ""
+  },
+  {
+    "id": "wood-sorrel",
+    "common_name": "Wood sorrel",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
     "narrative": ""
   },
   {


### PR DESCRIPTION
## Summary
- add 50 animal records such as roe deer and pollock to animals.json
- add 50 plant/fungi/lichen records such as emmer and woad to plants.json

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c50cbf5c0c832581417b2636ea8577