### PR TITLE
Align starch datasets with existing file layout

### DIFF
--- a/data/animals.json
+++ b/data/animals.json
@@ -128,6 +128,51 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Albatross, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Albatross move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "aleutian_kelp_otter",
+    "common_name": "Aleutian Kelp Otter",
+    "taxon_group": "mammal",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "kelp_forests"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "fur",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the kelp forests stretch far and wide, there dwells the Aleutian Kelp Otter, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn fur, which merchants and craftsmen prize. Thus does the Aleutian Kelp Otter move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "urchins",
+      "clams"
+    ],
+    "disease_risks": [
+      "toxoplasmosis"
+    ],
+    "size_class": "medium"
+  },
+  {
     "id": "allis-shad",
     "common_name": "Allis shad",
     "taxon_group": "fish",
@@ -196,6 +241,141 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Alpine ibex, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Alpine ibex move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "altamaha_swamp_rabbit",
+    "common_name": "Altamaha Swamp Rabbit",
+    "taxon_group": "mammal",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "swamps",
+      "floodplains"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the swamps and floodplains stretch far and wide, there dwells the Altamaha Swamp Rabbit, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Altamaha Swamp Rabbit move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "cane shoots",
+      "wetland clover"
+    ],
+    "disease_risks": [
+      "myxomatosis"
+    ],
+    "size_class": "small"
+  },
+  {
+    "id": "amazon_river_dolphin",
+    "common_name": "Amazon River Dolphin",
+    "taxon_group": "mammal",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers",
+      "floodplains"
+    ],
+    "diet": [
+      "piscivore",
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the rivers and floodplains stretch far and wide, there dwells the Amazon River Dolphin, a mammal of note. It keeps to a piscivore and carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Amazon River Dolphin move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "pacu",
+      "catfish",
+      "river crustaceans"
+    ],
+    "alt_names": [
+      "Boto"
+    ],
+    "disease_risks": [
+      "waterborne parasites"
+    ],
+    "size_class": "large"
+  },
+  {
+    "id": "amundsen_polar_bear",
+    "common_name": "Amundsen Polar Bear",
+    "taxon_group": "mammal",
+    "regions": [
+      "polar_ice",
+      "coastal"
+    ],
+    "habitats": [
+      "pack_ice",
+      "polar_deserts"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat",
+        "fat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "fat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the polar ice and coastal realms, where the pack ice and polar deserts stretch far and wide, there dwells the Amundsen Polar Bear, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat and fat, ever mindful it must be cooked thoroughly. From its form are drawn hide and fat, which merchants and craftsmen prize. Thus does the Amundsen Polar Bear move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "seals",
+      "walrus calves"
+    ],
+    "disease_risks": [
+      "trichinellosis"
+    ],
+    "size_class": "huge"
+  },
+  {
     "id": "anaconda",
     "common_name": "Anaconda",
     "taxon_group": "other",
@@ -260,6 +440,88 @@
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Anchovy, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Anchovy move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "ancient_karst_salamander",
+    "common_name": "Ancient Karst Salamander",
+    "taxon_group": "amphibian",
+    "regions": [
+      "subterranean"
+    ],
+    "habitats": [
+      "limestone_caves",
+      "underground_rivers"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "none"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the subterranean realms, where the limestone caves and underground rivers stretch far and wide, there dwells the Ancient Karst Salamander, a amphibian of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a none hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Ancient Karst Salamander move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "cave shrimp",
+      "gammarus"
+    ],
+    "size_class": "small"
+  },
+  {
+    "id": "andean_spectacled_bear",
+    "common_name": "Andean Spectacled Bear",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "montane_forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat",
+        "fat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "fat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the montane forest stretch far and wide, there dwells the Andean Spectacled Bear, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat and fat, ever mindful it must be cooked thoroughly. From its form are drawn hide and fat, which merchants and craftsmen prize. Thus does the Andean Spectacled Bear move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "bromeliads",
+      "guava",
+      "termite mounds"
+    ],
+    "size_class": "large"
+  },
+  {
     "id": "anole",
     "common_name": "Anole",
     "taxon_group": "other",
@@ -322,6 +584,52 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Ant, a insect of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Ant move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "arctic_ground_squirrel",
+    "common_name": "Arctic Ground Squirrel",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "arctic_tundra"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "fur",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the arctic tundra stretch far and wide, there dwells the Arctic Ground Squirrel, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn fur, which merchants and craftsmen prize. Thus does the Arctic Ground Squirrel move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "lichen",
+      "seed heads",
+      "berries"
+    ],
+    "disease_risks": [
+      "tularemia"
+    ],
+    "size_class": "small"
   },
   {
     "id": "arctic-char",
@@ -422,6 +730,80 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the grassland stretch far and wide, there dwells the Wild donkey, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Wild donkey move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "atacama_salt_flamingo",
+    "common_name": "Atacama Salt Flamingo",
+    "taxon_group": "bird",
+    "regions": [
+      "extreme"
+    ],
+    "habitats": [
+      "hyper_arid_salt_basins"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the extreme realms, where the hyper arid salt basins stretch far and wide, there dwells the Atacama Salt Flamingo, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Atacama Salt Flamingo move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "brine shrimp",
+      "algae"
+    ],
+    "size_class": "medium"
+  },
+  {
+    "id": "atlas_barbary_macaque",
+    "common_name": "Atlas Barbary Macaque",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "montane_forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the montane forest stretch far and wide, there dwells the Atlas Barbary Macaque, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Atlas Barbary Macaque move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "oak mast",
+      "forest insects"
+    ],
+    "disease_risks": [
+      "simian herpes"
+    ],
+    "size_class": "medium"
   },
   {
     "id": "aurochs",
@@ -556,6 +938,113 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Badger, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Badger move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "baikal_seal_colony",
+    "common_name": "Baikal Seal Colony",
+    "taxon_group": "mammal",
+    "regions": [
+      "aquatic",
+      "polar_ice"
+    ],
+    "habitats": [
+      "lakes",
+      "pack_ice"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat",
+        "fat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "fat",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic and polar ice realms, where the lakes and pack ice stretch far and wide, there dwells the Baikal Seal Colony, a mammal of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat and fat, ever mindful it must be cooked thoroughly. From its form are drawn fat and hide, which merchants and craftsmen prize. Thus does the Baikal Seal Colony move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "golomyanka",
+      "smelt"
+    ],
+    "alt_names": [
+      "Nerpa"
+    ],
+    "disease_risks": [
+      "parasites"
+    ],
+    "size_class": "medium"
+  },
+  {
+    "id": "baltic_gray_seal",
+    "common_name": "Baltic Gray Seal",
+    "taxon_group": "mammal",
+    "regions": [
+      "coastal",
+      "polar_ice"
+    ],
+    "habitats": [
+      "ocean_shores",
+      "ice_shelves"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat",
+        "fat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "fat",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal and polar ice realms, where the ocean shores and ice shelves stretch far and wide, there dwells the Baltic Gray Seal, a mammal of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat and fat, ever mindful it must be cooked thoroughly. From its form are drawn fat and hide, which merchants and craftsmen prize. Thus does the Baltic Gray Seal move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "herring",
+      "cod"
+    ],
+    "disease_risks": [
+      "phocine distemper"
+    ],
+    "size_class": "large"
+  },
+  {
     "id": "barbary-ape",
     "common_name": "Barbary ape",
     "taxon_group": "mammal",
@@ -656,6 +1145,77 @@
     "narrative": "In the terrestrial realms, where the ocean shores stretch far and wide, there dwells the Barnacle goose, a bird of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Barnacle goose move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "barren_volcanic_hawk",
+    "common_name": "Barren Volcanic Hawk",
+    "taxon_group": "bird",
+    "regions": [
+      "extreme"
+    ],
+    "habitats": [
+      "volcanic_regions",
+      "cliffs"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the extreme realms, where the volcanic regions and cliffs stretch far and wide, there dwells the Barren Volcanic Hawk, a bird of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Barren Volcanic Hawk move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "lava lizards",
+      "rodents"
+    ],
+    "size_class": "medium"
+  },
+  {
+    "id": "basque_cave_cricket",
+    "common_name": "Basque Cave Cricket",
+    "taxon_group": "insect",
+    "regions": [
+      "subterranean"
+    ],
+    "habitats": [
+      "limestone_caves"
+    ],
+    "diet": [
+      "detritivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "none"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the subterranean realms, where the limestone caves stretch far and wide, there dwells the Basque Cave Cricket, a insect of note. It keeps to a detritivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a none hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Basque Cave Cricket move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "fungal threads",
+      "decaying leaves"
+    ],
+    "size_class": "tiny"
+  },
+  {
     "id": "bat",
     "common_name": "Bat",
     "taxon_group": "mammal",
@@ -720,6 +1280,57 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Bear, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Bear move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "beaufort_ringed_seal",
+    "common_name": "Beaufort Ringed Seal",
+    "taxon_group": "mammal",
+    "regions": [
+      "polar_ice"
+    ],
+    "habitats": [
+      "pack_ice",
+      "ice_shelves"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat",
+        "fat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "fat",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the polar ice realms, where the pack ice and ice shelves stretch far and wide, there dwells the Beaufort Ringed Seal, a mammal of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat and fat, ever mindful it must be cooked thoroughly. From its form are drawn fat and hide, which merchants and craftsmen prize. Thus does the Beaufort Ringed Seal move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "arctic cod",
+      "shrimp"
+    ],
+    "disease_risks": [
+      "brucellosis"
+    ],
+    "size_class": "medium"
+  },
+  {
     "id": "beaver",
     "common_name": "Beaver",
     "taxon_group": "mammal",
@@ -750,6 +1361,39 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Beaver, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Beaver move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "bengal_thicket_cat",
+    "common_name": "Bengal Thicket Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "dry_forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the dry forest stretch far and wide, there dwells the Bengal Thicket Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Bengal Thicket Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "jungle fowl",
+      "rodents"
+    ],
+    "size_class": "medium"
   },
   {
     "id": "bezoar-goat",
@@ -1048,6 +1692,40 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Boar, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Boar move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "boreal_bog_lemming",
+    "common_name": "Boreal Bog Lemming",
+    "taxon_group": "mammal",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "bogs",
+      "fens"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the bogs and fens stretch far and wide, there dwells the Boreal Bog Lemming, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Boreal Bog Lemming move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "sedge",
+      "bog moss"
+    ],
+    "size_class": "tiny"
+  },
+  {
     "id": "brill",
     "common_name": "Brill",
     "taxon_group": "fish",
@@ -1247,6 +1925,48 @@
     "narrative": "In the terrestrial realms, where the grassland stretch far and wide, there dwells the Camelopard, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Camelopard move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "canary_laurel_pigeon",
+    "common_name": "Canary Laurel Pigeon",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "temperate_rainforest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the temperate rainforest stretch far and wide, there dwells the Canary Laurel Pigeon, a bird of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Canary Laurel Pigeon move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "laurel berries",
+      "mistletoe fruit"
+    ],
+    "size_class": "small"
+  },
+  {
     "id": "capercaillie",
     "common_name": "Capercaillie",
     "taxon_group": "bird",
@@ -1343,6 +2063,95 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Caracal, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Caracal move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "caribbean_hydrothermal_shrimp",
+    "common_name": "Caribbean Hydrothermal Shrimp",
+    "taxon_group": "crustacean",
+    "regions": [
+      "extreme"
+    ],
+    "habitats": [
+      "deep_sea",
+      "geothermal_springs"
+    ],
+    "diet": [
+      "detritivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "none"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the extreme realms, where the deep sea and geothermal springs stretch far and wide, there dwells the Caribbean Hydrothermal Shrimp, a crustacean of note. It keeps to a detritivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a none hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Caribbean Hydrothermal Shrimp move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "bacterial mats",
+      "sulfur flakes"
+    ],
+    "size_class": "small"
+  },
+  {
+    "id": "caribbean_reef_shark",
+    "common_name": "Caribbean Reef Shark",
+    "taxon_group": "fish",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coral_reefs",
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the coral reefs and open ocean stretch far and wide, there dwells the Caribbean Reef Shark, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Caribbean Reef Shark move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "reef fish",
+      "cephalopods"
+    ],
+    "disease_risks": [
+      "ciguatera"
+    ],
+    "size_class": "large"
+  },
+  {
     "id": "carp",
     "common_name": "Carp",
     "taxon_group": "fish",
@@ -1405,6 +2214,42 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Carp bream, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Carp bream move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "caspian_steppe_lynx",
+    "common_name": "Caspian Steppe Lynx",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "steppe"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the steppe stretch far and wide, there dwells the Caspian Steppe Lynx, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Caspian Steppe Lynx move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "hares",
+      "wild geese"
+    ],
+    "disease_risks": [
+      "rabies"
+    ],
+    "size_class": "medium"
   },
   {
     "id": "cassowary",
@@ -1510,6 +2355,48 @@
       "wool_shearing_cycle": ""
     },
     "butchering_age": "1 year"
