### PR TITLE
Add GitHub Pages deployment workflow and HTTP check

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/index.html
+++ b/index.html
@@ -102,7 +102,15 @@
 
 <main style="padding:1rem;"></main>
   </div>
-
-<script type="module" src="script.js"></script>
+<script>
+  if (/^https?:$/.test(window.location.protocol)) {
+    const s = document.createElement('script');
+    s.type = 'module';
+    s.src = 'script.js';
+    document.body.appendChild(s);
+  } else {
+    document.body.innerHTML = '<p>This application must be served over HTTP(S).<br>Use a local server or visit the GitHub Pages deployment.</p>';
+  }
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Deploy site automatically to GitHub Pages via new workflow
- Load `script.js` only when page served over HTTP(S) and show guidance otherwise

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c61d16705483258eddc02dabd2c9cf