### PR TITLE
Handle missing or cancelled profile prompts

### DIFF
--- a/script.js
+++ b/script.js
@@ -1374,24 +1374,36 @@ function selectProfile() {
     return;
   }
   if (ids.length === 0) {
-    while (!currentProfile) {
-      createProfile();
-    }
-  } else {
-    let choice = '';
-    while (!currentProfile) {
-      choice = prompt(`Select profile (${ids.map(id => profiles[id].name).join(', ')})\nEnter a new name to create one:`);
-      if (choice === null) continue;
-      const existingId = ids.find(id => profiles[id].name === choice);
-      if (existingId) {
-        currentProfileId = existingId;
-        currentProfile = profiles[existingId];
-        localStorage.setItem(LAST_PROFILE_KEY, currentProfileId);
-      } else if (choice) {
-        createProfile(choice);
-      }
+    // No saved profiles and prompting may be unavailable; create a default profile
+    createProfile('Player');
+    return;
   }
-}
+  if (typeof prompt !== 'function') {
+    // Fallback to the first profile if prompts cannot be shown
+    currentProfileId = ids[0];
+    currentProfile = profiles[currentProfileId];
+    localStorage.setItem(LAST_PROFILE_KEY, currentProfileId);
+    return;
+  }
+  let choice = '';
+  while (!currentProfile) {
+    choice = prompt(`Select profile (${ids.map(id => profiles[id].name).join(', ')})\nEnter a new name to create one:`);
+    if (choice === null || choice.trim() === '') {
+      // User cancelled; default to first profile so the UI can load
+      currentProfileId = ids[0];
+      currentProfile = profiles[currentProfileId];
+      localStorage.setItem(LAST_PROFILE_KEY, currentProfileId);
+      break;
+    }
+    const existingId = ids.find(id => profiles[id].name === choice);
+    if (existingId) {
+      currentProfileId = existingId;
+      currentProfile = profiles[existingId];
+      localStorage.setItem(LAST_PROFILE_KEY, currentProfileId);
+    } else {
+      createProfile(choice);
+    }
+  }
 }
 
 function canManageBuilding(city, building) {


### PR DESCRIPTION
## Summary
- Ensure a default profile is created when no profiles exist and prompts can't be shown
- Fallback to the first saved profile if the profile selection prompt is cancelled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c60f10db6c832591cd2ce2c3269345