+  },
+  {
+    "id": "cattail_bittern",
+    "common_name": "Cattail Bittern",
+    "taxon_group": "bird",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "marshes"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the marshes stretch far and wide, there dwells the Cattail Bittern, a bird of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Cattail Bittern move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "frogs",
+      "marsh insects"
+    ],
+    "size_class": "small"
   },
   {
     "id": "cattle",
@@ -1868,6 +2755,53 @@
     "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Chub, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Chub move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "chukchi_ice_fox",
+    "common_name": "Chukchi Ice Fox",
+    "taxon_group": "mammal",
+    "regions": [
+      "polar_ice",
+      "terrestrial"
+    ],
+    "habitats": [
+      "snowfields",
+      "arctic_tundra"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "fur",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the polar ice and terrestrial realms, where the snowfields and arctic tundra stretch far and wide, there dwells the Chukchi Ice Fox, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn fur, which merchants and craftsmen prize. Thus does the Chukchi Ice Fox move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "lemmings",
+      "seal carrion"
+    ],
+    "disease_risks": [
+      "rabies"
+    ],
+    "size_class": "small"
+  },
+  {
     "id": "civet",
     "common_name": "Civet",
     "taxon_group": "mammal",
@@ -2196,6 +3130,48 @@
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Conger eel, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Conger eel move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "congo_tigerfish",
+    "common_name": "Congo Tigerfish",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Congo Tigerfish, a fish of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Congo Tigerfish move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "tilapia",
+      "river minnows"
+    ],
+    "size_class": "medium"
+  },
+  {
     "id": "coot",
     "common_name": "Coot",
     "taxon_group": "bird",
@@ -2388,6 +3364,41 @@
     "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Crow, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Crow move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "cuatrocienegas_blind_loach",
+    "common_name": "Cuatrociénegas Blind Loach",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic",
+      "subterranean"
+    ],
+    "habitats": [
+      "underground_rivers",
+      "underground_lakes"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "none"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the aquatic and subterranean realms, where the underground rivers and underground lakes stretch far and wide, there dwells the Cuatrociénegas Blind Loach, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a none hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Cuatrociénegas Blind Loach move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "crustaceans",
+      "biofilm"
+    ],
+    "size_class": "small"
+  },
+  {
     "id": "cuckoo",
     "common_name": "Cuckoo",
     "taxon_group": "bird",
@@ -2556,6 +3567,175 @@
     "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Dace, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Dace move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "danakil_salt_fox",
+    "common_name": "Danakil Salt Fox",
+    "taxon_group": "mammal",
+    "regions": [
+      "extreme"
+    ],
+    "habitats": [
+      "hyper_arid_salt_basins"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "fur",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the extreme realms, where the hyper arid salt basins stretch far and wide, there dwells the Danakil Salt Fox, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn fur, which merchants and craftsmen prize. Thus does the Danakil Salt Fox move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "saltbush mice",
+      "beetles"
+    ],
+    "size_class": "small"
+  },
+  {
+    "id": "danube_backwater_pike",
+    "common_name": "Danube Backwater Pike",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers",
+      "floodplains"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the rivers and floodplains stretch far and wide, there dwells the Danube Backwater Pike, a fish of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Danube Backwater Pike move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "perch",
+      "carp fry"
+    ],
+    "disease_risks": [
+      "tapeworm"
+    ],
+    "size_class": "medium"
+  },
+  {
+    "id": "darwin_blue_footed_booby",
+    "common_name": "Darwin Blue-Footed Booby",
+    "taxon_group": "bird",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "ocean_shores",
+      "cliffs"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the ocean shores and cliffs stretch far and wide, there dwells the Darwin Blue-Footed Booby, a bird of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Darwin Blue-Footed Booby move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "anchovies",
+      "sardines"
+    ],
+    "size_class": "medium"
+  },
+  {
+    "id": "deccan_spotted_chevrotain",
+    "common_name": "Deccan Spotted Chevrotain",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "dry_forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the dry forest stretch far and wide, there dwells the Deccan Spotted Chevrotain, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Deccan Spotted Chevrotain move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "fallen fruit",
+      "young shoots"
+    ],
+    "size_class": "small"
+  },
+  {
     "id": "deer",
     "common_name": "Red Deer",
     "taxon_group": "mammal",
@@ -2643,6 +3823,49 @@
     "butchering_age": "3 years"
   },
   {
+    "id": "delta_mud_heron",
+    "common_name": "Delta Mud Heron",
+    "taxon_group": "bird",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "floodplains",
+      "marshes"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the floodplains and marshes stretch far and wide, there dwells the Delta Mud Heron, a bird of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Delta Mud Heron move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "mudfish",
+      "crayfish"
+    ],
+    "size_class": "medium"
+  },
+  {
     "id": "dhole",
     "common_name": "Dhole",
     "taxon_group": "other",
@@ -2705,6 +3928,43 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Dik-dik, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Dik-dik move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "dinaric_white_olm",
+    "common_name": "Dinaric White Olm",
+    "taxon_group": "amphibian",
+    "regions": [
+      "subterranean"
+    ],
+    "habitats": [
+      "limestone_caves",
+      "underground_lakes"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "none"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the subterranean realms, where the limestone caves and underground lakes stretch far and wide, there dwells the Dinaric White Olm, a amphibian of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a none hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Dinaric White Olm move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "aquatic snails",
+      "insects"
+    ],
+    "alt_names": [
+      "Proteus"
+    ],
+    "size_class": "small"
   },
   {
     "id": "dingo",
@@ -3062,6 +4322,43 @@
     ]
   },
   {
+    "id": "drakensberg_rock_hyrax",
+    "common_name": "Drakensberg Rock Hyrax",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hills"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the hills stretch far and wide, there dwells the Drakensberg Rock Hyrax, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Drakensberg Rock Hyrax move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "tuft grasses",
+      "alpine shrubs"
+    ],
+    "size_class": "small"
+  },
+  {
     "id": "duck",
     "common_name": "Duck",
     "taxon_group": "bird",
@@ -3182,6 +4479,46 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Dugong, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Dugong move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "dyrholaey_arctic_tern",
+    "common_name": "Dyrhólaey Arctic Tern",
+    "taxon_group": "bird",
+    "regions": [
+      "polar_ice",
+      "coastal"
+    ],
+    "habitats": [
+      "cliffs",
+      "pack_ice"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the polar ice and coastal realms, where the cliffs and pack ice stretch far and wide, there dwells the Dyrhólaey Arctic Tern, a bird of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Dyrhólaey Arctic Tern move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "capelin",
+      "sand eels"
+    ],
+    "size_class": "small"
+  },
+  {
     "id": "eagle",
     "common_name": "Eagle",
     "taxon_group": "bird",
@@ -3244,6 +4581,102 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the farmland stretch far and wide, there dwells the Earthworm, a annelid of note. It keeps to a detritivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Earthworm move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "east_greenland_muskoxen",
+    "common_name": "East Greenland Muskoxen",
+    "taxon_group": "mammal",
+    "regions": [
+      "polar_ice",
+      "terrestrial"
+    ],
+    "habitats": [
+      "arctic_tundra",
+      "polar_deserts"
+    ],
+    "diet": [
+      "grazer"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the polar ice and terrestrial realms, where the arctic tundra and polar deserts stretch far and wide, there dwells the East Greenland Muskoxen, a mammal of note. It keeps to a grazer fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide and meat, which merchants and craftsmen prize. Thus does the East Greenland Muskoxen move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "sedges",
+      "willow buds"
+    ],
+    "alt_names": [
+      "Muskox Herd"
+    ],
+    "disease_risks": [
+      "lungworm"
+    ],
+    "size_class": "large"
+  },
+  {
+    "id": "eastern_freshwater_cod",
+    "common_name": "Eastern Freshwater Cod",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Eastern Freshwater Cod, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Eastern Freshwater Cod move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "shrimp",
+      "small fish"
+    ],
+    "size_class": "large"
   },
   {
     "id": "echidna",
@@ -3342,6 +4775,39 @@
     "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Eelpout, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Eelpout move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "eldfell_lava_tube_spider",
+    "common_name": "Eldfell Lava Tube Spider",
+    "taxon_group": "arachnid",
+    "regions": [
+      "subterranean"
+    ],
+    "habitats": [
+      "lava_tubes"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the subterranean realms, where the lava tubes stretch far and wide, there dwells the Eldfell Lava Tube Spider, a arachnid of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Eldfell Lava Tube Spider move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "cave midges",
+      "isopods"
+    ],
+    "size_class": "small"
+  },
+  {
     "id": "electric-ray",
     "common_name": "Electric ray",
     "taxon_group": "other",
@@ -3438,6 +4904,48 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Elk, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Elk move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "elysian_tidepool_octopus",
+    "common_name": "Elysian Tidepool Octopus",
+    "taxon_group": "mollusk",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "tidal_flats"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the tidal flats stretch far and wide, there dwells the Elysian Tidepool Octopus, a mollusk of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Elysian Tidepool Octopus move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "crabs",
+      "snails"
+    ],
+    "size_class": "small"
+  },
+  {
     "id": "emu",
     "common_name": "Emu",
     "taxon_group": "other",
@@ -3502,6 +5010,82 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Ermine, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Ermine move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "ethiopian_geyser_frog",
+    "common_name": "Ethiopian Geyser Frog",
+    "taxon_group": "amphibian",
+    "regions": [
+      "extreme"
+    ],
+    "habitats": [
+      "geothermal_springs"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the extreme realms, where the geothermal springs stretch far and wide, there dwells the Ethiopian Geyser Frog, a amphibian of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Ethiopian Geyser Frog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "thermal midges",
+      "mosquitoes"
+    ],
+    "disease_risks": [
+      "chytrid"
+    ],
+    "size_class": "small"
+  },
+  {
+    "id": "ethiopian_highland_hare",
+    "common_name": "Ethiopian Highland Hare",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "alpine_tundra"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the alpine tundra stretch far and wide, there dwells the Ethiopian Highland Hare, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Ethiopian Highland Hare move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "heather shoots",
+      "tuft grasses"
+    ],
+    "disease_risks": [
+      "parasites"
+    ],
+    "size_class": "small"
+  },
+  {
     "id": "eurasian-jay",
     "common_name": "Eurasian jay",
     "taxon_group": "bird",
@@ -3536,6 +5120,44 @@
     ],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Eurasian jay, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Eurasian jay move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "everglade_snail_kite",
+    "common_name": "Everglade Snail Kite",
+    "taxon_group": "bird",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "marshes",
+      "swamps"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the marshes and swamps stretch far and wide, there dwells the Everglade Snail Kite, a bird of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Everglade Snail Kite move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "apple snails"
+    ],
+    "size_class": "medium"
   },
   {
     "id": "falcon",
@@ -3638,6 +5260,45 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Fennec fox, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Fennec fox move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "feroe_stormy_petrel",
+    "common_name": "Feroe Stormy Petrel",
+    "taxon_group": "bird",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "open_ocean",
+      "cliffs"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the open ocean and cliffs stretch far and wide, there dwells the Feroe Stormy Petrel, a bird of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Feroe Stormy Petrel move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "sand eels",
+      "plankton"
+    ],
+    "size_class": "small"
+  },
+  {
     "id": "ferret",
     "common_name": "Ferret",
     "taxon_group": "mammal",
@@ -3738,6 +5399,49 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Finch, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Finch move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "finnmark_arctic_char",
+    "common_name": "Finnmark Arctic Char",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "lakes",
+      "rivers"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the lakes and rivers stretch far and wide, there dwells the Finnmark Arctic Char, a fish of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Finnmark Arctic Char move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "caddis larvae",
+      "whitefish"
+    ],
+    "size_class": "medium"
+  },
+  {
     "id": "flamingo",
     "common_name": "Flamingo",
     "taxon_group": "bird",
@@ -3768,6 +5472,49 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the marshes stretch far and wide, there dwells the Flamingo, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Flamingo move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "floodplain_reedbuck",
+    "common_name": "Floodplain Reedbuck",
+    "taxon_group": "mammal",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "floodplains",
+      "marshes"
+    ],
+    "diet": [
+      "grazer"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the floodplains and marshes stretch far and wide, there dwells the Floodplain Reedbuck, a mammal of note. It keeps to a grazer fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Floodplain Reedbuck move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "reed grasses",
+      "waterlily leaves"
+    ],
+    "size_class": "medium"
   },
   {
     "id": "flounder",
@@ -3934,6 +5681,85 @@
     "narrative": "In the terrestrial realms, where the marshes stretch far and wide, there dwells the Frog, a amphibian of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Frog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "fynbos_cape_grysbok",
+    "common_name": "Fynbos Cape Grysbok",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "semi_arid_scrublands"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the semi arid scrublands stretch far and wide, there dwells the Fynbos Cape Grysbok, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Fynbos Cape Grysbok move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "fynbos shrubs",
+      "succulent shoots"
+    ],
+    "disease_risks": [
+      "ticks"
+    ],
+    "size_class": "small"
+  },
+  {
+    "id": "galapagos_marine_iguana",
+    "common_name": "Galápagos Marine Iguana",
+    "taxon_group": "reptile",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "ocean_shores",
+      "coastal_dunes"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the ocean shores and coastal dunes stretch far and wide, there dwells the Galápagos Marine Iguana, a reptile of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Galápagos Marine Iguana move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "marine algae",
+      "sea lettuce"
+    ],
+    "size_class": "medium"
+  },
+  {
     "id": "gall-wasp-oak-gall",
     "common_name": "Gall wasp (oak gall)",
     "taxon_group": "insect",
@@ -3960,6 +5786,52 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Gall wasp (oak gall), a insect of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Gall wasp (oak gall) move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "ganges_softshell_turtle",
+    "common_name": "Ganges Softshell Turtle",
+    "taxon_group": "reptile",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers",
+      "floodplains"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "shell",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the rivers and floodplains stretch far and wide, there dwells the Ganges Softshell Turtle, a reptile of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn shell, which merchants and craftsmen prize. Thus does the Ganges Softshell Turtle move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "snails",
+      "fish"
+    ],
+    "disease_risks": [
+      "salmonella"
+    ],
+    "size_class": "large"
   },
   {
     "id": "gannet",
@@ -4372,6 +6244,39 @@
       "wool_shearing_cycle": ""
     },
     "butchering_age": "1 year"
