### PR TITLE
feat: add collapsible shop categories and align item layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -1317,12 +1317,24 @@ async function renderShopUI(buildingName) {
     setMainHTML(html);
     return;
   }
+  const collapsible = sections.length > 1;
   sections.forEach((sec, sIdx) => {
-    html += `<h2>${sec.cat}</h2><ul>`;
+    if (collapsible) {
+      html += `<details class="shop-category" open><summary>${sec.cat}</summary><ul>`;
+    } else {
+      html += `<h2>${sec.cat}</h2><ul>`;
+    }
     sec.items.forEach((item, iIdx) => {
-      html += `<li class="shop-item"><button class="item-name" data-s="${sIdx}" data-i="${iIdx}">${item.name}</button> - ${item.sale_quantity} ${item.unit} - ${cpToCoins(item.price)} <input type="number" class="qty" value="1" min="1" data-s="${sIdx}" data-i="${iIdx}"> <button class="buy-btn" data-s="${sIdx}" data-i="${iIdx}">Buy</button></li>`;
+      html += `<li class="shop-item">
+        <button class="item-name" data-s="${sIdx}" data-i="${iIdx}">${item.name}</button>
+        <span class="sale-qty">${item.sale_quantity} ${item.unit}</span>
+        <span class="item-price">${cpToCoins(item.price)}</span>
+        <input type="number" class="qty" value="1" min="1" data-s="${sIdx}" data-i="${iIdx}">
+        <button class="buy-btn" data-s="${sIdx}" data-i="${iIdx}">Buy</button>
+      </li>`;
     });
     html += '</ul>';
+    if (collapsible) html += '</details>';
   });
   html += '</div>';
   setMainHTML(html);

--- a/style.css
+++ b/style.css
@@ -1531,13 +1531,38 @@ body.theme-dark .top-menu button {
 }
 
 .shop-item {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto auto auto auto;
   align-items: center;
   gap: 0.5rem;
+  width: 100%;
+}
+
+.shop-item .item-name {
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.shop-item .item-name:hover {
+  text-shadow: 0 0 0.5rem currentColor;
+}
+
+.shop-item .sale-qty,
+.shop-item .item-price {
+  text-align: right;
 }
 
 .shop-item .qty {
   width: 4rem;
+  justify-self: center;
+}
+
+.shop-item .buy-btn {
+  width: 4rem;
+  justify-self: center;
 }
 
 .overlay {


### PR DESCRIPTION
## Summary
- make shop sections collapsible when a shop has multiple categories
- align item rows with grid columns and subtle hover-only name buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c70afe8a848325b5bc5ea7671024b2