### PR TITLE
Fetch economy data at runtime

### DIFF
--- a/assets/data/shop.js
+++ b/assets/data/shop.js
@@ -1,4 +1,13 @@
-import ECONOMY_ITEMS from './economy_items.json' assert { type: 'json' };
+let economyItemsPromise = null;
+
+async function loadEconomyItems() {
+  if (!economyItemsPromise) {
+    economyItemsPromise = fetch('assets/data/economy_items.json')
+      .then(res => (res.ok ? res.json() : []))
+      .catch(() => []);
+  }
+  return economyItemsPromise;
+}
 
 const SHOP_RULES = [
   { pattern: /(smith|forge|armory|smithy)/i, sells: ['Weapons', 'Armor', 'Tools'], buys: ['Weapons', 'Armor', 'Tools'] },
@@ -20,8 +29,14 @@ export function shopCategoriesForBuilding(name) {
   return { sells: [], buys: [] };
 }
 
-export function itemsByCategory(category, limit = 10) {
-  return ECONOMY_ITEMS.filter(item => item.category_key === category && (item.quality_tier === 'Common' || item.quality_tier === 'Standard'))
+export async function itemsByCategory(category, limit = 10) {
+  const items = await loadEconomyItems();
+  return items
+    .filter(
+      item =>
+        item.category_key === category &&
+        (item.quality_tier === 'Common' || item.quality_tier === 'Standard')
+    )
     .slice(0, limit)
     .map(item => ({
       name: item.display_name || item.internal_name,
@@ -29,6 +44,6 @@ export function itemsByCategory(category, limit = 10) {
       category,
       sale_quantity: item.sale_quantity,
       bulk_discount_threshold: item.bulk_discount_threshold,
-      bulk_discount_pct: item.bulk_discount_pct
+      bulk_discount_pct: item.bulk_discount_pct,
     }));
 }

--- a/script.js
+++ b/script.js
@@ -1291,10 +1291,12 @@ function showInventoryUI() {
   setMainHTML(html);
 }
 
-function renderShopUI(buildingName) {
+async function renderShopUI(buildingName) {
   showBackButton();
   const categories = shopCategoriesForBuilding(buildingName).sells;
-  const sections = categories.map(cat => ({ cat, items: itemsByCategory(cat) }));
+  const sections = await Promise.all(
+    categories.map(async cat => ({ cat, items: await itemsByCategory(cat) }))
+  );
   let html = `<div class="shop-screen"><h1>${buildingName} Shop</h1><p>Funds: ${formatCurrency(currentCharacter.money)}</p>`;
   if (!sections.length) {
     html += '<p>No goods for sale.</p></div>';
@@ -1322,7 +1324,7 @@ function renderShopUI(buildingName) {
           }
           currentCharacter.money = fromIron(toIron(currentCharacter.money) - priceIron);
           addItemToInventory({ name: item.name, category: sec.cat, price: item.price });
-          renderShopUI(buildingName);
+          renderShopUI(buildingName).catch(console.error);
         });
       }
     });
@@ -1701,7 +1703,7 @@ function showNavigation() {
           };
         } else if (type === 'interaction') {
             if (action === 'shop') {
-              renderShopUI(pos.building);
+              renderShopUI(pos.building).catch(console.error);
               return;
             } else if (action === 'sell') {
               renderSellUI(pos.building);


### PR DESCRIPTION
## Summary
- load `economy_items.json` via `fetch` instead of a JSON module
- make shop UI await fetched inventory and handle async reloads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6318d38488325b32581e93e373184