+  },
+  {
+    "id": "gobi_long_eared_jerboa",
+    "common_name": "Gobi Long-Eared Jerboa",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "cold_desert"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the cold desert stretch far and wide, there dwells the Gobi Long-Eared Jerboa, a mammal of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Gobi Long-Eared Jerboa move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "beetles",
+      "desert moths"
+    ],
+    "size_class": "tiny"
   },
   {
     "id": "golden-jackal",
@@ -4925,6 +6830,52 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Guinea fowl, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Guinea fowl move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "gulf_coast_muskrat",
+    "common_name": "Gulf Coast Muskrat",
+    "taxon_group": "mammal",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "marshes",
+      "swamps"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "fur",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the marshes and swamps stretch far and wide, there dwells the Gulf Coast Muskrat, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn fur, which merchants and craftsmen prize. Thus does the Gulf Coast Muskrat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "cattails",
+      "bulrush"
+    ],
+    "disease_risks": [
+      "leptospirosis"
+    ],
+    "size_class": "small"
+  },
+  {
     "id": "gull",
     "common_name": "Gull",
     "taxon_group": "bird",
@@ -5019,6 +6970,59 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Hagfish, a fish of note. It keeps to a scavenger fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Hagfish move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "haida_gwaii_humpback",
+    "common_name": "Haida Gwaii Humpback",
+    "taxon_group": "mammal",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "open_ocean",
+      "continental_shelves"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "fat",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the open ocean and continental shelves stretch far and wide, there dwells the Haida Gwaii Humpback, a mammal of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn fat and meat, which merchants and craftsmen prize. Thus does the Haida Gwaii Humpback move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "herring",
+      "krill"
+    ],
+    "alt_names": [
+      "Pacific Humpback"
+    ],
+    "disease_risks": [
+      "parasites"
+    ],
+    "size_class": "huge"
   },
   {
     "id": "hake",
@@ -5377,6 +7381,48 @@
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Herring, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Herring move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "himalayan_musk_deer",
+    "common_name": "Himalayan Musk Deer",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "montane_forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the montane forest stretch far and wide, there dwells the Himalayan Musk Deer, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Himalayan Musk Deer move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "lichen",
+      "highland herbs"
+    ],
+    "size_class": "medium"
+  },
+  {
     "id": "honeybee",
     "common_name": "Honeybee",
     "taxon_group": "insect",
@@ -5572,6 +7618,82 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Howler monkey, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Howler monkey move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "huanghe_chinese_sturgeon",
+    "common_name": "Huanghe Chinese Sturgeon",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Huanghe Chinese Sturgeon, a fish of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Huanghe Chinese Sturgeon move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "shrimp",
+      "small fish"
+    ],
+    "size_class": "large"
+  },
+  {
+    "id": "huanghe_reed_warbler",
+    "common_name": "Huanghe Reed Warbler",
+    "taxon_group": "bird",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "floodplains",
+      "marshes"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "none"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the floodplains and marshes stretch far and wide, there dwells the Huanghe Reed Warbler, a bird of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a none hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Huanghe Reed Warbler move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "dragonflies",
+      "mosquito larvae"
+    ],
+    "size_class": "small"
+  },
+  {
     "id": "hyena",
     "common_name": "Hyena",
     "taxon_group": "mammal",
@@ -5634,6 +7756,53 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Hyrax, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Hyrax move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "iberian_montado_boar",
+    "common_name": "Iberian Montado Boar",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the forest and farmland stretch far and wide, there dwells the Iberian Montado Boar, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Iberian Montado Boar move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "acorns",
+      "roots",
+      "grubs"
+    ],
+    "disease_risks": [
+      "trichinosis"
+    ],
+    "size_class": "large"
   },
   {
     "id": "iberian-lynx",
@@ -5730,6 +7899,49 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the marshes stretch far and wide, there dwells the Ibis, a bird of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Ibis move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "idanre_wetland_duiker",
+    "common_name": "Idanre Wetland Duiker",
+    "taxon_group": "mammal",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "swamps",
+      "forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the swamps and forest stretch far and wide, there dwells the Idanre Wetland Duiker, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Idanre Wetland Duiker move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "aquatic herbs",
+      "fallen fruit"
+    ],
+    "size_class": "small"
   },
   {
     "id": "ide-orfe",
@@ -5832,6 +8044,85 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Impala, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Impala move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "indian_ocean_dolphin_fish",
+    "common_name": "Indian Ocean Dolphin Fish",
+    "taxon_group": "fish",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the open ocean stretch far and wide, there dwells the Indian Ocean Dolphin Fish, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Indian Ocean Dolphin Fish move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "flying fish",
+      "cephalopods"
+    ],
+    "size_class": "large"
+  },
+  {
+    "id": "inirida_giant_otter",
+    "common_name": "Inírida Giant Otter",
+    "taxon_group": "mammal",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers",
+      "swamps"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the rivers and swamps stretch far and wide, there dwells the Inírida Giant Otter, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Inírida Giant Otter move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "armored catfish",
+      "cichlids"
+    ],
+    "disease_risks": [
+      "canine distemper"
+    ],
+    "size_class": "large"
+  },
+  {
     "id": "jackdaw",
     "common_name": "Jackdaw",
     "taxon_group": "bird",
@@ -5862,6 +8153,94 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Jackdaw, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Jackdaw move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "javan_rainforest_peacock",
+    "common_name": "Javan Rainforest Peacock",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "tropical_rainforest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the tropical rainforest stretch far and wide, there dwells the Javan Rainforest Peacock, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Javan Rainforest Peacock move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "forest fruit",
+      "ground insects"
+    ],
+    "alt_names": [
+      "Java Peafowl"
+    ],
+    "size_class": "medium"
+  },
+  {
+    "id": "jeju_black_volcanic_crab",
+    "common_name": "Jeju Black Volcanic Crab",
+    "taxon_group": "crustacean",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "tidal_flats",
+      "lava_tubes"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the tidal flats and lava tubes stretch far and wide, there dwells the Jeju Black Volcanic Crab, a crustacean of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Jeju Black Volcanic Crab move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "algae",
+      "detritus"
+    ],
+    "size_class": "small"
   },
   {
     "id": "jellyfish",
@@ -5928,6 +8307,129 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Jerboa, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Jerboa move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "jinxian_rice_paddy_frog",
+    "common_name": "Jinxian Rice Paddy Frog",
+    "taxon_group": "amphibian",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "floodplains",
+      "farmland"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the floodplains and farmland stretch far and wide, there dwells the Jinxian Rice Paddy Frog, a amphibian of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Jinxian Rice Paddy Frog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "midges",
+      "rice pests"
+    ],
+    "size_class": "small"
+  },
+  {
+    "id": "juruena_armored_catfish",
+    "common_name": "Juruena Armored Catfish",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "detritivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Juruena Armored Catfish, a fish of note. It keeps to a detritivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Juruena Armored Catfish move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "algae films",
+      "leaf litter"
+    ],
+    "size_class": "small"
+  },
+  {
+    "id": "kafue_floodplain_lechwe",
+    "common_name": "Kafue Floodplain Lechwe",
+    "taxon_group": "mammal",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "floodplains",
+      "marshes"
+    ],
+    "diet": [
+      "grazer"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the floodplains and marshes stretch far and wide, there dwells the Kafue Floodplain Lechwe, a mammal of note. It keeps to a grazer fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Kafue Floodplain Lechwe move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "emergent grasses",
+      "aquatic sedge"
+    ],
+    "size_class": "medium"
+  },
+  {
     "id": "kakapo",
     "common_name": "Kakapo",
     "taxon_group": "other",
@@ -5958,6 +8460,39 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Kakapo, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Kakapo move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "kalahari_meerkat_band",
+    "common_name": "Kalahari Meerkat Band",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hot_desert"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the hot desert stretch far and wide, there dwells the Kalahari Meerkat Band, a mammal of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Kalahari Meerkat Band move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "beetle grubs",
+      "scorpions"
+    ],
+    "size_class": "small"
   },
   {
     "id": "kangaroo",
@@ -6050,6 +8585,49 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Kestrel, a bird of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Kestrel move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "kinabatangan_plain_catfish",
+    "common_name": "Kinabatangan Plain Catfish",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers",
+      "swamps"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the rivers and swamps stretch far and wide, there dwells the Kinabatangan Plain Catfish, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Kinabatangan Plain Catfish move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "freshwater prawns",
+      "snails"
+    ],
+    "size_class": "medium"
   },
   {
     "id": "kingfisher",
@@ -6152,6 +8730,45 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Kiwi, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Kiwi move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "komandor_fulmar",
+    "common_name": "Komandor Fulmar",
+    "taxon_group": "bird",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "open_ocean",
+      "cliffs"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the open ocean and cliffs stretch far and wide, there dwells the Komandor Fulmar, a bird of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Komandor Fulmar move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "squid",
+      "small fish"
+    ],
+    "size_class": "medium"
+  },
+  {
     "id": "komodo-dragon",
     "common_name": "Komodo dragon",
     "taxon_group": "other",
@@ -6246,6 +8863,99 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Kudu, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Kudu move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "lagoon_spotted_ray",
+    "common_name": "Lagoon Spotted Ray",
+    "taxon_group": "fish",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "lagoons",
+      "estuaries"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the lagoons and estuaries stretch far and wide, there dwells the Lagoon Spotted Ray, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Lagoon Spotted Ray move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "crabs",
+      "shrimp"
+    ],
+    "size_class": "medium"
+  },
+  {
+    "id": "laguna_capybara",
+    "common_name": "Laguna Capybara",
+    "taxon_group": "mammal",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "swamps",
+      "floodplains"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the swamps and floodplains stretch far and wide, there dwells the Laguna Capybara, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide and meat, which merchants and craftsmen prize. Thus does the Laguna Capybara move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "cane grass",
+      "water lettuce"
+    ],
+    "disease_risks": [
+      "leptospirosis"
+    ],
+    "size_class": "large"
   },
   {
     "id": "lamprey",
@@ -6672,6 +9382,82 @@
     "narrative": "In the aquatic realms, where the ocean shores stretch far and wide, there dwells the Lobster, a crustacean of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Lobster move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "loess_plateau_pika",
+    "common_name": "Loess Plateau Pika",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hills"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the hills stretch far and wide, there dwells the Loess Plateau Pika, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Loess Plateau Pika move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "bunchgrass",
+      "wildflowers"
+    ],
+    "size_class": "small"
+  },
+  {
+    "id": "lower_mekong_giant_barb",
+    "common_name": "Lower Mekong Giant Barb",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers",
+      "floodplains"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the rivers and floodplains stretch far and wide, there dwells the Lower Mekong Giant Barb, a fish of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Lower Mekong Giant Barb move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "river algae",
+      "flooded figs"
+    ],
+    "size_class": "huge"
+  },
+  {
     "id": "lynx",
     "common_name": "Lynx",
     "taxon_group": "mammal",
@@ -6734,6 +9520,76 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Mackerel, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Mackerel move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "madagascar_leaf_tailed_gecko",
+    "common_name": "Madagascar Leaf-Tailed Gecko",
+    "taxon_group": "reptile",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "tropical_rainforest"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the tropical rainforest stretch far and wide, there dwells the Madagascar Leaf-Tailed Gecko, a reptile of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Madagascar Leaf-Tailed Gecko move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "moths",
+      "forest crickets"
+    ],
+    "size_class": "small"
+  },
+  {
+    "id": "madagascar_rainbowfish",
+    "common_name": "Madagascar Rainbowfish",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "streams",
+      "rivers"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the streams and rivers stretch far and wide, there dwells the Madagascar Rainbowfish, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Madagascar Rainbowfish move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "insects",
+      "diatoms"
+    ],
+    "alt_names": [
+      "Madagascar Rainbow"
+    ],
+    "size_class": "small"
   },
   {
     "id": "magpie",
@@ -6832,6 +9688,56 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Manatee, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Manatee move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "mangrove_saltwater_crocodile",
+    "common_name": "Mangrove Saltwater Crocodile",
+    "taxon_group": "reptile",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "mangroves",
+      "estuaries"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the mangroves and estuaries stretch far and wide, there dwells the Mangrove Saltwater Crocodile, a reptile of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide and meat, which merchants and craftsmen prize. Thus does the Mangrove Saltwater Crocodile move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "fish",
+      "wild boar"
+    ],
+    "disease_risks": [
+      "salmonella"
+    ],
+    "size_class": "huge"
+  },
+  {
     "id": "markhor",
     "common_name": "Markhor",
     "taxon_group": "other",
@@ -6894,6 +9800,40 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Marmot, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Marmot move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "marshland_mongoose",
+    "common_name": "Marshland Mongoose",
+    "taxon_group": "mammal",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "marshes",
+      "swamps"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the marshes and swamps stretch far and wide, there dwells the Marshland Mongoose, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Marshland Mongoose move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "snakes",
+      "crabs"
+    ],
+    "size_class": "small"
   },
   {
     "id": "marten",
@@ -7523,6 +10463,88 @@
     "narrative": "In the aquatic realms, where the ocean shores stretch far and wide, there dwells the Mussel, a mollusk of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Mussel move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "nam_song_rice_paddy_eel",
+    "common_name": "Nam Song Rice Paddy Eel",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "floodplains",
+      "ponds"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the floodplains and ponds stretch far and wide, there dwells the Nam Song Rice Paddy Eel, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Nam Song Rice Paddy Eel move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "snails",
+      "small fish"
+    ],
+    "disease_risks": [
+      "parasites"
+    ],
+    "size_class": "small"
+  },
+  {
+    "id": "namib_brown_hyena",
+    "common_name": "Namib Brown Hyena",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hot_desert"
+    ],
+    "diet": [
+      "scavenger"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the hot desert stretch far and wide, there dwells the Namib Brown Hyena, a mammal of note. It keeps to a scavenger fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Namib Brown Hyena move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "carrion",
+      "desert beetles"
+    ],
+    "disease_risks": [
+      "rabies"
+    ],
+    "size_class": "large"
+  },
+  {
     "id": "narwhal",
     "common_name": "Narwhal",
     "taxon_group": "other",
@@ -7651,6 +10673,51 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Nightjar, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Nightjar move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "north_sea_codline",
+    "common_name": "North Sea Codline",
+    "taxon_group": "fish",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "continental_shelves"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the continental shelves stretch far and wide, there dwells the North Sea Codline, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the North Sea Codline move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "sand eels",
+      "herring"
+    ],
+    "disease_risks": [
+      "anisakiasis"
+    ],
+    "size_class": "large"
+  },
+  {
     "id": "numbat",
     "common_name": "Numbat",
     "taxon_group": "other",
@@ -7681,6 +10748,49 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Numbat, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Numbat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "nyasa_sitatunga",
+    "common_name": "Nyasa Sitatunga",
+    "taxon_group": "mammal",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "swamps",
+      "floodplains"
+    ],
+    "diet": [
+      "browser"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the swamps and floodplains stretch far and wide, there dwells the Nyasa Sitatunga, a mammal of note. It keeps to a browser fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Nyasa Sitatunga move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "papyrus",
+      "lotus leaves"
+    ],
+    "size_class": "large"
   },
   {
     "id": "octopus",
@@ -7745,6 +10855,117 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Okapi, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Okapi move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "okavango_painted_dog",
+    "common_name": "Okavango Painted Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "savanna"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the savanna stretch far and wide, there dwells the Okavango Painted Dog, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Okavango Painted Dog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "antelope calves",
+      "hares"
+    ],
+    "disease_risks": [
+      "canine distemper"
+    ],
+    "size_class": "medium"
+  },
+  {
+    "id": "okefenokee_bullfrog",
+    "common_name": "Okefenokee Bullfrog",
+    "taxon_group": "amphibian",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "swamps",
+      "marshes"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the swamps and marshes stretch far and wide, there dwells the Okefenokee Bullfrog, a amphibian of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Okefenokee Bullfrog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "dragonflies",
+      "small fish"
+    ],
+    "disease_risks": [
+      "chytrid"
+    ],
+    "size_class": "small"
+  },
+  {
+    "id": "okinawa_reef_manta",
+    "common_name": "Okinawa Reef Manta",
+    "taxon_group": "fish",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coral_reefs",
+      "open_ocean"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the coral reefs and open ocean stretch far and wide, there dwells the Okinawa Reef Manta, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Okinawa Reef Manta move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "plankton",
+      "krill"
+    ],
+    "size_class": "huge"
   },
   {
     "id": "olingo",
@@ -7841,6 +11062,52 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Orangutan, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Orangutan move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "orinoco_black_caiman",
+    "common_name": "Orinoco Black Caiman",
+    "taxon_group": "reptile",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "swamps",
+      "rivers"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the swamps and rivers stretch far and wide, there dwells the Orinoco Black Caiman, a reptile of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Orinoco Black Caiman move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "capybara",
+      "fish"
+    ],
+    "disease_risks": [
+      "salmonella"
+    ],
+    "size_class": "huge"
   },
   {
     "id": "osprey",
@@ -8033,6 +11300,94 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the farmland stretch far and wide, there dwells the Partridge, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Partridge move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "patagonian_fur_seal_rookery",
+    "common_name": "Patagonian Fur Seal Rookery",
+    "taxon_group": "mammal",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "ocean_shores",
+      "cliffs"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat",
+        "fat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "fat",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the ocean shores and cliffs stretch far and wide, there dwells the Patagonian Fur Seal Rookery, a mammal of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat and fat, ever mindful it must be cooked thoroughly. From its form are drawn fat and hide, which merchants and craftsmen prize. Thus does the Patagonian Fur Seal Rookery move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "anchovy",
+      "hake"
+    ],
+    "disease_risks": [
+      "brucellosis"
+    ],
+    "size_class": "large"
+  },
+  {
+    "id": "patagonian_mara_forager",
+    "common_name": "Patagonian Mara Forager",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "steppe"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the steppe stretch far and wide, there dwells the Patagonian Mara Forager, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Patagonian Mara Forager move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "bitter shrubs",
+      "tuft grasses"
+    ],
+    "size_class": "medium"
   },
   {
     "id": "peacock",
@@ -8264,6 +11619,48 @@
     ],
     "gendered": {},
     "narrative": "In the aquatic realms, where the ocean shores stretch far and wide, there dwells the Periwinkle, a mollusk of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Periwinkle move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "peruvian_lake_grebe",
