### PR TITLE
Remove shop/sell street sign labels

### DIFF
--- a/script.js
+++ b/script.js
@@ -1501,7 +1501,10 @@ function showNavigation() {
     const aria = prompt ? `${prompt} ${name}` : name;
     const dis = disabled ? 'disabled' : '';
     const cls = extraClass ? ` ${extraClass}` : '';
-    const labelHTML = icon && type !== 'interaction' ? '' : `<span class="street-sign">${name}</span>`;
+    const labelHTML =
+      icon && (type !== 'interaction' || ['shop', 'sell'].includes(action))
+        ? ''
+        : `<span class="street-sign">${name}</span>`;
     return `<div class="nav-item${cls}"><button data-type="${type}" ${attrs} aria-label="${aria}" ${dis}>${iconHTML}</button>${labelHTML}</div>`;
   };
   if (pos.building) {


### PR DESCRIPTION
## Summary
- Hide street sign labels for Shop and Sell actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c71e9fded083258f659d52db979199