### PR TITLE
Require proficiency for default spells

### DIFF
--- a/script.js
+++ b/script.js
@@ -2105,7 +2105,11 @@ function showSpellbookUI() {
     const schoolValue = currentCharacter[schoolKey] ?? 0;
     const profKey = elementalProficiencyMap[spell.element.toLowerCase()];
     const elemValue = currentCharacter[profKey] ?? 0;
-    if (elemValue >= spell.proficiency && schoolValue >= spell.proficiency) {
+    // Default spells have a proficiency requirement of 0. They should only
+    // unlock once the character has at least some proficiency in both the
+    // associated element and school. Treat 0 as requiring a minimum of 1.
+    const req = Math.max(spell.proficiency, 1);
+    if (elemValue >= req && schoolValue >= req) {
       unlocked.push(spell);
     }
   }

--- a/tests/spellbook.test.ts
+++ b/tests/spellbook.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { SPELLBOOK } from "../assets/data/spells.js";
+import { elementalProficiencyMap, schoolProficiencyMap } from "../assets/data/spell_proficiency.js";
+
+function unlockedSpells(character: Record<string, number>) {
+  const unlocked = [] as typeof SPELLBOOK;
+  for (const spell of SPELLBOOK) {
+    const schoolKey = schoolProficiencyMap[spell.school];
+    const schoolValue = character[schoolKey] ?? 0;
+    const profKey = elementalProficiencyMap[spell.element.toLowerCase()];
+    const elemValue = character[profKey] ?? 0;
+    const req = Math.max(spell.proficiency, 1);
+    if (elemValue >= req && schoolValue >= req) {
+      unlocked.push(spell);
+    }
+  }
+  return unlocked;
+}
+
+describe("spell unlocks", () => {
+  it("excludes default spells when both proficiencies are zero", () => {
+    const character: Record<string, number> = {};
+    expect(unlockedSpells(character).length).toBe(0);
+  });
+
+  it("requires non-zero proficiency in both element and school", () => {
+    const character = { fire: 1, destructive: 0 } as Record<string, number>;
+    expect(unlockedSpells(character).length).toBe(0);
+  });
+
+  it("includes default spells once both proficiencies are above zero", () => {
+    const character = { fire: 1, destructive: 1 } as Record<string, number>;
+    const spells = unlockedSpells(character).filter(
+      s => s.element === "Fire" && s.school === "Destructive"
+    );
+    const names = spells.map(s => s.name);
+    expect(names).toContain("Ember Shot");
+  });
+});


### PR DESCRIPTION
## Summary
- ensure default spells only unlock when both element and school have non-zero proficiency
- add spellbook tests for unlock requirements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c78c4777a4832598baa3c20fa1c7be