+    "common_name": "Peruvian Lake Grebe",
+    "taxon_group": "bird",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "lakes",
+      "marshes"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the lakes and marshes stretch far and wide, there dwells the Peruvian Lake Grebe, a bird of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Peruvian Lake Grebe move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "killifish",
+      "amphipods"
+    ],
+    "alt_names": [
+      "Junin Grebe"
+    ],
+    "size_class": "small"
   },
   {
     "id": "pheasant",
@@ -8721,6 +12118,45 @@
     "narrative": "In the terrestrial realms, where the alpine tundra stretch far and wide, there dwells the Ptarmigan, a bird of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Ptarmigan move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "qinghai_steppe_crane",
+    "common_name": "Qinghai Steppe Crane",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "steppe",
+      "floodplains"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the steppe and floodplains stretch far and wide, there dwells the Qinghai Steppe Crane, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Qinghai Steppe Crane move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "insects",
+      "bulrush tubers"
+    ],
+    "size_class": "large"
+  },
+  {
     "id": "quagga",
     "common_name": "Quagga",
     "taxon_group": "other",
@@ -8785,6 +12221,49 @@
     "narrative": "In the terrestrial realms, where the grassland stretch far and wide, there dwells the Quail, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Quail move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "queensland_lungfish",
+    "common_name": "Queensland Lungfish",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers",
+      "swamps"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the rivers and swamps stretch far and wide, there dwells the Queensland Lungfish, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Queensland Lungfish move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "mollusks",
+      "leaf litter"
+    ],
+    "size_class": "large"
+  },
+  {
     "id": "quetzal",
     "common_name": "Quetzal",
     "taxon_group": "other",
@@ -8815,6 +12294,45 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Quetzal, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Quetzal move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "quintana_roo_brown_pelican",
+    "common_name": "Quintana Roo Brown Pelican",
+    "taxon_group": "bird",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "estuaries",
+      "ocean_shores"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the estuaries and ocean shores stretch far and wide, there dwells the Quintana Roo Brown Pelican, a bird of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Quintana Roo Brown Pelican move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "menhaden",
+      "mullets"
+    ],
+    "size_class": "medium"
   },
   {
     "id": "quokka",
@@ -9091,6 +12609,48 @@
     "narrative": "In the aquatic realms, where the tidal flats stretch far and wide, there dwells the Razor clam, a mollusk of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Razor clam move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "red_sea_lionfish",
+    "common_name": "Red Sea Lionfish",
+    "taxon_group": "fish",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coral_reefs"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the coral reefs stretch far and wide, there dwells the Red Sea Lionfish, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Red Sea Lionfish move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "gobies",
+      "reef shrimp"
+    ],
+    "size_class": "medium"
+  },
+  {
     "id": "red-kite",
     "common_name": "Red kite",
     "taxon_group": "bird",
@@ -9255,6 +12815,48 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Roe deer, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Roe deer move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "ruaha_squeaker_catfish",
+    "common_name": "Ruaha Squeaker Catfish",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Ruaha Squeaker Catfish, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Ruaha Squeaker Catfish move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "aquatic insects",
+      "detritus"
+    ],
+    "size_class": "small"
+  },
+  {
     "id": "rudd",
     "common_name": "Rudd",
     "taxon_group": "fish",
@@ -9285,6 +12887,84 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Rudd, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Rudd move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "rwanda_bamboo_gorilla",
+    "common_name": "Rwanda Bamboo Gorilla",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "montane_forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the montane forest stretch far and wide, there dwells the Rwanda Bamboo Gorilla, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Rwanda Bamboo Gorilla move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "bamboo shoots",
+      "wild nettles"
+    ],
+    "disease_risks": [
+      "respiratory infections"
+    ],
+    "size_class": "large"
+  },
+  {
+    "id": "sahara_addax_caravan",
+    "common_name": "Sahara Addax Caravan",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hot_desert"
+    ],
+    "diet": [
+      "grazer"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the hot desert stretch far and wide, there dwells the Sahara Addax Caravan, a mammal of note. It keeps to a grazer fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Sahara Addax Caravan move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "desert grasses",
+      "acacia pods"
+    ],
+    "size_class": "large"
   },
   {
     "id": "saiga",
@@ -10797,6 +14477,43 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Tasmanian devil, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Tasmanian devil move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "tatacoa_spinytail_iguana",
+    "common_name": "Tatacoa Spinytail Iguana",
+    "taxon_group": "reptile",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "semi_arid_scrublands"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the semi arid scrublands stretch far and wide, there dwells the Tatacoa Spinytail Iguana, a reptile of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Tatacoa Spinytail Iguana move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "cactus flowers",
+      "mesquite leaves"
+    ],
+    "size_class": "medium"
+  },
+  {
     "id": "teal",
     "common_name": "Teal",
     "taxon_group": "bird",
@@ -10929,6 +14646,50 @@
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Thornback ray, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Thornback ray move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "tierra_del_fuego_penguin_fold",
+    "common_name": "Tierra del Fuego Penguin Fold",
+    "taxon_group": "bird",
+    "regions": [
+      "coastal",
+      "polar_ice"
+    ],
+    "habitats": [
+      "ocean_shores",
+      "ice_shelves"
+    ],
+    "diet": [
+      "piscivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal and polar ice realms, where the ocean shores and ice shelves stretch far and wide, there dwells the Tierra del Fuego Penguin Fold, a bird of note. It keeps to a piscivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Tierra del Fuego Penguin Fold move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "krill",
+      "smelt"
+    ],
+    "size_class": "medium"
+  },
+  {
     "id": "tiger",
     "common_name": "Tiger",
     "taxon_group": "mammal",
@@ -10991,6 +14752,56 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the marshes stretch far and wide, there dwells the Toad, a amphibian of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Toad move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "tonle_sap_siamese_crocodile",
+    "common_name": "Tonle Sap Siamese Crocodile",
+    "taxon_group": "reptile",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "marshes",
+      "swamps"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the marshes and swamps stretch far and wide, there dwells the Tonle Sap Siamese Crocodile, a reptile of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide and meat, which merchants and craftsmen prize. Thus does the Tonle Sap Siamese Crocodile move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "fish",
+      "waterfowl"
+    ],
+    "disease_risks": [
+      "salmonella"
+    ],
+    "size_class": "large"
   },
   {
     "id": "trout",
@@ -11189,6 +15000,136 @@
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Twaite shad, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Twaite shad move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "uluwatu_sea_snake",
+    "common_name": "Uluwatu Sea Snake",
+    "taxon_group": "reptile",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coral_reefs",
+      "open_ocean"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": false,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [
+      {
+        "type": "venom",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the coastal realms, where the coral reefs and open ocean stretch far and wide, there dwells the Uluwatu Sea Snake, a reptile of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, wandering free of sworn domain, and offers a high hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. From its form are drawn venom, which merchants and craftsmen prize. Thus does the Uluwatu Sea Snake move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "reef fish",
+      "moray eels"
+    ],
+    "size_class": "medium"
+  },
+  {
+    "id": "upper_nile_shoebill",
+    "common_name": "Upper Nile Shoebill",
+    "taxon_group": "bird",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "marshes",
+      "swamps"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [
+      {
+        "type": "feather",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the marshes and swamps stretch far and wide, there dwells the Upper Nile Shoebill, a bird of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. From its form are drawn feather, which merchants and craftsmen prize. Thus does the Upper Nile Shoebill move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "lungfish",
+      "tilapia"
+    ],
+    "alt_names": [
+      "Balaeniceps"
+    ],
+    "size_class": "large"
+  },
+  {
+    "id": "ural_forest_moose",
+    "common_name": "Ural Forest Moose",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "boreal_forest"
+    ],
+    "diet": [
+      "browser"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "antler",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the boreal forest stretch far and wide, there dwells the Ural Forest Moose, a mammal of note. It keeps to a browser fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide and antler, which merchants and craftsmen prize. Thus does the Ural Forest Moose move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "willow bark",
+      "pondweed"
+    ],
+    "disease_risks": [
+      "ticks"
+    ],
+    "size_class": "huge"
+  },
+  {
     "id": "vaquita",
     "common_name": "Vaquita",
     "taxon_group": "other",
@@ -11251,6 +15192,55 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Vicuna, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Vicuna move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "vietnamese_sika_deer",
+    "common_name": "Vietnamese Sika Deer",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "tropical_rainforest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "antler",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the tropical rainforest stretch far and wide, there dwells the Vietnamese Sika Deer, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide and antler, which merchants and craftsmen prize. Thus does the Vietnamese Sika Deer move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "young leaves",
+      "forest fruit"
+    ],
+    "disease_risks": [
+      "ticks"
+    ],
+    "size_class": "medium"
   },
   {
     "id": "walrus",
@@ -11873,6 +15863,49 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Wren, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Wren move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "wuling_mountain_serow",
+    "common_name": "Wuling Mountain Serow",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "montane_forest",
+      "cliffs"
+    ],
+    "diet": [
+      "browser"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the montane forest and cliffs stretch far and wide, there dwells the Wuling Mountain Serow, a mammal of note. It keeps to a browser fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Wuling Mountain Serow move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "moss",
+      "rock lichens"
+    ],
+    "size_class": "medium"
+  },
+  {
     "id": "xerus",
     "common_name": "Xerus",
     "taxon_group": "other",
@@ -11903,6 +15936,66 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Xerus, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Xerus move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "xinjiang_bactrian_camel",
+    "common_name": "Xinjiang Bactrian Camel",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "cold_desert"
+    ],
+    "diet": [
+      "browser"
+    ],
+    "domestication": {
+      "domesticated": true,
+      "trainable": true,
+      "draft_or_mount": true,
+      "notes": "Caravan stock bred along the Silk Road."
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat",
+        "milk"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "domesticated"
+      },
+      {
+        "type": "meat",
+        "harvest_method": "domesticated"
+      },
+      {
+        "type": "milk",
+        "harvest_method": "domesticated"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the cold desert stretch far and wide, there dwells the Xinjiang Bactrian Camel, a mammal of note. It keeps to a browser fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat and milk, ever mindful it must be cooked thoroughly. From its form are drawn hide, meat and milk, which merchants and craftsmen prize. Thus does the Xinjiang Bactrian Camel move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "saltbush",
+      "desert reeds"
+    ],
+    "alt_names": [
+      "Silk Road Camel"
+    ],
+    "disease_risks": [
+      "brucellosis"
+    ],
+    "size_class": "large"
   },
   {
     "id": "yak",
@@ -11967,6 +16060,102 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Yellow mongoose, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Yellow mongoose move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "yenisei_pine_marten",
+    "common_name": "Yenisei Pine Marten",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "boreal_forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "fur",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the boreal forest stretch far and wide, there dwells the Yenisei Pine Marten, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn fur, which merchants and craftsmen prize. Thus does the Yenisei Pine Marten move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "squirrels",
+      "berries"
+    ],
+    "disease_risks": [
+      "trichinellosis"
+    ],
+    "size_class": "small"
+  },
+  {
+    "id": "zagros_wild_goat",
+    "common_name": "Zagros Wild Goat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hills",
+      "cliffs"
+    ],
+    "diet": [
+      "browser"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "meat",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "horn",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the hills and cliffs stretch far and wide, there dwells the Zagros Wild Goat, a mammal of note. It keeps to a browser fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, meat and horn, which merchants and craftsmen prize. Thus does the Zagros Wild Goat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "food_sources": [
+      "thorn shrubs",
+      "wild herbs"
+    ],
+    "size_class": "medium"
   },
   {
     "id": "zebu",

--- a/data/plants.json
+++ b/data/plants.json
@@ -94,6 +94,44 @@
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Alder buckthorn, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Alder buckthorn marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "alentejo_winter_barley",
+    "common_name": "Alentejo Winter Barley",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "grain"
+      },
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Alentejo Winter Barley, a grass of note. Tilled and tended by folk, it answers well to plough and garden row. Its grain sustain the hungry when prepared with care. From its body folk derive grain and fiber, a boon to trade and craft. Thus the Alentejo Winter Barley marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "grain"
+    ],
+    "culinary_uses": [
+      "bread",
+      "ale"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "cool-season",
+    "sowing_season": "late autumn",
+    "harvest_season": "early summer",
+    "growth_duration": "180 days",
+    "companion_crops": [
+      "peas"
+    ]
+  },
+  {
     "id": "algae",
     "common_name": "Algae",
     "growth_form": "algae",
@@ -154,6 +192,62 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Aloe vera, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Aloe vera marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "alpine_edelweiss_cluster",
+    "common_name": "Alpine Edelweiss Cluster",
+    "growth_form": "herb",
+    "regions": [
+      "highland"
+    ],
+    "habitats": [
+      "mountains"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "flower"
+      }
+    ],
+    "narrative": "In the highland realms, where mountains holds sway, stands the Alpine Edelweiss Cluster, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Edelweiss, names born of custom and need. From its body folk derive flower, a boon to trade and craft. Thus the Alpine Edelweiss Cluster marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Collect sparingly to preserve cliffs.",
+    "seasonality": "summer",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Edelweiss"
+    ]
+  },
+  {
+    "id": "altamaha_buttonbush",
+    "common_name": "Altamaha Buttonbush",
+    "growth_form": "shrub",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "bark"
+      }
+    ],
+    "narrative": "In the wetlands transitional realms, where wetland holds sway, stands the Altamaha Buttonbush, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Buttonbush, names born of custom and need. From its body folk derive bark, a boon to trade and craft. Thus the Altamaha Buttonbush marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Thickets harbor waterfowl nests.",
+    "seasonality": "summer",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Buttonbush"
+    ]
+  },
+  {
     "id": "amaranth",
     "common_name": "Amaranth",
     "growth_form": "herb",
@@ -167,6 +261,34 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Amaranth, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Amaranth marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "amazon_floating_pistia",
+    "common_name": "Amazon Floating Pistia",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "lake"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where lake holds sway, stands the Amazon Floating Pistia, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Floating Lettuce, names born of custom and need. From its body folk derive fiber, a boon to trade and craft. Thus the Amazon Floating Pistia marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Skim mats to keep channels open.",
+    "seasonality": "year-round",
+    "harvest_season": "year-round",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Floating Lettuce"
+    ]
   },
   {
     "id": "angelica",
@@ -212,6 +334,44 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Anise, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Anise marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "appalachian_spicebush",
+    "common_name": "Appalachian Spicebush",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "spice"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Appalachian Spicebush, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Benjamin Bush, names born of custom and need. From its body folk derive leaf and spice, a boon to trade and craft. Thus the Appalachian Spicebush marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "tea",
+      "seasoning"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Gather leaves after the morning dew lifts.",
+    "seasonality": "spring",
+    "harvest_season": "late summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Benjamin Bush"
+    ]
   },
   {
     "id": "apple-tree",
@@ -337,6 +497,41 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Apricot, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. From its body folk derive fruit, a boon to trade and craft. Thus the Apricot marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "arctic_crowberry_mat",
+    "common_name": "Arctic Crowberry Mat",
+    "growth_form": "shrub",
+    "regions": [
+      "cold"
+    ],
+    "habitats": [
+      "tundra"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      }
+    ],
+    "narrative": "In the cold realms, where tundra holds sway, stands the Arctic Crowberry Mat, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Crowberry, names born of custom and need. From its body folk derive fruit, a boon to trade and craft. Thus the Arctic Crowberry Mat marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "jam",
+      "winter preserve"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Pick after first frost to sweeten berries.",
+    "seasonality": "late summer",
+    "harvest_season": "late summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Crowberry"
+    ]
+  },
+  {
     "id": "arrowhead",
     "common_name": "Arrowhead",
     "growth_form": "herb",
@@ -412,6 +607,88 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Asparagus, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Asparagus marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "atlantic_dulse_rack",
+    "common_name": "Atlantic Dulse Rack",
+    "growth_form": "seaweed",
+    "regions": [
+      "aquatic_salt"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "dye"
+      }
+    ],
+    "narrative": "In the aquatic salt realms, where coastal holds sway, stands the Atlantic Dulse Rack, a seaweed of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Dulse, names born of custom and need. From its body folk derive leaf and dye, a boon to trade and craft. Thus the Atlantic Dulse Rack marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "broth",
+      "seasoning"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Harvest after low tide for sweetest fronds.",
+    "seasonality": "spring",
+    "harvest_season": "spring",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Dulse"
+    ]
+  },
+  {
+    "id": "atlas_date_palm",
+    "common_name": "Atlas Date Palm",
+    "growth_form": "tree",
+    "regions": [
+      "arid"
+    ],
+    "habitats": [
+      "desert"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      },
+      {
+        "type": "fiber"
+      },
+      {
+        "type": "wood"
+      }
+    ],
+    "narrative": "In the arid realms, where desert holds sway, stands the Atlas Date Palm, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Atlas Date, names born of custom and need. From its body folk derive fruit, fiber and wood, a boon to trade and craft. Thus the Atlas Date Palm marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "dessert",
+      "paste"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "year-round",
+    "sowing_season": "offshoots",
+    "harvest_season": "autumn",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "alfalfa"
+    ],
+    "alt_names": [
+      "Atlas Date"
+    ]
+  },
+  {
     "id": "azalea",
     "common_name": "Azalea",
     "growth_form": "herb",
@@ -425,6 +702,116 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Azalea, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Azalea marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "badia_desert_hyssop",
+    "common_name": "Badia Desert Hyssop",
+    "growth_form": "herb",
+    "regions": [
+      "arid"
+    ],
+    "habitats": [
+      "desert"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": "In the arid realms, where desert holds sway, stands the Badia Desert Hyssop, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Desert Hyssop, names born of custom and need. From its body folk derive leaf and herb, a boon to trade and craft. Thus the Badia Desert Hyssop marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "tea",
+      "seasoning"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Harvest in cool dawn to preserve oils.",
+    "seasonality": "spring",
+    "harvest_season": "spring",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Desert Hyssop"
+    ]
+  },
+  {
+    "id": "baikal_water_shield",
+    "common_name": "Baikal Water Shield",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "lake"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where lake holds sway, stands the Baikal Water Shield, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Gorgon Plant, names born of custom and need. From its body folk derive leaf, a boon to trade and craft. Thus the Baikal Water Shield marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "stir-fry",
+      "soup"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Gather tender leaves from the surface.",
+    "seasonality": "summer",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Gorgon Plant"
+    ]
+  },
+  {
+    "id": "baltic_kelp_forest",
+    "common_name": "Baltic Kelp Forest",
+    "growth_form": "seaweed",
+    "regions": [
+      "aquatic_salt"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the aquatic salt realms, where coastal holds sway, stands the Baltic Kelp Forest, a seaweed of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Baltic Kelp, names born of custom and need. From its body folk derive leaf and fiber, a boon to trade and craft. Thus the Baltic Kelp Forest marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "salting",
+      "stew"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "summer",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Baltic Kelp"
+    ]
   },
   {
     "id": "bamboo",
@@ -549,6 +936,47 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Basil, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. From its body folk derive herb, a boon to trade and craft. Thus the Basil marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "bavarian_field_turnip",
+    "common_name": "Bavarian Field Turnip",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "root"
+      },
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Bavarian Field Turnip, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its root sustain the hungry when prepared with care. Among diverse tongues it is hailed as Bavarian Rübe, names born of custom and need. From its body folk derive root and leaf, a boon to trade and craft. Thus the Bavarian Field Turnip marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "root"
+    ],
+    "culinary_uses": [
+      "stew",
+      "pickle"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "cool-season",
+    "sowing_season": "early spring",
+    "harvest_season": "late autumn",
+    "growth_duration": "120 days",
+    "companion_crops": [
+      "cabbage"
+    ],
+    "alt_names": [
+      "Bavarian Rübe"
+    ]
+  },
+  {
     "id": "bay-laurel",
     "common_name": "Bay laurel",
     "growth_form": "tree",
@@ -562,6 +990,35 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Bay laurel, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Bay laurel marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "bayou_crimson_cardinal",
+    "common_name": "Bayou Crimson Cardinal",
+    "growth_form": "herb",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "flower"
+      }
+    ],
+    "narrative": "In the wetlands transitional realms, where wetland holds sway, stands the Bayou Crimson Cardinal, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Cardinal Flower, names born of custom and need. From its body folk derive flower, a boon to trade and craft. Thus the Bayou Crimson Cardinal marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true,
+    "toxic": true,
+    "toxicity_notes": "Sap may irritate skin.",
+    "foraging_notes": "Keep hands gloved when harvesting blooms.",
+    "seasonality": "summer",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Cardinal Flower"
+    ]
   },
   {
     "id": "beech",
@@ -673,6 +1130,45 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Betony, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive herb, a boon to trade and craft. Thus the Betony marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "bhutan_highland_buckwheat",
+    "common_name": "Bhutan Highland Buckwheat",
+    "growth_form": "herb",
+    "regions": [
+      "highland"
+    ],
+    "habitats": [
+      "farmland",
+      "mountains"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "grain"
+      }
+    ],
+    "narrative": "In the highland realms, where the farmland and mountains hold sway, stands the Bhutan Highland Buckwheat, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its grain sustain the hungry when prepared with care. Among diverse tongues it is hailed as Himalayan Buckwheat, names born of custom and need. From its body folk derive grain, a boon to trade and craft. Thus the Bhutan Highland Buckwheat marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "grain"
+    ],
+    "culinary_uses": [
+      "flatbread",
+      "porridge"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "cool-season",
+    "sowing_season": "spring thaw",
+    "harvest_season": "autumn",
+    "growth_duration": "120 days",
+    "companion_crops": [
+      "potatoes"
+    ],
+    "alt_names": [
+      "Himalayan Buckwheat"
+    ]
+  },
+  {
     "id": "bilberry",
     "common_name": "Bilberry",
     "growth_form": "shrub",
@@ -765,6 +1261,38 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Bitter vetch, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Bitter vetch marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "black_forest_morel_patch",
+    "common_name": "Black Forest Morel Patch",
+    "growth_form": "mushroom",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "mushroom"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Black Forest Morel Patch, a mushroom of note. It springs forth unbidden, owing nothing to the care of humankind. Its fruiting body sustain the hungry when prepared with care. From its body folk derive mushroom, a boon to trade and craft. Thus the Black Forest Morel Patch marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruiting body"
+    ],
+    "culinary_uses": [
+      "sauté",
+      "broth"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Appears after spring rains.",
+    "seasonality": "spring",
+    "harvest_season": "spring",
+    "growth_duration": "short flush"
   },
   {
     "id": "black-pepper",
@@ -878,6 +1406,44 @@
       }
     ],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Borage, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. From its body folk derive leaf, a boon to trade and craft. Thus the Borage marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "boreal_fireweed_glade",
