### PR TITLE
feat: expand diet categories

### DIFF
--- a/src/types/biomes.ts
+++ b/src/types/biomes.ts
@@ -52,7 +52,18 @@ export const REGIONS = [
 ] as const;
 export type Region = typeof REGIONS[number];
 
-export const DIET = ["herbivore","carnivore","omnivore","insectivore","detritivore","filter_feeder"] as const;
+export const DIET = [
+  "herbivore",
+  "carnivore",
+  "omnivore",
+  "insectivore",
+  "detritivore",
+  "filter_feeder",
+  "grazer",
+  "browser",
+  "scavenger",
+  "piscivore",
+] as const;
 export type Diet = typeof DIET[number];
 
 export const RISK = ["none","low","moderate","high","extreme"] as const;


### PR DESCRIPTION
## Summary
- broaden diet constant to support additional categories

## Testing
- `npm test`
- `npm run validate`
- `npm run build:indexes` (fails: TypeError: Cannot read properties of undefined (reading 'push'))

------
https://chatgpt.com/codex/tasks/task_e_68c6230dd0c0832595bc4965acbef9bd