### PR TITLE
Fix crash when saved profiles are corrupted

### DIFF
--- a/script.js
+++ b/script.js
@@ -271,7 +271,12 @@ function normalizeProficiencyNameWidths() {
 const STORAGE_KEY = 'rpgProfiles';
 const LAST_PROFILE_KEY = 'rpgLastProfile';
 const TEMP_CHARACTER_KEY = 'rpgTempCharacter';
-let profiles = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+let profiles = {};
+try {
+  profiles = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+} catch {
+  profiles = {};
+}
 let currentProfileId = localStorage.getItem(LAST_PROFILE_KEY);
 let currentProfile = currentProfileId ? profiles[currentProfileId] : null;
 let currentCharacter = null;
@@ -2386,7 +2391,12 @@ function startCharacterCreation() {
   updateScale();
   showBackButton();
   mapContainer.style.display = 'none';
-  const saved = JSON.parse(localStorage.getItem(TEMP_CHARACTER_KEY) || '{}');
+  let saved = {};
+  try {
+    saved = JSON.parse(localStorage.getItem(TEMP_CHARACTER_KEY) || '{}');
+  } catch {
+    saved = {};
+  }
   const character = saved.character || {};
   const buildEntries = Object.values(characterBuilds);
   const classField = {


### PR DESCRIPTION
## Summary
- Avoid `JSON.parse` failures when loading profiles or temporary characters
- Ensure UI loads even if localStorage data is invalid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c619c5766c8325a412356f26d0b348