+    "common_name": "Boreal Fireweed Glade",
+    "growth_form": "herb",
+    "regions": [
+      "cold"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "flower"
+      }
+    ],
+    "narrative": "In the cold realms, where forest holds sway, stands the Boreal Fireweed Glade, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Fireweed, names born of custom and need. From its body folk derive leaf and flower, a boon to trade and craft. Thus the Boreal Fireweed Glade marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "tea",
+      "jelly"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Young shoots taste best before bloom.",
+    "seasonality": "summer",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Fireweed"
+    ]
   },
   {
     "id": "boxwood",
@@ -1181,6 +1747,45 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Caper, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Caper marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "capital_rooftop_lettuce",
+    "common_name": "Capital Rooftop Lettuce",
+    "growth_form": "herb",
+    "regions": [
+      "urban"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the urban realms, where urban holds sway, stands the Capital Rooftop Lettuce, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Rooftop Lettuce, names born of custom and need. From its body folk derive leaf, a boon to trade and craft. Thus the Capital Rooftop Lettuce marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "salad",
+      "wraps"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Keep soil boxes well watered.",
+    "seasonality": "cool-season",
+    "sowing_season": "early spring",
+    "harvest_season": "summer",
+    "growth_duration": "80 days",
+    "companion_crops": [
+      "radish"
+    ],
+    "alt_names": [
+      "Rooftop Lettuce"
+    ]
+  },
+  {
     "id": "caraway",
     "common_name": "Caraway",
     "growth_form": "herb",
@@ -1209,6 +1814,47 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Cardamom, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Cardamom marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "caribbean_sea_grape",
+    "common_name": "Caribbean Sea Grape",
+    "growth_form": "shrub",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      },
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the coastal realms, where coastal holds sway, stands the Caribbean Sea Grape, a shrub of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Sea Grape, names born of custom and need. From its body folk derive fruit and leaf, a boon to trade and craft. Thus the Caribbean Sea Grape marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "jam",
+      "wine"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "warm-season",
+    "sowing_season": "spring",
+    "harvest_season": "late summer",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "coconut"
+    ],
+    "alt_names": [
+      "Sea Grape"
+    ]
   },
   {
     "id": "carrageen-moss",
@@ -1340,6 +1986,46 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Castor bean, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Castor bean marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "catalan_saffron_crocus",
+    "common_name": "Catalan Saffron Crocus",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "flower"
+      },
+      {
+        "type": "spice"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Catalan Saffron Crocus, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its flower sustain the hungry when prepared with care. Among diverse tongues it is hailed as Catalan Safrà, names born of custom and need. From its body folk derive flower and spice, a boon to trade and craft. Thus the Catalan Saffron Crocus marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "flower"
+    ],
+    "culinary_uses": [
+      "spice"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "autumn",
+    "sowing_season": "summer",
+    "harvest_season": "autumn",
+    "growth_duration": "90 days",
+    "companion_crops": [
+      "grapevines"
+    ],
+    "alt_names": [
+      "Catalan Safrà"
+    ]
+  },
+  {
     "id": "catnip",
     "common_name": "Catnip",
     "growth_form": "herb",
@@ -1368,6 +2054,46 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Cattail, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Cattail marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "caucasus_rhubarb_fan",
+    "common_name": "Caucasus Rhubarb Fan",
+    "growth_form": "herb",
+    "regions": [
+      "highland"
+    ],
+    "habitats": [
+      "mountains"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the highland realms, where mountains holds sway, stands the Caucasus Rhubarb Fan, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Mountain Rhubarb, names born of custom and need. From its body folk derive leaf, a boon to trade and craft. Thus the Caucasus Rhubarb Fan marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "tart",
+      "stew"
+    ],
+    "medicinal": true,
+    "toxic": true,
+    "toxicity_notes": "Leaf blades are poisonous; use stalks only.",
+    "foraging_notes": "Peel thick stalks to tame sourness.",
+    "seasonality": "spring",
+    "sowing_season": "crown division",
+    "harvest_season": "spring",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "berries"
+    ],
+    "alt_names": [
+      "Mountain Rhubarb"
+    ]
   },
   {
     "id": "cedar",
@@ -1657,6 +2383,47 @@
     "narrative": "In the terrestrial realms, where grassland holds sway, stands the Chicory, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Chicory marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "chihuahuan_agave_stand",
+    "common_name": "Chihuahuan Agave Stand",
+    "growth_form": "herb",
+    "regions": [
+      "arid"
+    ],
+    "habitats": [
+      "desert"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "sap"
+      },
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the arid realms, where desert holds sway, stands the Chihuahuan Agave Stand, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its sap sustain the hungry when prepared with care. Among diverse tongues it is hailed as Lechuguilla, names born of custom and need. From its body folk derive sap and fiber, a boon to trade and craft. Thus the Chihuahuan Agave Stand marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "sap"
+    ],
+    "culinary_uses": [
+      "syrup",
+      "roast heart"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "year-round",
+    "sowing_season": "pups",
+    "harvest_season": "dry season",
+    "growth_duration": "8 years",
+    "companion_crops": [
+      "mesquite"
+    ],
+    "alt_names": [
+      "Lechuguilla"
+    ]
+  },
+  {
     "id": "chives",
     "common_name": "Chives",
     "growth_form": "herb",
@@ -1879,6 +2646,36 @@
     "narrative": "In the wetlands transitional realms, where wetland holds sway, stands the Common reed (Phragmites), a grass of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive fiber, a boon to trade and craft. Thus the Common reed (Phragmites) marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "congo_papyrus_stand",
+    "common_name": "Congo Papyrus Stand",
+    "growth_form": "grass",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "riverlands",
+      "wetland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where the riverlands and wetland hold sway, stands the Congo Papyrus Stand, a grass of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Papyrus Reed, names born of custom and need. From its body folk derive fiber, a boon to trade and craft. Thus the Congo Papyrus Stand marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Cut lower stems for writing sheets.",
+    "seasonality": "year-round",
+    "sowing_season": "spring",
+    "harvest_season": "year-round",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Papyrus Reed"
+    ]
+  },
+  {
     "id": "coral-fungus",
     "common_name": "Coral fungus",
     "growth_form": "fungus",
@@ -1984,6 +2781,44 @@
     "narrative": "In the terrestrial realms, where wetland holds sway, stands the Cranberry, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Cranberry marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "crete_thyme_mat",
+    "common_name": "Crete Thyme Mat",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hills"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where hills holds sway, stands the Crete Thyme Mat, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Cretan Thyme, names born of custom and need. From its body folk derive leaf and herb, a boon to trade and craft. Thus the Crete Thyme Mat marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "herb",
+      "tea"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Cut during full bloom for best oils.",
+    "seasonality": "summer",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Cretan Thyme"
+    ]
+  },
+  {
     "id": "cucumber",
     "common_name": "Cucumber",
     "growth_form": "vine",
@@ -2056,6 +2891,47 @@
     "narrative": "In the terrestrial realms, where grassland holds sway, stands the Daisy, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Daisy marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "dalmatian_fig_orchard",
+    "common_name": "Dalmatian Fig Orchard",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      },
+      {
+        "type": "wood"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Dalmatian Fig Orchard, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Dalmatian Fico, names born of custom and need. From its body folk derive fruit and wood, a boon to trade and craft. Thus the Dalmatian Fig Orchard marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "fresh eating",
+      "drying"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "warm-season",
+    "sowing_season": "spring cuttings",
+    "harvest_season": "late summer",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "olive"
+    ],
+    "alt_names": [
+      "Dalmatian Fico"
+    ]
+  },
+  {
     "id": "damson",
     "common_name": "Damson",
     "growth_form": "tree",
@@ -2075,6 +2951,43 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Damson, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. From its body folk derive fruit, a boon to trade and craft. Thus the Damson marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "danakil_saltwort_patch",
+    "common_name": "Danakil Saltwort Patch",
+    "growth_form": "herb",
+    "regions": [
+      "arid"
+    ],
+    "habitats": [
+      "desert"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "dye"
+      }
+    ],
+    "narrative": "In the arid realms, where desert holds sway, stands the Danakil Saltwort Patch, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Saltwort, names born of custom and need. From its body folk derive leaf and dye, a boon to trade and craft. Thus the Danakil Saltwort Patch marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "brine pickle"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Rinse well to soften salinity.",
+    "seasonality": "summer",
+    "harvest_season": "summer",
+    "growth_duration": "annual",
+    "alt_names": [
+      "Saltwort"
+    ]
+  },
+  {
     "id": "dandelion",
     "common_name": "Dandelion",
     "growth_form": "herb",
@@ -2088,6 +3001,76 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where grassland holds sway, stands the Dandelion, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Dandelion marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "danube_water_caltrop",
+    "common_name": "Danube Water Caltrop",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland",
+      "lake"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "nut"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where the wetland and lake hold sway, stands the Danube Water Caltrop, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its nut sustain the hungry when prepared with care. Among diverse tongues it is hailed as Devil Nut, names born of custom and need. From its body folk derive nut, a boon to trade and craft. Thus the Danube Water Caltrop marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "nut"
+    ],
+    "culinary_uses": [
+      "boil",
+      "roast"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "autumn",
+    "sowing_season": "spring",
+    "harvest_season": "autumn",
+    "growth_duration": "150 days",
+    "companion_crops": [
+      "lotus"
+    ],
+    "alt_names": [
+      "Devil Nut"
+    ]
+  },
+  {
+    "id": "darwin_mangrove_tea",
+    "common_name": "Darwin Mangrove Tea",
+    "growth_form": "tree",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "bark"
+      },
+      {
+        "type": "wood"
+      }
+    ],
+    "narrative": "In the coastal realms, where coastal holds sway, stands the Darwin Mangrove Tea, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Mangrove Tea, names born of custom and need. From its body folk derive bark and wood, a boon to trade and craft. Thus the Darwin Mangrove Tea marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Harvest bark sparingly at low tide.",
+    "seasonality": "year-round",
+    "harvest_season": "year-round",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Mangrove Tea"
+    ]
   },
   {
     "id": "date-palm",
@@ -2137,6 +3120,44 @@
       }
     ],
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Death cap, a mushroom of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive mushroom, a boon to trade and craft. Thus the Death cap marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "delta_sweet_flag",
+    "common_name": "Delta Sweet Flag",
+    "growth_form": "herb",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "root"
+      }
+    ],
+    "narrative": "In the wetlands transitional realms, where wetland holds sway, stands the Delta Sweet Flag, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its root sustain the hungry when prepared with care. Among diverse tongues it is hailed as Calamus, names born of custom and need. From its body folk derive root, a boon to trade and craft. Thus the Delta Sweet Flag marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "root"
+    ],
+    "culinary_uses": [
+      "candied",
+      "tea"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "spring",
+    "sowing_season": "rhizome division",
+    "harvest_season": "autumn",
+    "growth_duration": "150 days",
+    "companion_crops": [
+      "watercress"
+    ],
+    "alt_names": [
+      "Calamus"
+    ]
   },
   {
     "id": "dewberry-bramble",
@@ -2199,6 +3220,76 @@
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Dogwood, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Dogwood marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "dolomite_alpine_willow",
+    "common_name": "Dolomite Alpine Willow",
+    "growth_form": "shrub",
+    "regions": [
+      "highland"
+    ],
+    "habitats": [
+      "mountains"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "bark"
+      }
+    ],
+    "narrative": "In the highland realms, where mountains holds sway, stands the Dolomite Alpine Willow, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Alpine Willow, names born of custom and need. From its body folk derive bark, a boon to trade and craft. Thus the Dolomite Alpine Willow marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Bark steeped for pain relief.",
+    "seasonality": "spring",
+    "harvest_season": "spring",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Alpine Willow"
+    ]
+  },
+  {
+    "id": "douro_wine_vineyard",
+    "common_name": "Douro Wine Vineyard",
+    "growth_form": "vine",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hills",
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      },
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the hills and farmland hold sway, stands the Douro Wine Vineyard, a vine of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Douro Vine, names born of custom and need. From its body folk derive fruit and leaf, a boon to trade and craft. Thus the Douro Wine Vineyard marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "wine",
+      "raisin"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "warm-season",
+    "sowing_season": "spring cuttings",
+    "harvest_season": "autumn",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "lavender"
+    ],
+    "alt_names": [
+      "Douro Vine"
+    ]
+  },
+  {
     "id": "dragonfruit",
     "common_name": "Dragonfruit",
     "growth_form": "herb",
@@ -2244,6 +3335,47 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Durian, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Durian marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "east_china_sea_samphire",
+    "common_name": "East China Sea Samphire",
+    "growth_form": "herb",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": "In the coastal realms, where coastal holds sway, stands the East China Sea Samphire, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Sea Asparagus, names born of custom and need. From its body folk derive leaf and herb, a boon to trade and craft. Thus the East China Sea Samphire marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "pickle",
+      "salad"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "summer",
+    "sowing_season": "spring",
+    "harvest_season": "summer",
+    "growth_duration": "90 days",
+    "companion_crops": [
+      "sea beet"
+    ],
+    "alt_names": [
+      "Sea Asparagus"
+    ]
+  },
+  {
     "id": "eelgrass-zostera",
     "common_name": "Eelgrass (Zostera)",
     "growth_form": "grass",
@@ -2261,6 +3393,51 @@
       }
     ],
     "narrative": "In the aquatic salt realms, where coastal holds sway, stands the Eelgrass (Zostera), a grass of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive fiber, a boon to trade and craft. Thus the Eelgrass (Zostera) marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "egyptian_moringa_grove",
+    "common_name": "Egyptian Moringa Grove",
+    "growth_form": "tree",
+    "regions": [
+      "arid"
+    ],
+    "habitats": [
+      "desert",
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "seed"
+      },
+      {
+        "type": "oil"
+      }
+    ],
+    "narrative": "In the arid realms, where the desert and farmland hold sway, stands the Egyptian Moringa Grove, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Desert Moringa, names born of custom and need. From its body folk derive leaf, seed and oil, a boon to trade and craft. Thus the Egyptian Moringa Grove marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "stew",
+      "tea"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "year-round",
+    "sowing_season": "spring",
+    "harvest_season": "year-round",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "beans"
+    ],
+    "alt_names": [
+      "Desert Moringa"
+    ]
   },
   {
     "id": "einkorn",
@@ -2327,6 +3504,89 @@
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Elm, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Elm marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "emerald_lotus_paddy",
+    "common_name": "Emerald Lotus Paddy",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "root"
+      },
+      {
+        "type": "flower"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where wetland holds sway, stands the Emerald Lotus Paddy, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its root sustain the hungry when prepared with care. Among diverse tongues it is hailed as Emerald Lotus, names born of custom and need. From its body folk derive root and flower, a boon to trade and craft. Thus the Emerald Lotus Paddy marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "root"
+    ],
+    "culinary_uses": [
+      "stir-fry",
+      "sweets"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "summer",
+    "sowing_season": "spring",
+    "harvest_season": "late summer",
+    "growth_duration": "180 days",
+    "companion_crops": [
+      "fish"
+    ],
+    "alt_names": [
+      "Emerald Lotus"
+    ]
+  },
+  {
+    "id": "emilian_chicory_heads",
+    "common_name": "Emilian Chicory Heads",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "root"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Emilian Chicory Heads, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Radicchio Rosso, names born of custom and need. From its body folk derive leaf and root, a boon to trade and craft. Thus the Emilian Chicory Heads marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "salad",
+      "braise"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Blanch heads in cellars for tenderness.",
+    "seasonality": "cool-season",
+    "sowing_season": "late summer",
+    "harvest_season": "winter",
+    "growth_duration": "150 days",
+    "companion_crops": [
+      "grapes"
+    ],
+    "alt_names": [
+      "Radicchio Rosso"
+    ]
+  },
+  {
     "id": "emmer",
     "common_name": "Emmer",
     "growth_form": "grass",
@@ -2365,6 +3625,77 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Ergot (rye fungus), a fungus of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive mushroom, a boon to trade and craft. Thus the Ergot (rye fungus) marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "estonian_bog_rosemary",
+    "common_name": "Estonian Bog Rosemary",
+    "growth_form": "shrub",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": "In the wetlands transitional realms, where wetland holds sway, stands the Estonian Bog Rosemary, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Bog Rosemary, names born of custom and need. From its body folk derive herb, a boon to trade and craft. Thus the Estonian Bog Rosemary marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": false,
+    "toxic": true,
+    "toxicity_notes": "Berries are poisonous.",
+    "foraging_notes": "Admire only; do not harvest.",
+    "seasonality": "spring",
+    "harvest_season": "spring",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Bog Rosemary"
+    ]
+  },
+  {
+    "id": "ethiopian_ensete_grove",
+    "common_name": "Ethiopian Ensete Grove",
+    "growth_form": "tree",
+    "regions": [
+      "highland"
+    ],
+    "habitats": [
+      "farmland",
+      "mountains"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "tuber"
+      },
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the highland realms, where the farmland and mountains hold sway, stands the Ethiopian Ensete Grove, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its tuber sustain the hungry when prepared with care. Among diverse tongues it is hailed as False Banana, names born of custom and need. From its body folk derive tuber and fiber, a boon to trade and craft. Thus the Ethiopian Ensete Grove marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "tuber"
+    ],
+    "culinary_uses": [
+      "fermented bread",
+      "porridge"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "year-round",
+    "sowing_season": "suckers",
+    "harvest_season": "year-round",
+    "growth_duration": "3 years",
+    "companion_crops": [
+      "coffee"
+    ],
+    "alt_names": [
+      "False Banana"
+    ]
+  },
+  {
     "id": "eucalyptus",
     "common_name": "Eucalyptus",
     "growth_form": "herb",
@@ -2378,6 +3709,44 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Eucalyptus, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Eucalyptus marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "faroe_rockweed",
+    "common_name": "Faroe Rockweed",
+    "growth_form": "seaweed",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the coastal realms, where coastal holds sway, stands the Faroe Rockweed, a seaweed of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Rockweed, names born of custom and need. From its body folk derive leaf and fiber, a boon to trade and craft. Thus the Faroe Rockweed marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "stew",
+      "fertilizer tea"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Dry fronds for winter fodder.",
+    "seasonality": "year-round",
+    "harvest_season": "year-round",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Rockweed"
+    ]
   },
   {
     "id": "fennel",
@@ -2459,6 +3828,34 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Figs, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Figs marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "finnmark_bogbean_patch",
+    "common_name": "Finnmark Bogbean Patch",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where wetland holds sway, stands the Finnmark Bogbean Patch, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Menyanthes, names born of custom and need. From its body folk derive leaf, a boon to trade and craft. Thus the Finnmark Bogbean Patch marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Harvest sparingly for tonics.",
+    "seasonality": "spring",
+    "harvest_season": "spring",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Menyanthes"
+    ]
+  },
+  {
     "id": "fir",
     "common_name": "Fir",
     "growth_form": "tree",
@@ -2527,6 +3924,49 @@
       ],
       "luxury_tier": []
     }
