### PR TITLE
Integrate shop/sell icons and coin imagery

### DIFF
--- a/assets/data/city_nav.js
+++ b/assets/data/city_nav.js
@@ -1665,8 +1665,18 @@ function applyBusinessEmployees(nav) {
     building.employees = defaultEmployeesForBuilding(name);
     const categories = shopCategoriesForBuilding(name);
     const baseInteractions = [];
-    if (categories.sells.length) baseInteractions.push({ name: "Shop", action: "shop" });
-    if (categories.buys.length) baseInteractions.push({ name: "Sell", action: "sell" });
+    if (categories.sells.length)
+      baseInteractions.push({
+        name: "Shop",
+        action: "shop",
+        icon: "assets/images/icons/Economy/Shop.png",
+      });
+    if (categories.buys.length)
+      baseInteractions.push({
+        name: "Sell",
+        action: "sell",
+        icon: "assets/images/icons/Economy/Sell.png",
+      });
     baseInteractions.push({ name: "Manage", action: "manage" });
     building.interactions = baseInteractions.concat(building.interactions || []);
   });

--- a/assets/data/currency.js
+++ b/assets/data/currency.js
@@ -94,17 +94,53 @@ export function toCp({pl=0,g=0,si=0,cp=0,st=0,ci=0}={}){
   return convertCurrency(iron, 'coldIron', 'copper');
 }
 
-export function cpToCoins(value, tidy=true){
-  const iron = Math.round(convertCurrency(value, 'copper', 'coldIron'));
+export function cpToCoins(value, tidy = true, icons = false) {
+  const iron = Math.round(convertCurrency(value, "copper", "coldIron"));
   const counts = fromIron(iron);
-  const order = ['platinum','gold','silver','copper','steel','coldIron'];
-  const abbr = {platinum:'pl', gold:'g', silver:'si', copper:'cp', steel:'st', coldIron:'ci'};
+  const order = [
+    "platinum",
+    "gold",
+    "silver",
+    "copper",
+    "steel",
+    "coldIron",
+  ];
+  const abbr = {
+    platinum: "pl",
+    gold: "g",
+    silver: "si",
+    copper: "cp",
+    steel: "st",
+    coldIron: "ci",
+  };
+  const iconMap = {
+    platinum: "assets/images/icons/Economy/Platinum Coin.png",
+    gold: "assets/images/icons/Economy/Gold Coin.png",
+    silver: "assets/images/icons/Economy/Silver Coin.png",
+    copper: "assets/images/icons/Economy/Copper Coin.png",
+    steel: "assets/images/icons/Economy/Steel Coin.png",
+    coldIron: "assets/images/icons/Economy/Cold Iron Coin.png",
+  };
   const result = [];
-  for (const denom of order){
+  for (const denom of order) {
     const count = counts[denom] || 0;
-    if (count > 0 || (!tidy && result.length)){
-      if (count > 0 || !tidy) result.push(`${count}${abbr[denom]}`);
+    if (count > 0 || (!tidy && result.length)) {
+      if (icons) {
+        if (count > 0 || !tidy) {
+          result.push(
+            `<span class="coin"><span class="coin-amount">${count}</span><img src="${iconMap[denom]}" alt="${abbr[denom]}" class="coin-icon"></span>`
+          );
+        }
+      } else {
+        if (count > 0 || !tidy) result.push(`${count}${abbr[denom]}`);
+      }
     }
   }
-  return result.length ? result.join(' ') : '0cp';
+  if (!result.length) {
+    if (icons) {
+      return `<span class="coin"><span class="coin-amount">0</span><img src="${iconMap.copper}" alt="cp" class="coin-icon"></span>`;
+    }
+    return "0cp";
+  }
+  return icons ? `<span class="currency">${result.join(" ")}</span>` : result.join(" ");
 }

--- a/script.js
+++ b/script.js
@@ -1328,7 +1328,7 @@ async function renderShopUI(buildingName) {
       html += `<li class="shop-item">
         <button class="item-name" data-s="${sIdx}" data-i="${iIdx}">${item.name}</button>
         <span class="sale-qty">${item.sale_quantity} ${item.unit}</span>
-        <span class="item-price">${cpToCoins(item.price)}</span>
+        <span class="item-price">${cpToCoins(item.price, true, true)}</span>
         <input type="number" class="qty" value="1" min="1" data-s="${sIdx}" data-i="${iIdx}">
         <button class="buy-btn" data-s="${sIdx}" data-i="${iIdx}">Buy</button>
       </li>`;
@@ -1383,7 +1383,7 @@ function renderSellUI(buildingName) {
     const basePrice = item.price || 0;
     const profit = item.profit || 0;
     const sellPrice = resale ? Math.max(0, Math.floor(basePrice - profit)) : Math.floor(basePrice);
-    html += `<li>${item.name} x${item.qty} - ${cpToCoins(sellPrice)} <button data-idx="${idx}" data-price="${sellPrice}">Sell</button></li>`;
+    html += `<li>${item.name} x${item.qty} - ${cpToCoins(sellPrice, true, true)} <button data-idx="${idx}" data-price="${sellPrice}">Sell</button></li>`;
   });
   html += '</ul></div>';
   setMainHTML(html);
@@ -1501,7 +1501,7 @@ function showNavigation() {
     const aria = prompt ? `${prompt} ${name}` : name;
     const dis = disabled ? 'disabled' : '';
     const cls = extraClass ? ` ${extraClass}` : '';
-    const labelHTML = icon ? '' : `<span class="street-sign">${name}</span>`;
+    const labelHTML = icon && type !== 'interaction' ? '' : `<span class="street-sign">${name}</span>`;
     return `<div class="nav-item${cls}"><button data-type="${type}" ${attrs} aria-label="${aria}" ${dis}>${iconHTML}</button>${labelHTML}</div>`;
   };
   if (pos.building) {

--- a/style.css
+++ b/style.css
@@ -1555,6 +1555,11 @@ body.theme-dark .top-menu button {
   text-align: right;
 }
 
+.shop-item .item-price {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .shop-item .qty {
   width: 4rem;
   justify-self: center;
@@ -1563,6 +1568,27 @@ body.theme-dark .top-menu button {
 .shop-item .buy-btn {
   width: 4rem;
   justify-self: center;
+}
+
+.currency {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15em;
+}
+
+.currency .coin {
+  display: inline-flex;
+  align-items: center;
+}
+
+.currency .coin-amount {
+  margin-right: 0.1em;
+}
+
+.currency .coin-icon {
+  height: 1em;
+  width: auto;
+  vertical-align: middle;
 }
 
 .overlay {


### PR DESCRIPTION
## Summary
- add dedicated Shop/Sell icons to building interactions
- render price values with coin icons instead of text abbreviations
- style coin icons to scale with text

## Testing
- `npm test`
- `node --test tests/economy_import/importer.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c71343439c8325aacaf24b275a59b8