### PR TITLE
Add clear local data option to main menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
 <div id="dropdownMenu">
     <button data-action="character-select">Character Select</button>
     <button data-action="new-character">New Character</button>
+    <button data-action="clear-data">Clear Local Data</button>
 </div>
 
 <div id="characterMenu">

--- a/script.js
+++ b/script.js
@@ -3146,6 +3146,19 @@ function loadPreferences() {
   updateScale();
 }
 
+async function clearLocalData() {
+  if (!confirm('Clear all local data? This will reload the page.')) return;
+  try {
+    localStorage.clear();
+    if (typeof caches !== 'undefined') {
+      const keys = await caches.keys();
+      await Promise.all(keys.map(k => caches.delete(k)));
+    }
+  } finally {
+    location.reload();
+  }
+}
+
 const settingsButton = document.getElementById('settings-button');
 const settingsPanel = document.getElementById('settings-panel');
 settingsButton.addEventListener('click', () => {
@@ -3246,6 +3259,8 @@ dropdownMenu.addEventListener('click', e => {
     startCharacterCreation();
   } else if (action === 'character-select') {
     showCharacterSelectUI();
+  } else if (action === 'clear-data') {
+    clearLocalData();
   } else {
     showBackButton();
     setMainHTML(`<div class="no-character"><h1>${action} not implemented</h1></div>`);

--- a/style.css
+++ b/style.css
@@ -9,6 +9,8 @@
   --capped-color: #2e8b57;
   --new-char-bg: #333333;
   --new-char-color: #f0f0f0;
+  --clear-data-bg: #800000;
+  --clear-data-color: #f0f0f0;
   --hp-color: #ff0000;
   --mp-color: #0000ff;
   --stamina-color: #00ff00;
@@ -257,6 +259,13 @@ button:not(:disabled):hover,
   color: var(--new-char-color);
 }
 
+#dropdownMenu button[data-action="clear-data"],
+#dropdownMenu button[data-action="clear-data"]:hover,
+#dropdownMenu button[data-action="clear-data"].selected {
+  background: var(--clear-data-bg);
+  color: var(--clear-data-color);
+}
+
 #characterMenu button svg,
 #characterMenu .letter-icon {
   width: 1.5rem;
@@ -346,6 +355,8 @@ body.theme-light {
   --capped-color: #2e8b57;
   --new-char-bg: #333333;
   --new-char-color: #f0f0f0;
+  --clear-data-bg: #800000;
+  --clear-data-color: #f0f0f0;
   --hp-color: #ff0000;
   --mp-color: #0000ff;
   --stamina-color: #00ff00;
@@ -360,6 +371,8 @@ body.theme-sepia {
   --capped-color: #1e90ff;
   --new-char-bg: #4a3b2d;
   --new-char-color: #e8dcc2;
+  --clear-data-bg: #800000;
+  --clear-data-color: #e8dcc2;
   --hp-color: #800000;
   --mp-color: #000080;
   --stamina-color: #008000;
@@ -380,6 +393,8 @@ body.theme-dark {
   --capped-color: #9370db;
   --new-char-bg: #444444;
   --new-char-color: #eeeeee;
+  --clear-data-bg: #800000;
+  --clear-data-color: #eeeeee;
   --hp-color: #800000;
   --mp-color: #000080;
   --stamina-color: #008000;


### PR DESCRIPTION
## Summary
- Add `Clear Local Data` option to main menu
- Provide styling and theming for the new action
- Implement logic to wipe browser storage and caches, then reload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c71f4d87408325a3eb28d9e3dbc42b