+  },
+  {
+    "id": "floodplain_watermint",
+    "common_name": "Floodplain Watermint",
+    "growth_form": "herb",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland",
+      "riverlands"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": "In the wetlands transitional realms, where the wetland and riverlands hold sway, stands the Floodplain Watermint, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Water Mint, names born of custom and need. From its body folk derive leaf and herb, a boon to trade and craft. Thus the Floodplain Watermint marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "herb",
+      "tea"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Harvest before flowering for richest oils.",
+    "seasonality": "summer",
+    "sowing_season": "spring",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "peas"
+    ],
+    "alt_names": [
+      "Water Mint"
+    ]
   },
   {
     "id": "fly-agaric",
@@ -2606,6 +4046,118 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the aquatic fresh realms, where wetland holds sway, stands the Frogbit, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Frogbit marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "galapagos_red_mangrove",
+    "common_name": "Galápagos Red Mangrove",
+    "growth_form": "tree",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "bark"
+      },
+      {
+        "type": "wood"
+      }
+    ],
+    "narrative": "In the coastal realms, where coastal holds sway, stands the Galápagos Red Mangrove, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Red Mangrove, names born of custom and need. From its body folk derive bark and wood, a boon to trade and craft. Thus the Galápagos Red Mangrove marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Roots shelter nurseries for reef fish.",
+    "seasonality": "year-round",
+    "harvest_season": "year-round",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Red Mangrove"
+    ]
+  },
+  {
+    "id": "galician_kale_row",
+    "common_name": "Galician Kale Row",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Galician Kale Row, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Grelos, names born of custom and need. From its body folk derive leaf, a boon to trade and craft. Thus the Galician Kale Row marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "broth",
+      "stew"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "cool-season",
+    "sowing_season": "early spring",
+    "harvest_season": "winter",
+    "growth_duration": "200 days",
+    "companion_crops": [
+      "beans"
+    ],
+    "alt_names": [
+      "Grelos"
+    ]
+  },
+  {
+    "id": "ganges_floating_rice",
+    "common_name": "Ganges Floating Rice",
+    "growth_form": "grass",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "riverlands",
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "grain"
+      },
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where the riverlands and farmland hold sway, stands the Ganges Floating Rice, a grass of note. Tilled and tended by folk, it answers well to plough and garden row. Its grain sustain the hungry when prepared with care. Among diverse tongues it is hailed as Deepwater Rice, names born of custom and need. From its body folk derive grain and fiber, a boon to trade and craft. Thus the Ganges Floating Rice marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "grain"
+    ],
+    "culinary_uses": [
+      "rice",
+      "porridge"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Keep paddies flooded through high water.",
+    "seasonality": "monsoon",
+    "sowing_season": "early monsoon",
+    "harvest_season": "dry season",
+    "growth_duration": "210 days",
+    "companion_crops": [
+      "fish"
+    ],
+    "alt_names": [
+      "Deepwater Rice"
+    ]
   },
   {
     "id": "garlic",
@@ -2696,6 +4248,34 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Ginseng, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Ginseng marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "gobi_saxaul_bush",
+    "common_name": "Gobi Saxaul Bush",
+    "growth_form": "shrub",
+    "regions": [
+      "arid"
+    ],
+    "habitats": [
+      "desert"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "wood"
+      }
+    ],
+    "narrative": "In the arid realms, where desert holds sway, stands the Gobi Saxaul Bush, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Saxaul, names born of custom and need. From its body folk derive wood, a boon to trade and craft. Thus the Gobi Saxaul Bush marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Staple fuelwood of the dunes.",
+    "seasonality": "year-round",
+    "harvest_season": "year-round",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Saxaul"
+    ]
+  },
+  {
     "id": "gooseberry",
     "common_name": "Gooseberry",
     "growth_form": "shrub",
@@ -2782,6 +4362,34 @@
     ]
   },
   {
+    "id": "great_lakes_marsh_blazingstar",
+    "common_name": "Great Lakes Marsh Blazingstar",
+    "growth_form": "herb",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "flower"
+      }
+    ],
+    "narrative": "In the wetlands transitional realms, where wetland holds sway, stands the Great Lakes Marsh Blazingstar, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Marsh Blazing Star, names born of custom and need. From its body folk derive flower, a boon to trade and craft. Thus the Great Lakes Marsh Blazingstar marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Supports migrating butterflies.",
+    "seasonality": "late summer",
+    "harvest_season": "late summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Marsh Blazing Star"
+    ]
+  },
+  {
     "id": "guarana",
     "common_name": "Guarana",
     "growth_form": "herb",
@@ -2825,6 +4433,48 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Guelder rose, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Guelder rose marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "haida_sugar_kelp_line",
+    "common_name": "Haida Sugar Kelp Line",
+    "growth_form": "seaweed",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the coastal realms, where coastal holds sway, stands the Haida Sugar Kelp Line, a seaweed of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Sugar Kelp, names born of custom and need. From its body folk derive leaf and fiber, a boon to trade and craft. Thus the Haida Sugar Kelp Line marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "broth",
+      "salting"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Hang spore ropes in autumn swells.",
+    "seasonality": "spring",
+    "sowing_season": "autumn spore ropes",
+    "harvest_season": "spring",
+    "growth_duration": "210 days",
+    "companion_crops": [
+      "mussels"
+    ],
+    "alt_names": [
+      "Sugar Kelp"
+    ]
   },
   {
     "id": "hawthorn",
@@ -2964,6 +4614,34 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Hibiscus, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Hibiscus marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "himalayan_blue_poppy",
+    "common_name": "Himalayan Blue Poppy",
+    "growth_form": "herb",
+    "regions": [
+      "highland"
+    ],
+    "habitats": [
+      "mountains"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "flower"
+      }
+    ],
+    "narrative": "In the highland realms, where mountains holds sway, stands the Himalayan Blue Poppy, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Blue Poppy, names born of custom and need. From its body folk derive flower, a boon to trade and craft. Thus the Himalayan Blue Poppy marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Grows on misty scree slopes.",
+    "seasonality": "summer",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Blue Poppy"
+    ]
+  },
+  {
     "id": "holly",
     "common_name": "Holly",
     "growth_form": "tree",
@@ -3073,6 +4751,89 @@
     "narrative": "In the terrestrial realms, where wetland holds sway, stands the Horsetail, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Horsetail marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "huanghe_lotus_root",
+    "common_name": "Huanghe Lotus Root",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "root"
+      },
+      {
+        "type": "flower"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where wetland holds sway, stands the Huanghe Lotus Root, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its root sustain the hungry when prepared with care. Among diverse tongues it is hailed as Yellow River Lotus, names born of custom and need. From its body folk derive root and flower, a boon to trade and craft. Thus the Huanghe Lotus Root marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "root"
+    ],
+    "culinary_uses": [
+      "stir-fry",
+      "soup"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "autumn",
+    "sowing_season": "spring",
+    "harvest_season": "autumn",
+    "growth_duration": "200 days",
+    "companion_crops": [
+      "rice"
+    ],
+    "alt_names": [
+      "Yellow River Lotus"
+    ]
+  },
+  {
+    "id": "hungarian_paprika_chili",
+    "common_name": "Hungarian Paprika Chili",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      },
+      {
+        "type": "spice"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Hungarian Paprika Chili, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Kalocsa Pepper, names born of custom and need. From its body folk derive fruit and spice, a boon to trade and craft. Thus the Hungarian Paprika Chili marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "spice",
+      "powder"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Dry pods before grinding.",
+    "seasonality": "warm-season",
+    "sowing_season": "spring",
+    "harvest_season": "autumn",
+    "growth_duration": "140 days",
+    "companion_crops": [
+      "tomatoes"
+    ],
+    "alt_names": [
+      "Kalocsa Pepper"
+    ]
+  },
+  {
     "id": "hyssop",
     "common_name": "Hyssop",
     "growth_form": "herb",
@@ -3088,6 +4849,152 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Hyssop, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Hyssop marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "iberian_sea_lavender",
+    "common_name": "Iberian Sea Lavender",
+    "growth_form": "herb",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "flower"
+      },
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": "In the coastal realms, where coastal holds sway, stands the Iberian Sea Lavender, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Sea Lavender, names born of custom and need. From its body folk derive flower and herb, a boon to trade and craft. Thus the Iberian Sea Lavender marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Gather blossoms for fragrant sachets.",
+    "seasonality": "summer",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Sea Lavender"
+    ]
+  },
+  {
+    "id": "icelandic_angelica_plot",
+    "common_name": "Icelandic Angelica Plot",
+    "growth_form": "herb",
+    "regions": [
+      "cold"
+    ],
+    "habitats": [
+      "tundra"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "root"
+      }
+    ],
+    "narrative": "In the cold realms, where tundra holds sway, stands the Icelandic Angelica Plot, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Icelandic Angelica, names born of custom and need. From its body folk derive leaf and root, a boon to trade and craft. Thus the Icelandic Angelica Plot marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "candy",
+      "tea"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "summer",
+    "sowing_season": "spring",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "birch"
+    ],
+    "alt_names": [
+      "Icelandic Angelica"
+    ]
+  },
+  {
+    "id": "idaho_catkin_willow",
+    "common_name": "Idaho Catkin Willow",
+    "growth_form": "tree",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "wood"
+      },
+      {
+        "type": "bark"
+      }
+    ],
+    "narrative": "In the wetlands transitional realms, where wetland holds sway, stands the Idaho Catkin Willow, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Basket Willow, names born of custom and need. From its body folk derive wood and bark, a boon to trade and craft. Thus the Idaho Catkin Willow marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Cut rods in dormancy for weaving.",
+    "seasonality": "spring",
+    "sowing_season": "cuttings",
+    "harvest_season": "winter",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "cranberries"
+    ],
+    "alt_names": [
+      "Basket Willow"
+    ]
+  },
+  {
+    "id": "inca_oca_patch",
+    "common_name": "Inca Oca Patch",
+    "growth_form": "herb",
+    "regions": [
+      "highland"
+    ],
+    "habitats": [
+      "farmland",
+      "mountains"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "tuber"
+      }
+    ],
+    "narrative": "In the highland realms, where the farmland and mountains hold sway, stands the Inca Oca Patch, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its tuber sustain the hungry when prepared with care. Among diverse tongues it is hailed as Oxalis Tuberosa, names born of custom and need. From its body folk derive tuber, a boon to trade and craft. Thus the Inca Oca Patch marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "tuber"
+    ],
+    "culinary_uses": [
+      "roast",
+      "sun-sweet"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "cool-season",
+    "sowing_season": "early spring",
+    "harvest_season": "late autumn",
+    "growth_duration": "200 days",
+    "companion_crops": [
+      "corn"
+    ],
+    "alt_names": [
+      "Oxalis Tuberosa"
+    ]
+  },
+  {
     "id": "ink-cap",
     "common_name": "Ink cap",
     "growth_form": "mushroom",
@@ -3101,6 +5008,90 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Ink cap, a mushroom of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Ink cap marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "inle_garden_watercress",
+    "common_name": "Inle Garden Watercress",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland",
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where the wetland and farmland hold sway, stands the Inle Garden Watercress, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Floating Watercress, names born of custom and need. From its body folk derive leaf, a boon to trade and craft. Thus the Inle Garden Watercress marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "salad",
+      "garnish"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "cool-season",
+    "sowing_season": "late autumn",
+    "harvest_season": "spring",
+    "growth_duration": "90 days",
+    "companion_crops": [
+      "floating tomatoes"
+    ],
+    "alt_names": [
+      "Floating Watercress"
+    ]
+  },
+  {
+    "id": "istrian_olive_terrace",
+    "common_name": "Istrian Olive Terrace",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "hills"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      },
+      {
+        "type": "oil"
+      },
+      {
+        "type": "wood"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the farmland and hills hold sway, stands the Istrian Olive Terrace, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Istrian Olea, names born of custom and need. From its body folk derive fruit, oil and wood, a boon to trade and craft. Thus the Istrian Olive Terrace marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "oil",
+      "cured"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "warm-season",
+    "sowing_season": "spring cuttings",
+    "harvest_season": "late autumn",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "grapes"
+    ],
+    "alt_names": [
+      "Istrian Olea"
+    ]
   },
   {
     "id": "ivy",
@@ -3133,6 +5124,44 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Jackfruit, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Jackfruit marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "japanese_nori_rafter",
+    "common_name": "Japanese Nori Rafter",
+    "growth_form": "seaweed",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the coastal realms, where coastal holds sway, stands the Japanese Nori Rafter, a seaweed of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Nori, names born of custom and need. From its body folk derive leaf, a boon to trade and craft. Thus the Japanese Nori Rafter marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "wraps",
+      "soup"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "winter",
+    "sowing_season": "autumn spores",
+    "harvest_season": "winter",
+    "growth_duration": "120 days",
+    "companion_crops": [
+      "oysters"
+    ],
+    "alt_names": [
+      "Nori"
+    ]
+  },
+  {
     "id": "jasmine",
     "common_name": "Jasmine",
     "growth_form": "herb",
@@ -3163,6 +5192,43 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Jicama, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Jicama marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "jordanian_sagebrush",
+    "common_name": "Jordanian Sagebrush",
+    "growth_form": "shrub",
+    "regions": [
+      "arid"
+    ],
+    "habitats": [
+      "desert"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": "In the arid realms, where desert holds sway, stands the Jordanian Sagebrush, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Desert Sage, names born of custom and need. From its body folk derive leaf and herb, a boon to trade and craft. Thus the Jordanian Sagebrush marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "tea",
+      "seasoning"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "spring",
+    "harvest_season": "spring",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Desert Sage"
+    ]
+  },
+  {
     "id": "juniper",
     "common_name": "Juniper",
     "growth_form": "tree",
@@ -3178,6 +5244,182 @@
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Juniper, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Juniper marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "jura_valerian_clump",
+    "common_name": "Jura Valerian Clump",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "hills"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "root"
+      },
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the forest and hills hold sway, stands the Jura Valerian Clump, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive root and herb, a boon to trade and craft. Thus the Jura Valerian Clump marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Harvest roots after first frost.",
+    "seasonality": "spring",
+    "harvest_season": "autumn",
+    "growth_duration": "perennial"
+  },
+  {
+    "id": "juruena_arrowhead_bed",
+    "common_name": "Juruena Arrowhead Bed",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "tuber"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where wetland holds sway, stands the Juruena Arrowhead Bed, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its tuber sustain the hungry when prepared with care. Among diverse tongues it is hailed as Arrowhead Sagittaria, names born of custom and need. From its body folk derive tuber, a boon to trade and craft. Thus the Juruena Arrowhead Bed marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "tuber"
+    ],
+    "culinary_uses": [
+      "boil",
+      "grill"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "dry-season",
+    "sowing_season": "start of rains",
+    "harvest_season": "dry-season",
+    "growth_duration": "160 days",
+    "companion_crops": [
+      "fish"
+    ],
+    "alt_names": [
+      "Arrowhead Sagittaria"
+    ]
+  },
+  {
+    "id": "jutland_reed_canary",
+    "common_name": "Jutland Reed Canary",
+    "growth_form": "grass",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the wetlands transitional realms, where wetland holds sway, stands the Jutland Reed Canary, a grass of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Reed Canary Grass, names born of custom and need. From its body folk derive fiber, a boon to trade and craft. Thus the Jutland Reed Canary marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Cut for thatch before seedheads mature.",
+    "seasonality": "summer",
+    "sowing_season": "spring",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Reed Canary Grass"
+    ]
+  },
+  {
+    "id": "kailash_highland_barley",
+    "common_name": "Kailash Highland Barley",
+    "growth_form": "grass",
+    "regions": [
+      "highland"
+    ],
+    "habitats": [
+      "farmland",
+      "mountains"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "grain"
+      },
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the highland realms, where the farmland and mountains hold sway, stands the Kailash Highland Barley, a grass of note. Tilled and tended by folk, it answers well to plough and garden row. Its grain sustain the hungry when prepared with care. Among diverse tongues it is hailed as Tibetan Barley, names born of custom and need. From its body folk derive grain and fiber, a boon to trade and craft. Thus the Kailash Highland Barley marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "grain"
+    ],
+    "culinary_uses": [
+      "tsampa",
+      "beer"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "cool-season",
+    "sowing_season": "early spring",
+    "harvest_season": "late summer",
+    "growth_duration": "120 days",
+    "companion_crops": [
+      "peas"
+    ],
+    "alt_names": [
+      "Tibetan Barley"
+    ]
+  },
+  {
+    "id": "kalahari_tsamma_melon",
+    "common_name": "Kalahari Tsamma Melon",
+    "growth_form": "vine",
+    "regions": [
+      "arid"
+    ],
+    "habitats": [
+      "desert"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      },
+      {
+        "type": "seed"
+      }
+    ],
+    "narrative": "In the arid realms, where desert holds sway, stands the Kalahari Tsamma Melon, a vine of note. It springs forth unbidden, owing nothing to the care of humankind. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Tsamma Melon, names born of custom and need. From its body folk derive fruit and seed, a boon to trade and craft. Thus the Kalahari Tsamma Melon marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "juice",
+      "stew"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Store fruits in shade for water reserve.",
+    "seasonality": "rainy season",
+    "harvest_season": "rainy season",
+    "growth_duration": "annual",
+    "alt_names": [
+      "Tsamma Melon"
+    ]
+  },
+  {
     "id": "kale",
     "common_name": "Kale",
     "growth_form": "herb",
@@ -3191,6 +5433,41 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Kale, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Kale marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "karpatian_wild_garlic",
+    "common_name": "Karpatian Wild Garlic",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Karpatian Wild Garlic, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Ramsons, names born of custom and need. From its body folk derive leaf, a boon to trade and craft. Thus the Karpatian Wild Garlic marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "pesto",
+      "seasoning"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Gather before flowering.",
+    "seasonality": "spring",
+    "harvest_season": "spring",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Ramsons"
+    ]
   },
   {
     "id": "kava",
@@ -3238,6 +5515,46 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Khat, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Khat marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "kinabatangan_water_spinach",
+    "common_name": "Kinabatangan Water Spinach",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland",
+      "riverlands"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where the wetland and riverlands hold sway, stands the Kinabatangan Water Spinach, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Kangkung, names born of custom and need. From its body folk derive leaf, a boon to trade and craft. Thus the Kinabatangan Water Spinach marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "stir-fry",
+      "pickle"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Harvest tender tips weekly.",
+    "seasonality": "year-round",
+    "sowing_season": "cuttings",
+    "harvest_season": "year-round",
+    "growth_duration": "60 days",
+    "companion_crops": [
+      "paddy rice"
+    ],
+    "alt_names": [
+      "Kangkung"
+    ]
+  },
+  {
     "id": "kiwi-fruit",
     "common_name": "Kiwi fruit",
     "growth_form": "herb",
@@ -3268,6 +5585,75 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Kohlrabi, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Kohlrabi marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "kootenay_sedge_meadow",
+    "common_name": "Kootenay Sedge Meadow",
+    "growth_form": "grass",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the wetlands transitional realms, where wetland holds sway, stands the Kootenay Sedge Meadow, a grass of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Sedge Meadow, names born of custom and need. From its body folk derive fiber, a boon to trade and craft. Thus the Kootenay Sedge Meadow marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Provides fodder for migrating elk.",
+    "seasonality": "summer",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Sedge Meadow"
+    ]
+  },
+  {
+    "id": "korean_glasswort_flat",
+    "common_name": "Korean Glasswort Flat",
+    "growth_form": "herb",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "dye"
+      }
+    ],
+    "narrative": "In the coastal realms, where coastal holds sway, stands the Korean Glasswort Flat, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Salicornia, names born of custom and need. From its body folk derive leaf and dye, a boon to trade and craft. Thus the Korean Glasswort Flat marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "pickle",
+      "salad"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "summer",
+    "sowing_season": "spring",
+    "harvest_season": "late summer",
+    "growth_duration": "100 days",
+    "companion_crops": [
+      "sea rice"
+    ],
+    "alt_names": [
+      "Salicornia"
+    ]
+  },
+  {
     "id": "kumquat",
     "common_name": "Kumquat",
     "growth_form": "herb",
@@ -3281,6 +5667,48 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Kumquat, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Kumquat marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "ladakh_dryland_mustard",
+    "common_name": "Ladakh Dryland Mustard",
+    "growth_form": "herb",
+    "regions": [
+      "highland"
+    ],
+    "habitats": [
+      "farmland",
+      "mountains"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "seed"
+      },
+      {
+        "type": "oil"
+      }
+    ],
+    "narrative": "In the highland realms, where the farmland and mountains hold sway, stands the Ladakh Dryland Mustard, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its seed sustain the hungry when prepared with care. Among diverse tongues it is hailed as Ladakhi Mustard, names born of custom and need. From its body folk derive seed and oil, a boon to trade and craft. Thus the Ladakh Dryland Mustard marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "seed"
+    ],
+    "culinary_uses": [
+      "oil",
+      "pickle"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "cool-season",
+    "sowing_season": "spring thaw",
+    "harvest_season": "autumn",
+    "growth_duration": "150 days",
+    "companion_crops": [
+      "barley"
+    ],
+    "alt_names": [
+      "Ladakhi Mustard"
+    ]
   },
   {
     "id": "ladys-bedstraw",
@@ -3298,6 +5726,82 @@
     "narrative": "In the terrestrial realms, where grassland holds sway, stands the Lady's bedstraw, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Lady's bedstraw marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "lagoon_coastal_coconut",
+    "common_name": "Lagoon Coastal Coconut",
+    "growth_form": "tree",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "nut"
+      },
+      {
+        "type": "oil"
+      },
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the coastal realms, where coastal holds sway, stands the Lagoon Coastal Coconut, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its nut sustain the hungry when prepared with care. Among diverse tongues it is hailed as Lagoon Coconut, names born of custom and need. From its body folk derive nut, oil and fiber, a boon to trade and craft. Thus the Lagoon Coastal Coconut marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "nut"
+    ],
+    "culinary_uses": [
+      "milk",
+      "oil"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "year-round",
+    "sowing_season": "transplant",
+    "harvest_season": "year-round",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "breadfruit"
+    ],
+    "alt_names": [
+      "Lagoon Coconut"
+    ]
+  },
+  {
+    "id": "laguna_azolla_mat",
+    "common_name": "Laguna Azolla Mat",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where wetland holds sway, stands the Laguna Azolla Mat, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Floating Fern, names born of custom and need. From its body folk derive herb, a boon to trade and craft. Thus the Laguna Azolla Mat marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Use as living mulch in rice paddies.",
+    "seasonality": "year-round",
+    "sowing_season": "early monsoon",
+    "harvest_season": "year-round",
+    "growth_duration": "fast spread",
+    "companion_crops": [
+      "rice"
+    ],
+    "alt_names": [
+      "Floating Fern"
+    ]
+  },
+  {
     "id": "lambs-lettuce",
     "common_name": "Lambs lettuce",
     "growth_form": "herb",
@@ -3311,6 +5815,42 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where grassland holds sway, stands the Lambs lettuce, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Lambs lettuce marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "lapland_cloudberry_bog",
+    "common_name": "Lapland Cloudberry Bog",
+    "growth_form": "shrub",
+    "regions": [
+      "cold"
+    ],
+    "habitats": [
+      "wetland",
+      "tundra"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      }
+    ],
+    "narrative": "In the cold realms, where the wetland and tundra hold sway, stands the Lapland Cloudberry Bog, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Cloudberry, names born of custom and need. From its body folk derive fruit, a boon to trade and craft. Thus the Lapland Cloudberry Bog marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "jam",
+      "dessert"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Swamps yield heavily after long winters.",
+    "seasonality": "late summer",
+    "harvest_season": "late summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Cloudberry"
+    ]
   },
   {
     "id": "larch",
@@ -3620,6 +6160,47 @@
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Liverwort, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Liverwort marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "loire_meadow_clover",
+    "common_name": "Loire Meadow Clover",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "flower"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where grassland holds sway, stands the Loire Meadow Clover, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Trifolium of Loire, names born of custom and need. From its body folk derive leaf and flower, a boon to trade and craft. Thus the Loire Meadow Clover marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "fodder infusion",
+      "salad"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "summer",
+    "sowing_season": "spring",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "grain"
+    ],
+    "alt_names": [
+      "Trifolium of Loire"
+    ]
+  },
+  {
     "id": "loquat",
     "common_name": "Loquat",
     "growth_form": "herb",
@@ -3663,6 +6244,45 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Lovage, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Lovage marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "lowcountry_pawpaw",
+    "common_name": "Lowcountry Pawpaw",
+    "growth_form": "tree",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "riverlands",
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      }
+    ],
+    "narrative": "In the wetlands transitional realms, where the riverlands and forest hold sway, stands the Lowcountry Pawpaw, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as River Pawpaw, names born of custom and need. From its body folk derive fruit, a boon to trade and craft. Thus the Lowcountry Pawpaw marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "custard",
+      "fresh eating"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "late summer",
+    "sowing_season": "spring",
+    "harvest_season": "late summer",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "black walnut"
+    ],
+    "alt_names": [
+      "River Pawpaw"
+    ]
   },
   {
     "id": "luffa",
@@ -3727,6 +6347,47 @@
       }
     ],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Madder, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive dye, a boon to trade and craft. Thus the Madder marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "maldives_pandanus_grove",
+    "common_name": "Maldives Pandanus Grove",
+    "growth_form": "tree",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      },
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the coastal realms, where coastal holds sway, stands the Maldives Pandanus Grove, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Screwpine, names born of custom and need. From its body folk derive fruit and fiber, a boon to trade and craft. Thus the Maldives Pandanus Grove marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "starch",
+      "dessert"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "year-round",
+    "sowing_season": "cuttings",
+    "harvest_season": "year-round",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "coconut"
+    ],
+    "alt_names": [
+      "Screwpine"
+    ]
   },
   {
     "id": "mandrake",
@@ -3808,6 +6469,47 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Marjoram, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. From its body folk derive herb, a boon to trade and craft. Thus the Marjoram marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "market_square_herb_planter",
+    "common_name": "Market Square Herb Planter",
+    "growth_form": "herb",
+    "regions": [
+      "urban"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": "In the urban realms, where urban holds sway, stands the Market Square Herb Planter, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Planter Herbs, names born of custom and need. From its body folk derive leaf and herb, a boon to trade and craft. Thus the Market Square Herb Planter marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "herb",
+      "tea"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "year-round",
+    "sowing_season": "spring",
+    "harvest_season": "year-round",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "tomato"
+    ],
+    "alt_names": [
+      "Planter Herbs"
+    ]
+  },
+  {
     "id": "marsh-marigold",
     "common_name": "Marsh marigold",
     "growth_form": "herb",
@@ -3870,6 +6572,44 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Medlar, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Medlar marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "mekong_water_celery",
+    "common_name": "Mekong Water Celery",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where wetland holds sway, stands the Mekong Water Celery, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Pak Chi, names born of custom and need. From its body folk derive leaf, a boon to trade and craft. Thus the Mekong Water Celery marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "soup",
+      "salad"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "cool-season",
+    "sowing_season": "late autumn",
+    "harvest_season": "spring",
+    "growth_duration": "120 days",
+    "companion_crops": [
+      "fish"
+    ],
+    "alt_names": [
+      "Pak Chi"
+    ]
   },
   {
     "id": "melon",
@@ -4067,6 +6807,34 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Myrtle, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Myrtle marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "namib_welwitschia_pair",
+    "common_name": "Namib Welwitschia Pair",
+    "growth_form": "shrub",
+    "regions": [
+      "arid"
+    ],
+    "habitats": [
+      "desert"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the arid realms, where desert holds sway, stands the Namib Welwitschia Pair, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Welwitschia, names born of custom and need. From its body folk derive leaf, a boon to trade and craft. Thus the Namib Welwitschia Pair marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Leaves persist for centuries across the gravel plains.",
+    "seasonality": "year-round",
+    "harvest_season": "year-round",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Welwitschia"
+    ]
+  },
+  {
     "id": "nasturtium",
     "common_name": "Nasturtium",
     "growth_form": "herb",
@@ -4144,6 +6912,123 @@
       }
     ],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Nigella (black cumin), a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. From its body folk derive seed, a boon to trade and craft. Thus the Nigella (black cumin) marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "nile_blue_lily",
+    "common_name": "Nile Blue Lily",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "lake",
+      "wetland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "seed"
+      },
+      {
+        "type": "flower"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where the lake and wetland hold sway, stands the Nile Blue Lily, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its seed sustain the hungry when prepared with care. Among diverse tongues it is hailed as Blue Lotus, names born of custom and need. From its body folk derive seed and flower, a boon to trade and craft. Thus the Nile Blue Lily marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "seed"
+    ],
+    "culinary_uses": [
+      "porridge",
+      "tea"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "summer",
+    "sowing_season": "spring",
+    "harvest_season": "late summer",
+    "growth_duration": "180 days",
+    "companion_crops": [
+      "lotus"
+    ],
+    "alt_names": [
+      "Blue Lotus"
+    ]
+  },
+  {
+    "id": "north_sea_sea_beet",
+    "common_name": "North Sea Sea Beet",
+    "growth_form": "herb",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the coastal realms, where coastal holds sway, stands the North Sea Sea Beet, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Sea Beet, names born of custom and need. From its body folk derive leaf, a boon to trade and craft. Thus the North Sea Sea Beet marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "greens",
+      "stew"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "spring",
+    "harvest_season": "spring",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Sea Beet"
+    ]
+  },
+  {
+    "id": "novgorod_flax_field",
+    "common_name": "Novgorod Flax Field",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "seed"
+      },
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Novgorod Flax Field, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its seed sustain the hungry when prepared with care. Among diverse tongues it is hailed as Linen Flax, names born of custom and need. From its body folk derive seed and fiber, a boon to trade and craft. Thus the Novgorod Flax Field marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "seed"
+    ],
+    "culinary_uses": [
+      "oil",
+      "porridge"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "summer",
+    "sowing_season": "early spring",
+    "harvest_season": "late summer",
+    "growth_duration": "110 days",
+    "companion_crops": [
+      "legumes"
+    ],
+    "alt_names": [
+      "Linen Flax"
+    ]
   },
   {
     "id": "nutmeg",
@@ -4247,6 +7132,48 @@
       ],
       "luxury_tier": []
     }
+  },
+  {
+    "id": "occitanian_truffle_oak",
+    "common_name": "Occitanian Truffle Oak",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "hills"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "mushroom"
+      },
+      {
+        "type": "wood"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the forest and hills hold sway, stands the Occitanian Truffle Oak, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruiting body sustain the hungry when prepared with care. Among diverse tongues it is hailed as Truffle Oak Grove, names born of custom and need. From its body folk derive fruiting body and wood, a boon to trade and craft. Thus the Occitanian Truffle Oak marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruiting body"
+    ],
+    "culinary_uses": [
+      "gourmet shaving"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Train hogs to root at dawn.",
+    "seasonality": "autumn",
+    "sowing_season": "spring saplings",
+    "harvest_season": "late autumn",
+    "growth_duration": "many years",
+    "companion_crops": [
+      "hazelnut"
+    ],
+    "alt_names": [
+      "Truffle Oak Grove"
+    ]
   },
   {
     "id": "okra",
@@ -4484,6 +7411,45 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Oregano, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. From its body folk derive herb, a boon to trade and craft. Thus the Oregano marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "orinoco_sagittaria",
+    "common_name": "Orinoco Sagittaria",
+    "growth_form": "herb",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "riverlands",
+      "wetland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "tuber"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where the riverlands and wetland hold sway, stands the Orinoco Sagittaria, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its tuber sustain the hungry when prepared with care. Among diverse tongues it is hailed as Orinoco Arrowroot, names born of custom and need. From its body folk derive tuber, a boon to trade and craft. Thus the Orinoco Sagittaria marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "tuber"
+    ],
+    "culinary_uses": [
+      "stew",
+      "roast"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "dry-season",
+    "sowing_season": "rising waters",
+    "harvest_season": "dry-season",
+    "growth_duration": "150 days",
+    "companion_crops": [
+      "fish"
+    ],
+    "alt_names": [
+      "Orinoco Arrowroot"
+    ]
+  },
+  {
     "id": "oyster-mushroom",
     "common_name": "Oyster Mushroom",
     "alt_names": [
@@ -4534,6 +7500,85 @@
       ],
       "luxury_tier": []
     }
+  },
+  {
+    "id": "palace_courtyard_lime",
+    "common_name": "Palace Courtyard Lime",
+    "growth_form": "tree",
+    "regions": [
+      "urban"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      },
+      {
+        "type": "oil"
+      }
+    ],
+    "narrative": "In the urban realms, where urban holds sway, stands the Palace Courtyard Lime, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Courtyard Lime, names born of custom and need. From its body folk derive fruit and oil, a boon to trade and craft. Thus the Palace Courtyard Lime marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "drink",
+      "condiment"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "year-round",
+    "sowing_season": "potted cuttings",
+    "harvest_season": "year-round",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "mint"
+    ],
+    "alt_names": [
+      "Courtyard Lime"
+    ]
+  },
+  {
+    "id": "pamir_wild_thyme",
+    "common_name": "Pamir Wild Thyme",
+    "growth_form": "herb",
+    "regions": [
+      "highland"
+    ],
+    "habitats": [
+      "mountains"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": "In the highland realms, where mountains holds sway, stands the Pamir Wild Thyme, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Pamir Thyme, names born of custom and need. From its body folk derive leaf and herb, a boon to trade and craft. Thus the Pamir Wild Thyme marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "tea",
+      "herb"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Dry on shaded cloth to keep aroma.",
+    "seasonality": "summer",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Pamir Thyme"
+    ]
   },
   {
     "id": "pansy",
@@ -4827,6 +7872,48 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Persimmon, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Persimmon marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "piedmont_hazelnut_copse",
+    "common_name": "Piedmont Hazelnut Copse",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "hills"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "nut"
+      },
+      {
+        "type": "wood"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the forest and hills hold sway, stands the Piedmont Hazelnut Copse, a shrub of note. Tilled and tended by folk, it answers well to plough and garden row. Its nut sustain the hungry when prepared with care. Among diverse tongues it is hailed as Tonda Nut Grove, names born of custom and need. From its body folk derive nut and wood, a boon to trade and craft. Thus the Piedmont Hazelnut Copse marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "nut"
+    ],
+    "culinary_uses": [
+      "confection",
+      "roast"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "cool-season",
+    "sowing_season": "spring",
+    "harvest_season": "late summer",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "truffles"
+    ],
+    "alt_names": [
+      "Tonda Nut Grove"
+    ]
+  },
+  {
     "id": "pine",
     "common_name": "Pine",
     "growth_form": "tree",
@@ -5103,6 +8190,79 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Purslane, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. From its body folk derive leaf, a boon to trade and craft. Thus the Purslane marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "quebec_maple_grove",
+    "common_name": "Quebec Maple Grove",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "sap"
+      },
+      {
+        "type": "wood"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Quebec Maple Grove, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its sap sustain the hungry when prepared with care. Among diverse tongues it is hailed as Sugar Maple Stand, names born of custom and need. From its body folk derive sap and wood, a boon to trade and craft. Thus the Quebec Maple Grove marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "sap"
+    ],
+    "culinary_uses": [
+      "syrup",
+      "sugar"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Tap on cold clear mornings.",
+    "seasonality": "late winter",
+    "harvest_season": "early spring",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Sugar Maple Stand"
+    ]
+  },
+  {
+    "id": "queensland_mangrove_fern",
+    "common_name": "Queensland Mangrove Fern",
+    "growth_form": "herb",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the coastal realms, where coastal holds sway, stands the Queensland Mangrove Fern, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Mangrove Fern, names born of custom and need. From its body folk derive leaf, a boon to trade and craft. Thus the Queensland Mangrove Fern marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "greens",
+      "stew"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Blanch young fronds to tame bitterness.",
+    "seasonality": "summer",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Mangrove Fern"
+    ]
+  },
+  {
     "id": "quince",
     "common_name": "Quince",
     "growth_form": "herb",
@@ -5332,6 +8492,48 @@
     "narrative": "In the terrestrial realms, where tundra holds sway, stands the Reindeer moss, a lichen of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Reindeer moss marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "rhine_riesling_vine",
+    "common_name": "Rhine Riesling Vine",
+    "growth_form": "vine",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "hills"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      },
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the farmland and hills hold sway, stands the Rhine Riesling Vine, a vine of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Rhine Riesling, names born of custom and need. From its body folk derive fruit and leaf, a boon to trade and craft. Thus the Rhine Riesling Vine marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "wine",
+      "table"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "warm-season",
+    "sowing_season": "spring cuttings",
+    "harvest_season": "autumn",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "fava beans"
+    ],
+    "alt_names": [
+      "Rhine Riesling"
+    ]
+  },
+  {
     "id": "rice",
     "common_name": "Rice",
     "growth_form": "grass",
@@ -5349,6 +8551,38 @@
       }
     ],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Rice, a grass of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. From its body folk derive grain, a boon to trade and craft. Thus the Rice marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "riverfront_poplar_row",
+    "common_name": "Riverfront Poplar Row",
+    "growth_form": "tree",
+    "regions": [
+      "urban"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "wood"
+      }
+    ],
+    "narrative": "In the urban realms, where urban holds sway, stands the Riverfront Poplar Row, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as River Poplar, names born of custom and need. From its body folk derive wood, a boon to trade and craft. Thus the Riverfront Poplar Row marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Planted for shade and windbreak.",
+    "seasonality": "spring",
+    "sowing_season": "cuttings",
+    "harvest_season": "winter",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "willow"
+    ],
+    "alt_names": [
+      "River Poplar"
+    ]
   },
   {
     "id": "rose",
@@ -5577,6 +8811,43 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Sage, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Sage marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "saharan_acacia_bosk",
+    "common_name": "Saharan Acacia Bosk",
+    "growth_form": "tree",
+    "regions": [
+      "arid"
+    ],
+    "habitats": [
+      "desert"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "seed"
+      },
+      {
+        "type": "wood"
+      }
+    ],
+    "narrative": "In the arid realms, where desert holds sway, stands the Saharan Acacia Bosk, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its seed sustain the hungry when prepared with care. Among diverse tongues it is hailed as Desert Acacia, names born of custom and need. From its body folk derive seed and wood, a boon to trade and craft. Thus the Saharan Acacia Bosk marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "seed"
+    ],
+    "culinary_uses": [
+      "roast meal",
+      "fodder"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "dry-season",
+    "harvest_season": "dry-season",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Desert Acacia"
+    ]
   },
   {
     "id": "salad-burnet",
@@ -5813,6 +9084,87 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Shallots, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Shallots marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "sicilian_blood_orange",
+    "common_name": "Sicilian Blood Orange",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      },
+      {
+        "type": "oil"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Sicilian Blood Orange, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Arancia Rossa, names born of custom and need. From its body folk derive fruit and oil, a boon to trade and craft. Thus the Sicilian Blood Orange marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "dessert",
+      "fresh eating"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "warm-season",
+    "sowing_season": "spring",
+    "harvest_season": "winter",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "basil"
+    ],
+    "alt_names": [
+      "Arancia Rossa"
+    ]
+  },
+  {
+    "id": "silesian_potato_patch",
+    "common_name": "Silesian Potato Patch",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "tuber"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Silesian Potato Patch, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its tuber sustain the hungry when prepared with care. Among diverse tongues it is hailed as Silesian Kartofel, names born of custom and need. From its body folk derive tuber, a boon to trade and craft. Thus the Silesian Potato Patch marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "tuber"
+    ],
+    "culinary_uses": [
+      "dumplings",
+      "stew"
+    ],
+    "medicinal": false,
+    "toxic": true,
+    "toxicity_notes": "Sprouts and green skins are bitter.",
+    "foraging_notes": "Earthing ridges keeps tubers covered.",
+    "seasonality": "cool-season",
+    "sowing_season": "spring",
+    "harvest_season": "autumn",
+    "growth_duration": "120 days",
+    "companion_crops": [
+      "beans"
+    ],
+    "alt_names": [
+      "Silesian Kartofel"
+    ]
   },
   {
     "id": "skirret",
@@ -6064,6 +9416,41 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Sunflower, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Sunflower marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "svalbard_purple_saxifrage",
+    "common_name": "Svalbard Purple Saxifrage",
+    "growth_form": "herb",
+    "regions": [
+      "cold"
+    ],
+    "habitats": [
+      "tundra"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "flower"
+      }
+    ],
+    "narrative": "In the cold realms, where tundra holds sway, stands the Svalbard Purple Saxifrage, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its flower sustain the hungry when prepared with care. Among diverse tongues it is hailed as Purple Saxifrage, names born of custom and need. From its body folk derive flower, a boon to trade and craft. Thus the Svalbard Purple Saxifrage marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "flower"
+    ],
+    "culinary_uses": [
+      "garnish",
+      "syrup"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Blooms under midnight sun.",
+    "seasonality": "summer",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Purple Saxifrage"
+    ]
+  },
+  {
     "id": "sweet-flag-acorus-calamus",
     "common_name": "Sweet flag (Acorus calamus)",
     "growth_form": "herb",
@@ -6211,6 +9598,48 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Tea, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Tea marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "tenement_window_box_mint",
+    "common_name": "Tenement Window Box Mint",
+    "growth_form": "herb",
+    "regions": [
+      "urban"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": "In the urban realms, where urban holds sway, stands the Tenement Window Box Mint, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Window Mint, names born of custom and need. From its body folk derive leaf and herb, a boon to trade and craft. Thus the Tenement Window Box Mint marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "tea",
+      "garnish"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "foraging_notes": "Keep pots trimmed to prevent bolting.",
+    "seasonality": "year-round",
+    "sowing_season": "spring",
+    "harvest_season": "year-round",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "parsley"
+    ],
+    "alt_names": [
+      "Window Mint"
+    ]
+  },
+  {
     "id": "thyme",
     "common_name": "Thyme",
     "growth_form": "herb",
@@ -6284,6 +9713,86 @@
           "High Table"
         ]
       }
+    ]
+  },
+  {
+    "id": "toscana_artichoke_bed",
+    "common_name": "Toscana Artichoke Bed",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "flower"
+      },
+      {
+        "type": "leaf"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Toscana Artichoke Bed, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its flower sustain the hungry when prepared with care. Among diverse tongues it is hailed as Tuscan Carciofo, names born of custom and need. From its body folk derive flower and leaf, a boon to trade and craft. Thus the Toscana Artichoke Bed marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "flower"
+    ],
+    "culinary_uses": [
+      "roast",
+      "preserve"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "spring",
+    "sowing_season": "winter",
+    "harvest_season": "spring",
+    "growth_duration": "150 days",
+    "companion_crops": [
+      "leeks"
+    ],
+    "alt_names": [
+      "Tuscan Carciofo"
+    ]
+  },
+  {
+    "id": "transylvanian_beech_mast",
+    "common_name": "Transylvanian Beech Mast",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "hills"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "nut"
+      },
+      {
+        "type": "wood"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the forest and hills hold sway, stands the Transylvanian Beech Mast, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its nut sustain the hungry when prepared with care. Among diverse tongues it is hailed as Beech Mast Grove, names born of custom and need. From its body folk derive nut and wood, a boon to trade and craft. Thus the Transylvanian Beech Mast marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "nut"
+    ],
+    "culinary_uses": [
+      "pottage",
+      "flour"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Gather before squirrels strip the branches.",
+    "seasonality": "autumn",
+    "harvest_season": "autumn",
+    "growth_duration": "perennial",
+    "alt_names": [
+      "Beech Mast Grove"
     ]
   },
   {
@@ -6405,6 +9914,47 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Turnips, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Turnips marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "tuscan_rosemary_hedge",
+    "common_name": "Tuscan Rosemary Hedge",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "herb"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Tuscan Rosemary Hedge, a shrub of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Rosmarino Toscano, names born of custom and need. From its body folk derive leaf and herb, a boon to trade and craft. Thus the Tuscan Rosemary Hedge marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "herb",
+      "roast"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "seasonality": "year-round",
+    "sowing_season": "spring cuttings",
+    "harvest_season": "year-round",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "grapes"
+    ],
+    "alt_names": [
+      "Rosmarino Toscano"
+    ]
+  },
+  {
     "id": "ube",
     "common_name": "Ube",
     "growth_form": "herb",
@@ -6418,6 +9968,88 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Ube, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Ube marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "umbria_fava_trellis",
+    "common_name": "Umbria Fava Trellis",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "seed"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Umbria Fava Trellis, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its seed sustain the hungry when prepared with care. Among diverse tongues it is hailed as Umbria Broad Bean, names born of custom and need. From its body folk derive seed, a boon to trade and craft. Thus the Umbria Fava Trellis marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "seed"
+    ],
+    "culinary_uses": [
+      "stew",
+      "puree"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "cool-season",
+    "sowing_season": "late autumn",
+    "harvest_season": "late spring",
+    "growth_duration": "210 days",
+    "companion_crops": [
+      "grain"
+    ],
+    "alt_names": [
+      "Umbria Broad Bean"
+    ]
+  },
+  {
+    "id": "valencia_almond_lot",
+    "common_name": "Valencia Almond Lot",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "nut"
+      },
+      {
+        "type": "oil"
+      },
+      {
+        "type": "wood"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Valencia Almond Lot, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its nut sustain the hungry when prepared with care. Among diverse tongues it is hailed as Valencian Almendra, names born of custom and need. From its body folk derive nut, oil and wood, a boon to trade and craft. Thus the Valencia Almond Lot marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "nut"
+    ],
+    "culinary_uses": [
+      "confection",
+      "oil"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "warm-season",
+    "sowing_season": "winter plantings",
+    "harvest_season": "late summer",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "lavender"
+    ],
+    "alt_names": [
+      "Valencian Almendra"
+    ]
   },
   {
     "id": "valerian",
@@ -6463,6 +10095,48 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where grassland holds sway, stands the Violet, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Violet marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "walloon_endive_forcer",
+    "common_name": "Walloon Endive Forcer",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf"
+      },
+      {
+        "type": "root"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Walloon Endive Forcer, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Chicon, names born of custom and need. From its body folk derive leaf and root, a boon to trade and craft. Thus the Walloon Endive Forcer marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "salad",
+      "braise"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Force roots in dark cellars.",
+    "seasonality": "cool-season",
+    "sowing_season": "spring",
+    "harvest_season": "winter",
+    "growth_duration": "180 days",
+    "companion_crops": [
+      "potatoes"
+    ],
+    "alt_names": [
+      "Chicon"
+    ]
   },
   {
     "id": "walnut",
@@ -6869,5 +10543,80 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Yew, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Yew marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "yorkshire_ryegrass_pasture",
+    "common_name": "Yorkshire Ryegrass Pasture",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland",
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "fiber"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the grassland and farmland hold sway, stands the Yorkshire Ryegrass Pasture, a grass of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Pasture Ryegrass, names born of custom and need. From its body folk derive fiber, a boon to trade and craft. Thus the Yorkshire Ryegrass Pasture marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": false,
+    "toxic": false,
+    "foraging_notes": "Pasture cut for hay midsummer.",
+    "seasonality": "cool-season",
+    "sowing_season": "autumn",
+    "harvest_season": "summer",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "clover"
+    ],
+    "alt_names": [
+      "Pasture Ryegrass"
+    ]
+  },
+  {
+    "id": "zagreb_plum_orchard",
+    "common_name": "Zagreb Plum Orchard",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "hills"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit"
+      },
+      {
+        "type": "wood"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the farmland and hills hold sway, stands the Zagreb Plum Orchard, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Slivovitz Grove, names born of custom and need. From its body folk derive fruit and wood, a boon to trade and craft. Thus the Zagreb Plum Orchard marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "culinary_uses": [
+      "brandy",
+      "jam"
+    ],
+    "medicinal": false,
+    "toxic": false,
+    "seasonality": "warm-season",
+    "sowing_season": "winter",
+    "harvest_season": "late summer",
+    "growth_duration": "perennial",
+    "companion_crops": [
+      "bees"
+    ],
+    "alt_names": [
+      "Slivovitz Grove"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- keep the expanded animal catalog sorted with existing ids so the 100 starch additions blend with prior records
- alphabetize the plant collection likewise to match the established ordering for earlier entries
- drop the temporary ingestion script and spec sheets now that the data lives in the primary JSON files

## Testing
- npm run validate
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8b93a6b2c83259f5874b3fd68c6cb