### PR TITLE
Add missing animal and plant entries with aliases

### DIFF
--- a/data/animals.json
+++ b/data/animals.json
@@ -173,6 +173,49 @@
     "size_class": "medium"
   },
   {
+    "id": "alligator",
+    "common_name": "Alligator",
+    "taxon_group": "reptile",
+    "regions": [
+      "aquatic",
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "swamps",
+      "rivers"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "tooth",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic and wetlands transitional realms, where the swamps and rivers stretch far and wide, there dwells the Alligator, a reptile of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide and tooth, which merchants and craftsmen prize. Thus does the Alligator move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "allis-shad",
     "common_name": "Allis shad",
     "taxon_group": "fish",
@@ -207,6 +250,48 @@
     ],
     "gendered": {},
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Allis shad, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Allis shad move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "alpaca",
+    "common_name": "Alpaca",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland",
+      "farmland"
+    ],
+    "diet": [
+      "herbivore",
+      "grazer"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "sheep wool",
+        "notes": "Shorn into soft fiber",
+        "harvest_method": "domesticated",
+        "yield_unit": "kg",
+        "avg_yield": 3
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the grassland and farmland stretch far and wide, there dwells the Alpaca, a mammal of note. It keeps to a herbivore and grazer fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn sheep wool, which merchants and craftsmen prize. Thus does the Alpaca move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "alpine-ibex",
@@ -586,6 +671,45 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Ant, a insect of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Ant move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "antelope",
+    "common_name": "Antelope",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "savanna",
+      "grassland"
+    ],
+    "diet": [
+      "herbivore",
+      "grazer"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the savanna and grassland stretch far and wide, there dwells the Antelope, a mammal of note. It keeps to a herbivore and grazer fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Antelope move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "arctic_ground_squirrel",
     "common_name": "Arctic Ground Squirrel",
     "taxon_group": "mammal",
@@ -872,6 +996,35 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Axolotl, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Axolotl move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "baboon",
+    "common_name": "Baboon",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "savanna",
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the savanna and forest stretch far and wide, there dwells the Baboon, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Baboon move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "bactrian-camel",
@@ -1246,6 +1399,35 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the limestone caves stretch far and wide, there dwells the Bat, a mammal of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Bat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "beagle",
+    "common_name": "Beagle",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Beagle, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Beagle move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "bear",
@@ -1726,6 +1908,38 @@
     "size_class": "tiny"
   },
   {
+    "id": "boxer_dog",
+    "common_name": "Boxer Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Boxer Dog, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Boxer Dog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Boxer"
+    ]
+  },
+  {
     "id": "brill",
     "common_name": "Brill",
     "taxon_group": "fish",
@@ -1762,6 +1976,66 @@
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Brill, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Brill move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "broadtail_coon_cat",
+    "common_name": "Broadtail Coon Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Broadtail Coon Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Broadtail Coon Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Maine Coon"
+    ]
+  },
+  {
+    "id": "bulldog",
+    "common_name": "Bulldog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Bulldog, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Bulldog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "burbot",
     "common_name": "Burbot",
     "taxon_group": "fish",
@@ -1792,6 +2066,43 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Burbot, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Burbot move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "burrowing_groundhog",
+    "common_name": "Burrowing Groundhog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland",
+      "farmland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the grassland and farmland stretch far and wide, there dwells the Burrowing Groundhog, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Burrowing Groundhog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Ground Hog",
+      "Woodchuck"
+    ]
   },
   {
     "id": "bustard",
@@ -2466,7 +2777,9 @@
     },
     "narrative": "In the terrestrial realms, where the farmland and grassland stretch far and wide, there dwells the Cattle, a mammal of note. It keeps to a herbivore and grazer fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat and milk, ever mindful it must be beef roasted or salted; milk drunk fresh or soured. From its form are drawn meat, milk and hide, which merchants and craftsmen prize. Thus does the Cattle move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
     "alt_names": [
-      "Cow"
+      "Cow",
+      "Bull",
+      "Ox"
     ],
     "food_sources": [
       "pasture grasses",
@@ -2487,6 +2800,34 @@
       "wool_shearing_cycle": ""
     },
     "butchering_age": "2 years"
+  },
+  {
+    "id": "chameleon",
+    "common_name": "Chameleon",
+    "taxon_group": "reptile",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Chameleon, a reptile of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Chameleon move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "chamois",
@@ -2659,6 +3000,34 @@
     ]
   },
   {
+    "id": "chimpanzee",
+    "common_name": "Chimpanzee",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Chimpanzee, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Chimpanzee move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "chinchilla",
     "common_name": "Chinchilla",
     "taxon_group": "other",
@@ -2689,6 +3058,39 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Chinchilla, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Chinchilla move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "chipmunk",
+    "common_name": "Chipmunk",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "hills"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the forest and hills stretch far and wide, there dwells the Chipmunk, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Chipmunk move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "chital",
@@ -2802,6 +3204,38 @@
     "size_class": "small"
   },
   {
+    "id": "city_terrier_dog",
+    "common_name": "City Terrier Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the City Terrier Dog, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the City Terrier Dog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Boston Terrier"
+    ]
+  },
+  {
     "id": "civet",
     "common_name": "Civet",
     "taxon_group": "mammal",
@@ -2864,6 +3298,37 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the aquatic realms, where the ocean shores stretch far and wide, there dwells the Clam, a mollusk of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Clam move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "classic_shorthair_cat",
+    "common_name": "Classic Shorthair Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Classic Shorthair Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Classic Shorthair Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "American Shorthair"
+    ]
   },
   {
     "id": "coati",
@@ -3024,6 +3489,110 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Coelacanth, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Coelacanth move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "common_fish",
+    "common_name": "Common Fish",
+    "taxon_group": "fish",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "rivers",
+      "lakes"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the rivers and lakes stretch far and wide, there dwells the Common Fish, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Common Fish move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Fish"
+    ]
+  },
+  {
+    "id": "common_lizard",
+    "common_name": "Common Lizard",
+    "taxon_group": "reptile",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "semi_arid_scrublands"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the forest and semi arid scrublands stretch far and wide, there dwells the Common Lizard, a reptile of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Common Lizard move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Lizard"
+    ]
+  },
+  {
+    "id": "common_monkey",
+    "common_name": "Common Monkey",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "tropical_rainforest",
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the tropical rainforest and forest stretch far and wide, there dwells the Common Monkey, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Common Monkey move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Monkey"
+    ]
   },
   {
     "id": "common-swift",
@@ -3236,6 +3805,81 @@
     "narrative": "In the coastal realms, where the ocean shores stretch far and wide, there dwells the Cormorant, a bird of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Cormorant move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "cougar",
+    "common_name": "Cougar",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "montane_forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the forest and montane forest stretch far and wide, there dwells the Cougar, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Cougar move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Puma"
+    ]
+  },
+  {
+    "id": "coyote",
+    "common_name": "Coyote",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland",
+      "semi_arid_scrublands"
+    ],
+    "diet": [
+      "omnivore",
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the grassland and semi arid scrublands stretch far and wide, there dwells the Coyote, a mammal of note. It keeps to a omnivore and carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Coyote move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "crab",
     "common_name": "Crab",
     "taxon_group": "crustacean",
@@ -3330,6 +3974,45 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the wetlands transitional realms, where the marshes stretch far and wide, there dwells the Crane fly, a insect of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Crane fly move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "crocodile",
+    "common_name": "Crocodile",
+    "taxon_group": "reptile",
+    "regions": [
+      "aquatic",
+      "coastal"
+    ],
+    "habitats": [
+      "swamps",
+      "rivers"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic and coastal realms, where the swamps and rivers stretch far and wide, there dwells the Crocodile, a reptile of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Crocodile move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "crow",
@@ -3429,6 +4112,37 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Cuckoo, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Cuckoo move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "curled_rex_cat",
+    "common_name": "Curled Rex Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Curled Rex Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Curled Rex Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Devon Rex"
+    ]
   },
   {
     "id": "curlew",
@@ -3565,6 +4279,35 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Dace, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Dace move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "dachshund",
+    "common_name": "Dachshund",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Dachshund, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Dachshund move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "danakil_salt_fox",
@@ -3801,7 +4544,9 @@
       "collective": "herd"
     },
     "narrative": "In the terrestrial realms, where the forest and hills stretch far and wide, there dwells the Red Deer, a mammal of note. It keeps to a herbivore and grazer fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be venison roasted or smoked. From its form are drawn meat, hide and antler, which merchants and craftsmen prize. Thus does the Red Deer move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
-    "alt_names": [],
+    "alt_names": [
+      "Deer"
+    ],
     "food_sources": [
       "grass",
       "leaves",
@@ -4359,6 +5104,55 @@
     "size_class": "small"
   },
   {
+    "id": "dromedary_camel",
+    "common_name": "Dromedary Camel",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hot_desert",
+      "semi_arid_scrublands"
+    ],
+    "diet": [
+      "herbivore",
+      "browser"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat",
+        "milk"
+      ],
+      "preparation_notes": "Cook thoroughly; milk soured or boiled."
+    },
+    "byproducts": [
+      {
+        "type": "milk",
+        "harvest_method": "domesticated",
+        "yield_unit": "L",
+        "avg_yield": 5
+      },
+      {
+        "type": "hide",
+        "harvest_method": "domesticated"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the hot desert and semi arid scrublands stretch far and wide, there dwells the Dromedary Camel, a mammal of note. It keeps to a herbivore and browser fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat and milk, ever mindful it must be cooked thoroughly; milk soured or boiled. From its form are drawn milk and hide, which merchants and craftsmen prize. Thus does the Dromedary Camel move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Dromedary"
+    ]
+  },
+  {
     "id": "duck",
     "common_name": "Duck",
     "taxon_group": "bird",
@@ -4838,6 +5632,37 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Electric ray, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Electric ray move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "elegant_temple_cat",
+    "common_name": "Elegant Temple Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Elegant Temple Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Elegant Temple Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Siamese"
+    ]
   },
   {
     "id": "elephant",
@@ -5549,6 +6374,38 @@
     "narrative": "In the aquatic realms, where the ocean shores stretch far and wide, there dwells the Flounder, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Flounder move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "fluffy_spitz_dog",
+    "common_name": "Fluffy Spitz Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Fluffy Spitz Dog, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Fluffy Spitz Dog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Pomeranian"
+    ]
+  },
+  {
     "id": "flying-squirrel",
     "common_name": "Flying squirrel",
     "taxon_group": "other",
@@ -5579,6 +6436,37 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Flying squirrel, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Flying squirrel move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "folded_ear_cat",
+    "common_name": "Folded Ear Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Folded Ear Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Folded Ear Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Scottish Fold"
+    ]
   },
   {
     "id": "fox",
@@ -5966,6 +6854,37 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Genet, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Genet move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "gentle_ragdoll_cat",
+    "common_name": "Gentle Ragdoll Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Gentle Ragdoll Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Gentle Ragdoll Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Ragdoll"
+    ]
+  },
+  {
     "id": "gerenuk",
     "common_name": "Gerenuk",
     "taxon_group": "other",
@@ -6028,6 +6947,38 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Gharial, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Gharial move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "giant_guardian_dog",
+    "common_name": "Giant Guardian Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Giant Guardian Dog, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Giant Guardian Dog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Great Dane"
+    ]
   },
   {
     "id": "giant-anteater",
@@ -6158,6 +7109,39 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Gila monster, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Gila monster move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "giraffe",
+    "common_name": "Giraffe",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "savanna"
+    ],
+    "diet": [
+      "herbivore",
+      "browser"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the savanna stretch far and wide, there dwells the Giraffe, a mammal of note. It keeps to a herbivore and browser fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Giraffe move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "goat",
     "common_name": "Goat",
     "taxon_group": "mammal",
@@ -6277,6 +7261,35 @@
       "desert moths"
     ],
     "size_class": "tiny"
+  },
+  {
+    "id": "golden_retriever",
+    "common_name": "Golden Retriever",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Golden Retriever, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Golden Retriever move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "golden-jackal",
@@ -6502,6 +7515,68 @@
     "narrative": "In the aquatic realms, where the ocean shores stretch far and wide, there dwells the Goose barnacle, a crustacean of note. It keeps to a detritivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Goose barnacle move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "gopher",
+    "common_name": "Gopher",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland",
+      "farmland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the grassland and farmland stretch far and wide, there dwells the Gopher, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Gopher move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "gorilla",
+    "common_name": "Gorilla",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "herbivore",
+      "browser"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Gorilla, a mammal of note. It keeps to a herbivore and browser fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Gorilla move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "goshawk",
     "common_name": "Goshawk",
     "taxon_group": "bird",
@@ -6564,6 +7639,37 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Grayling, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Grayling move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "great_ape",
+    "common_name": "Great Ape",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Great Ape, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Great Ape move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Ape"
+    ]
   },
   {
     "id": "great-spotted-woodpecker",
@@ -6666,6 +7772,35 @@
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Grey mullet, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Grey mullet move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "greyhound",
+    "common_name": "Greyhound",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Greyhound, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Greyhound move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "greylag-goose",
     "common_name": "Greylag goose",
     "taxon_group": "bird",
@@ -6696,6 +7831,51 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the marshes stretch far and wide, there dwells the Greylag goose, a bird of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Greylag goose move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "grizzled_bear",
+    "common_name": "Grizzled Bear",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "montane_forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "fat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the forest and montane forest stretch far and wide, there dwells the Grizzled Bear, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide and fat, which merchants and craftsmen prize. Thus does the Grizzled Bear move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Grizzly Bear"
+    ]
   },
   {
     "id": "grouse",
@@ -6762,6 +7942,38 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Guanaco, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Guanaco move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "guardian_pinscher_dog",
+    "common_name": "Guardian Pinscher Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Guardian Pinscher Dog, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Guardian Pinscher Dog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Doberman Pinscher"
+    ]
+  },
+  {
     "id": "gudgeon",
     "common_name": "Gudgeon",
     "taxon_group": "fish",
@@ -6796,6 +8008,39 @@
     ],
     "gendered": {},
     "narrative": "In the aquatic realms, where the rivers stretch far and wide, there dwells the Gudgeon, a fish of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Gudgeon move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "guinea_pig",
+    "common_name": "Guinea Pig",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Guinea Pig, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Guinea Pig move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "guinea-fowl",
@@ -7025,6 +8270,37 @@
     "size_class": "huge"
   },
   {
+    "id": "hairless_sphynx_cat",
+    "common_name": "Hairless Sphynx Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Hairless Sphynx Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Hairless Sphynx Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Sphynx"
+    ]
+  },
+  {
     "id": "hake",
     "common_name": "Hake",
     "taxon_group": "fish",
@@ -7123,6 +8399,34 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Hammerhead shark, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Hammerhead shark move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "hamster",
+    "common_name": "Hamster",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Hamster, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Hamster move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "hare",
@@ -7317,6 +8621,38 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Hedgehog, a mammal of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Hedgehog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "herding_shepherd_dog",
+    "common_name": "Herding Shepherd Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Herding Shepherd Dog, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Herding Shepherd Dog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Australian Shepherd"
+    ]
+  },
+  {
     "id": "heron",
     "common_name": "Heron",
     "taxon_group": "bird",
@@ -7423,6 +8759,42 @@
     "size_class": "medium"
   },
   {
+    "id": "hippopotamus",
+    "common_name": "Hippopotamus",
+    "taxon_group": "mammal",
+    "regions": [
+      "aquatic",
+      "terrestrial"
+    ],
+    "habitats": [
+      "rivers",
+      "lakes",
+      "swamps"
+    ],
+    "diet": [
+      "herbivore",
+      "grazer"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the aquatic and terrestrial realms, where the rivers, lakes and swamps stretch far and wide, there dwells the Hippopotamus, a mammal of note. It keeps to a herbivore and grazer fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Hippopotamus move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "honeybee",
     "common_name": "Honeybee",
     "taxon_group": "insect",
@@ -7519,6 +8891,57 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Hoopoe, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Hoopoe move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "horned_buffalo",
+    "common_name": "Horned Buffalo",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "marshes",
+      "grassland"
+    ],
+    "diet": [
+      "herbivore",
+      "grazer"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat",
+        "milk"
+      ],
+      "preparation_notes": "Cook thoroughly; milk simmered before drinking."
+    },
+    "byproducts": [
+      {
+        "type": "milk",
+        "harvest_method": "domesticated",
+        "yield_unit": "L",
+        "avg_yield": 8
+      },
+      {
+        "type": "hide",
+        "harvest_method": "either",
+        "yield_unit": "kg",
+        "avg_yield": 25
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the marshes and grassland stretch far and wide, there dwells the Horned Buffalo, a mammal of note. It keeps to a herbivore and grazer fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat and milk, ever mindful it must be cooked thoroughly; milk simmered before drinking. From its form are drawn milk and hide, which merchants and craftsmen prize. Thus does the Horned Buffalo move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Buffalo"
+    ]
+  },
+  {
     "id": "horse",
     "common_name": "Horse",
     "taxon_group": "mammal",
@@ -7551,7 +8974,10 @@
     },
     "byproducts": [],
     "gendered": {},
-    "narrative": "In the terrestrial realms, where the farmland stretch far and wide, there dwells the Horse, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Horse move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+    "narrative": "In the terrestrial realms, where the farmland stretch far and wide, there dwells the Horse, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Horse move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Mustang"
+    ]
   },
   {
     "id": "horsefish",
@@ -8123,6 +9549,40 @@
     "size_class": "large"
   },
   {
+    "id": "jackal",
+    "common_name": "Jackal",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "semi_arid_scrublands",
+      "savanna"
+    ],
+    "diet": [
+      "omnivore",
+      "scavenger"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the semi arid scrublands and savanna stretch far and wide, there dwells the Jackal, a mammal of note. It keeps to a omnivore and scavenger fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Jackal move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "jackdaw",
     "common_name": "Jackdaw",
     "taxon_group": "bird",
@@ -8153,6 +9613,38 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Jackdaw, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Jackdaw move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "jaguar",
+    "common_name": "Jaguar",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "tropical_rainforest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the tropical rainforest stretch far and wide, there dwells the Jaguar, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Jaguar move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "javan_rainforest_peacock",
@@ -8728,6 +10220,35 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Kiwi, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Kiwi move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "koala",
+    "common_name": "Koala",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "herbivore",
+      "browser"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Koala, a mammal of note. It keeps to a herbivore and browser fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Koala move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "komandor_fulmar",
@@ -9318,6 +10839,48 @@
     "narrative": "In the terrestrial realms, where the grassland stretch far and wide, there dwells the Lion, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Lion move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "llama",
+    "common_name": "Llama",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland",
+      "alpine_tundra"
+    ],
+    "diet": [
+      "herbivore",
+      "grazer"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "sheep wool",
+        "notes": "Long fibers spun into cloth",
+        "harvest_method": "domesticated",
+        "yield_unit": "kg",
+        "avg_yield": 4
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the grassland and alpine tundra stretch far and wide, there dwells the Llama, a mammal of note. It keeps to a herbivore and grazer fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn sheep wool, which merchants and craftsmen prize. Thus does the Llama move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "loach",
     "common_name": "Loach",
     "taxon_group": "fish",
@@ -9456,6 +11019,70 @@
       "flooded figs"
     ],
     "size_class": "huge"
+  },
+  {
+    "id": "lowland_corgi_dog",
+    "common_name": "Lowland Corgi Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Lowland Corgi Dog, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Lowland Corgi Dog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Pembroke Welsh Corgi"
+    ]
+  },
+  {
+    "id": "lowland_hound_dog",
+    "common_name": "Lowland Hound Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Lowland Hound Dog, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Lowland Hound Dog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Basset Hound"
+    ]
   },
   {
     "id": "lynx",
@@ -9688,6 +11315,34 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Manatee, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Manatee move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "mandrill",
+    "common_name": "Mandrill",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "tropical_rainforest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the tropical rainforest stretch far and wide, there dwells the Mandrill, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Mandrill move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "mangrove_saltwater_crocodile",
     "common_name": "Mangrove Saltwater Crocodile",
     "taxon_group": "reptile",
@@ -9768,6 +11423,34 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Markhor, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Markhor move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "marmoset",
+    "common_name": "Marmoset",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "tropical_rainforest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the tropical rainforest stretch far and wide, there dwells the Marmoset, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Marmoset move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "marmot",
@@ -10192,6 +11875,37 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Moray eel, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Moray eel move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "mosscoat_forest_cat",
+    "common_name": "Mosscoat Forest Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Mosscoat Forest Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Mosscoat Forest Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Norwegian Forest Cat"
+    ]
+  },
+  {
     "id": "mouflon",
     "common_name": "Mouflon",
     "taxon_group": "mammal",
@@ -10226,6 +11940,45 @@
     ],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the hills stretch far and wide, there dwells the Mouflon, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Mouflon move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "mountain_goat",
+    "common_name": "Mountain Goat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "alpine_tundra",
+      "cliffs"
+    ],
+    "diet": [
+      "herbivore",
+      "browser"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the alpine tundra and cliffs stretch far and wide, there dwells the Mountain Goat, a mammal of note. It keeps to a herbivore and browser fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn hide, which merchants and craftsmen prize. Thus does the Mountain Goat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "mouse",
@@ -10431,6 +12184,46 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Muskox, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Muskox move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "muskrat",
+    "common_name": "Muskrat",
+    "taxon_group": "mammal",
+    "regions": [
+      "aquatic",
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "swamps",
+      "marshes"
+    ],
+    "diet": [
+      "herbivore",
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "fur",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the aquatic and wetlands transitional realms, where the swamps and marshes stretch far and wide, there dwells the Muskrat, a mammal of note. It keeps to a herbivore and omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn fur, which merchants and craftsmen prize. Thus does the Muskrat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "mussel",
     "common_name": "Mussel",
     "taxon_group": "mollusk",
@@ -10609,6 +12402,35 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Nautilus, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Nautilus move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "newt",
+    "common_name": "Newt",
+    "taxon_group": "amphibian",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "swamps",
+      "streams"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the swamps and streams stretch far and wide, there dwells the Newt, a amphibian of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Newt move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "nightingale",
     "common_name": "Nightingale",
     "taxon_group": "bird",
@@ -10718,6 +12540,38 @@
     "size_class": "large"
   },
   {
+    "id": "northern_husky_dog",
+    "common_name": "Northern Husky Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Northern Husky Dog, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Northern Husky Dog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Siberian Husky"
+    ]
+  },
+  {
     "id": "numbat",
     "common_name": "Numbat",
     "taxon_group": "other",
@@ -10791,6 +12645,38 @@
       "lotus leaves"
     ],
     "size_class": "large"
+  },
+  {
+    "id": "ocelot",
+    "common_name": "Ocelot",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "tropical_rainforest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the tropical rainforest stretch far and wide, there dwells the Ocelot, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Ocelot move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "octopus",
@@ -11110,6 +12996,40 @@
     "size_class": "huge"
   },
   {
+    "id": "oryx",
+    "common_name": "Oryx",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hot_desert",
+      "semi_arid_scrublands"
+    ],
+    "diet": [
+      "herbivore",
+      "grazer"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the hot desert and semi arid scrublands stretch far and wide, there dwells the Oryx, a mammal of note. It keeps to a herbivore and grazer fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Oryx move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "osprey",
     "common_name": "Osprey",
     "taxon_group": "bird",
@@ -11238,6 +13158,36 @@
     "narrative": "In the aquatic realms, where the ocean shores stretch far and wide, there dwells the Oyster, a mollusk of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Oyster move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "panda",
+    "common_name": "Panda",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "temperate_rainforest",
+      "montane_forest"
+    ],
+    "diet": [
+      "herbivore",
+      "browser"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the temperate rainforest and montane forest stretch far and wide, there dwells the Panda, a mammal of note. It keeps to a herbivore and browser fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Panda move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "pangolin",
     "common_name": "Pangolin",
     "taxon_group": "other",
@@ -11268,6 +13218,69 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Pangolin, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Pangolin move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "parakeet",
+    "common_name": "Parakeet",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and forest stretch far and wide, there dwells the Parakeet, a bird of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Parakeet move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Parakeet"
+    ]
+  },
+  {
+    "id": "parrot",
+    "common_name": "Parrot",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Parrot, a bird of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Parrot move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Parrot"
+    ]
   },
   {
     "id": "partridge",
@@ -11762,7 +13775,8 @@
     "narrative": "In the terrestrial realms, where the farmland and forest stretch far and wide, there dwells the Domestic Pig, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat and fat, ever mindful it must be cooked thoroughly to prevent trichinosis. From its form are drawn meat, fat and hide, which merchants and craftsmen prize. Thus does the Domestic Pig move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
     "alt_names": [
       "Hog",
-      "Swine"
+      "Swine",
+      "Pig"
     ],
     "food_sources": [
       "acorns",
@@ -11954,6 +13968,44 @@
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Plaice, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Plaice move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "plains_gnu",
+    "common_name": "Plains Gnu",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "savanna",
+      "grassland"
+    ],
+    "diet": [
+      "herbivore",
+      "grazer"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the savanna and grassland stretch far and wide, there dwells the Plains Gnu, a mammal of note. It keeps to a herbivore and grazer fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Plains Gnu move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Gnu",
+      "Wildebeest"
+    ]
+  },
+  {
     "id": "platypus",
     "common_name": "Platypus",
     "taxon_group": "other",
@@ -11984,6 +14036,81 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Platypus, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Platypus move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "plush_shorthair_cat",
+    "common_name": "Plush Shorthair Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Plush Shorthair Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Plush Shorthair Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "British Shorthair"
+    ]
+  },
+  {
+    "id": "polar_bear",
+    "common_name": "Polar Bear",
+    "taxon_group": "mammal",
+    "regions": [
+      "polar_ice",
+      "coastal"
+    ],
+    "habitats": [
+      "pack_ice",
+      "ice_shelves"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat",
+        "fat"
+      ],
+      "preparation_notes": "Cook thoroughly; liver avoided for toxicity."
+    },
+    "byproducts": [
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "fat",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the polar ice and coastal realms, where the pack ice and ice shelves stretch far and wide, there dwells the Polar Bear, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat and fat, ever mindful it must be cooked thoroughly; liver avoided for toxicity. From its form are drawn hide and fat, which merchants and craftsmen prize. Thus does the Polar Bear move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "polecat",
@@ -12054,6 +14181,35 @@
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Pollock, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Pollock move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "poodle",
+    "common_name": "Poodle",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Poodle, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Poodle move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "porcupine",
     "common_name": "Porcupine",
     "taxon_group": "mammal",
@@ -12084,6 +14240,72 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Porcupine, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Porcupine move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "porpoise",
+    "common_name": "Porpoise",
+    "taxon_group": "mammal",
+    "regions": [
+      "aquatic"
+    ],
+    "habitats": [
+      "open_ocean",
+      "ocean_shores"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the aquatic realms, where the open ocean and ocean shores stretch far and wide, there dwells the Porpoise, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Porpoise move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "prairie_dog",
+    "common_name": "Prairie Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "prairie",
+      "grassland"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the prairie and grassland stretch far and wide, there dwells the Prairie Dog, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Prairie Dog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "ptarmigan",
@@ -12747,6 +14969,49 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Rhea, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Rhea move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "rhinoceros",
+    "common_name": "Rhinoceros",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "savanna",
+      "grassland"
+    ],
+    "diet": [
+      "herbivore",
+      "grazer"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "horn",
+        "harvest_method": "wild"
+      },
+      {
+        "type": "hide",
+        "harvest_method": "wild"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the savanna and grassland stretch far and wide, there dwells the Rhinoceros, a mammal of note. It keeps to a herbivore and grazer fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn horn and hide, which merchants and craftsmen prize. Thus does the Rhinoceros move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "roach",
     "common_name": "Roach",
     "taxon_group": "fish",
@@ -12813,6 +15078,35 @@
     ],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Roe deer, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Roe deer move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "rottweiler",
+    "common_name": "Rottweiler",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Rottweiler, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Rottweiler move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "ruaha_squeaker_catfish",
@@ -12925,6 +15219,37 @@
     "size_class": "large"
   },
   {
+    "id": "sable_temple_cat",
+    "common_name": "Sable Temple Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Sable Temple Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Sable Temple Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Burmese"
+    ]
+  },
+  {
     "id": "sahara_addax_caravan",
     "common_name": "Sahara Addax Caravan",
     "taxon_group": "mammal",
@@ -13031,6 +15356,35 @@
     "narrative": "In the terrestrial realms, where the grassland stretch far and wide, there dwells the Saiga antelope, a mammal of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Saiga antelope move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "salamander",
+    "common_name": "Salamander",
+    "taxon_group": "amphibian",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "streams",
+      "swamps"
+    ],
+    "diet": [
+      "insectivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the wetlands transitional realms, where the streams and swamps stretch far and wide, there dwells the Salamander, a amphibian of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Salamander move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
     "id": "salmon",
     "common_name": "Salmon",
     "taxon_group": "fish",
@@ -13125,6 +15479,41 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Sardine, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Sardine move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "scaled_reptile",
+    "common_name": "Scaled Reptile",
+    "taxon_group": "reptile",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Scaled Reptile, a reptile of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Scaled Reptile move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Reptile"
+    ]
   },
   {
     "id": "scallop",
@@ -13347,6 +15736,42 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Secretarybird, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Secretarybird move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "shadow_panther",
+    "common_name": "Shadow Panther",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "tropical_rainforest",
+      "forest"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "high"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the tropical rainforest and forest stretch far and wide, there dwells the Shadow Panther, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Shadow Panther move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Panther"
+    ]
+  },
+  {
     "id": "sheep",
     "common_name": "Domestic Sheep",
     "taxon_group": "mammal",
@@ -13414,7 +15839,12 @@
       "collective": "flock"
     },
     "narrative": "In the terrestrial realms, where the farmland, grassland and hills stretch far and wide, there dwells the Domestic Sheep, a mammal of note. It keeps to a herbivore and grazer fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat and milk, ever mindful it must be lamb roasted or stewed. From its form are drawn sheep wool, milk and meat, which merchants and craftsmen prize. Thus does the Domestic Sheep move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
-    "alt_names": [],
+    "alt_names": [
+      "Sheep",
+      "Ewe",
+      "Lamb",
+      "Ram"
+    ],
     "food_sources": [
       "pasture grasses",
       "hay",
@@ -13435,6 +15865,35 @@
       "wool_shearing_cycle": "yearly"
     },
     "butchering_age": "1 year"
+  },
+  {
+    "id": "shih_tzu",
+    "common_name": "Shih Tzu",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Shih Tzu, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Shih Tzu move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "shoebill",
@@ -13565,6 +16024,37 @@
     "narrative": "In the aquatic realms, where the ocean shores stretch far and wide, there dwells the Shrimp, a crustacean of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Shrimp move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "silken_palace_cat",
+    "common_name": "Silken Palace Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Silken Palace Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Silken Palace Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Persian (Modern)"
+    ]
+  },
+  {
     "id": "silkworm",
     "common_name": "Silkworm",
     "taxon_group": "insect",
@@ -13591,6 +16081,44 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the farmland stretch far and wide, there dwells the Silkworm, a insect of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Silkworm move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "silver_fox",
+    "common_name": "Silver Fox",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "boreal_forest",
+      "arctic_tundra"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [
+      {
+        "type": "fur",
+        "harvest_method": "either"
+      }
+    ],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the boreal forest and arctic tundra stretch far and wide, there dwells the Silver Fox, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn fur, which merchants and craftsmen prize. Thus does the Silver Fox move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "skua",
@@ -13623,6 +16151,66 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Skua, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Skua move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "skunk",
+    "common_name": "Skunk",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "grassland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the forest and grassland stretch far and wide, there dwells the Skunk, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Skunk move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "slate_blue_cat",
+    "common_name": "Slate Blue Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Slate Blue Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Slate Blue Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Russian Blue"
+    ]
   },
   {
     "id": "sloth",
@@ -13819,6 +16407,38 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the aquatic realms, where the ocean shores stretch far and wide, there dwells the Sole, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Sole move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "song_canary",
+    "common_name": "Song Canary",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "forest"
+    ],
+    "diet": [
+      "herbivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "none"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and forest stretch far and wide, there dwells the Song Canary, a bird of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a none hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Song Canary move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Canary"
+    ]
   },
   {
     "id": "song-thrush",
@@ -14023,6 +16643,68 @@
     ],
     "gendered": {},
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Spiny dogfish, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Spiny dogfish move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "spotted_jungle_cat",
+    "common_name": "Spotted Jungle Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Spotted Jungle Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Spotted Jungle Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Bengal"
+    ]
+  },
+  {
+    "id": "spotted_temple_cat",
+    "common_name": "Spotted Temple Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Spotted Temple Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Spotted Temple Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Egyptian Mau"
+    ]
   },
   {
     "id": "sprat",
@@ -14413,6 +17095,38 @@
     "narrative": "In the terrestrial realms, where the lakes stretch far and wide, there dwells the Swan, a bird of note. It keeps to a herbivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Swan move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "talking_mynah_bird",
+    "common_name": "Talking Mynah Bird",
+    "taxon_group": "bird",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "forest"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and forest stretch far and wide, there dwells the Talking Mynah Bird, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Talking Mynah Bird move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Mynah Bird"
+    ]
+  },
+  {
     "id": "tapir",
     "common_name": "Tapir",
     "taxon_group": "other",
@@ -14646,6 +17360,37 @@
     "narrative": "In the aquatic realms, where the open ocean stretch far and wide, there dwells the Thornback ray, a fish of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Thornback ray move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "ticked_companion_cat",
+    "common_name": "Ticked Companion Cat",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "diet": [
+      "carnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban stretch far and wide, there dwells the Ticked Companion Cat, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Ticked Companion Cat move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Abyssinian"
+    ]
+  },
+  {
     "id": "tierra_del_fuego_penguin_fold",
     "common_name": "Tierra del Fuego Penguin Fold",
     "taxon_group": "bird",
@@ -14720,6 +17465,38 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Tiger, a mammal of note. It keeps to a carnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is given to fury when roused, staunch in guarding its bounds, and offers a high hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Tiger move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "tiny_companion_dog",
+    "common_name": "Tiny Companion Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Tiny Companion Dog, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is given to fury when roused, staunch in guarding its bounds, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Tiny Companion Dog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Chihuahua"
+    ]
   },
   {
     "id": "toad",
@@ -14930,6 +17707,41 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Turkey, a bird of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Turkey move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "turtle",
+    "common_name": "Turtle",
+    "taxon_group": "reptile",
+    "regions": [
+      "aquatic",
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "rivers",
+      "lakes",
+      "swamps"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the aquatic and wetlands transitional realms, where the rivers, lakes and swamps stretch far and wide, there dwells the Turtle, a reptile of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Turtle move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "turtle-dove",
@@ -15305,6 +18117,38 @@
     "byproducts": [],
     "gendered": {},
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Warthog, a other of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Warthog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
+  },
+  {
+    "id": "water_retriever_dog",
+    "common_name": "Water Retriever Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "low"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Water Retriever Dog, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is mild of temper, wandering free of sworn domain, and offers a low hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Water Retriever Dog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "Labrador Retriever"
+    ]
   },
   {
     "id": "weasel",
@@ -15831,6 +18675,38 @@
     "narrative": "In the terrestrial realms, where the forest stretch far and wide, there dwells the Woodcock, a bird of note. It keeps to a insectivore fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. From its form are drawn meat, which merchants and craftsmen prize. Thus does the Woodcock move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
+    "id": "working_shepherd_dog",
+    "common_name": "Working Shepherd Dog",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "farmland"
+    ],
+    "diet": [
+      "omnivore"
+    ],
+    "domestication": {
+      "domesticated": true
+    },
+    "behavior": {
+      "aggressive": true,
+      "territorial": true,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": false
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the urban and farmland stretch far and wide, there dwells the Working Shepherd Dog, a mammal of note. It keeps to a omnivore fare, taking sustenance as the wilds afford. Long has it abided beside the hearths of humankind, knowing the touch of halter and hand. It is given to fury when roused, staunch in guarding its bounds, and offers a moderate hazard to the heedless. Its flesh is shunned at feast and fire, deemed unfit for mortal taste. No craftsman covets its remains, save in times of need. Thus does the Working Shepherd Dog move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it.",
+    "alt_names": [
+      "German Shepherd"
+    ]
+  },
+  {
     "id": "wren",
     "common_name": "Wren",
     "taxon_group": "bird",
@@ -16156,6 +19032,40 @@
       "wild herbs"
     ],
     "size_class": "medium"
+  },
+  {
+    "id": "zebra",
+    "common_name": "Zebra",
+    "taxon_group": "mammal",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "savanna",
+      "grassland"
+    ],
+    "diet": [
+      "herbivore",
+      "grazer"
+    ],
+    "domestication": {
+      "domesticated": false
+    },
+    "behavior": {
+      "aggressive": false,
+      "territorial": false,
+      "risk_to_humans": "moderate"
+    },
+    "edibility": {
+      "edible": true,
+      "parts": [
+        "meat"
+      ],
+      "preparation_notes": "Cook thoroughly."
+    },
+    "byproducts": [],
+    "gendered": {},
+    "narrative": "In the terrestrial realms, where the savanna and grassland stretch far and wide, there dwells the Zebra, a mammal of note. It keeps to a herbivore and grazer fare, taking sustenance as the wilds afford. No yoke nor leash has tamed it, for it prospers without the aid of men. It is mild of temper, wandering free of sworn domain, and offers a moderate hazard to the heedless. Those who seek its tablefare take the meat, ever mindful it must be cooked thoroughly. No craftsman covets its remains, save in times of need. Thus does the Zebra move through legend and living world alike, keeping the balance of nature and stirring wonder in those who behold it."
   },
   {
     "id": "zebu",

--- a/data/plants.json
+++ b/data/plants.json
@@ -291,6 +291,22 @@
     ]
   },
   {
+    "id": "amy_root",
+    "common_name": "Amy Root",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Amy Root, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Amy Root marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true
+  },
+  {
     "id": "angelica",
     "common_name": "Angelica",
     "growth_form": "herb",
@@ -334,6 +350,26 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Anise, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Anise marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "annual_sow_thistle",
+    "common_name": "Annual Sow Thistle",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "grassland"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where the farmland and grassland hold sway, stands the Annual Sow Thistle, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Annual Sow Thistle marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "foraging_notes": "Tender leaves gathered young for cooking."
   },
   {
     "id": "appalachian_spicebush",
@@ -413,7 +449,7 @@
       }
     ],
     "seasonality": "Deciduous; flowers in spring, fruit ripens in autumn",
-    "narrative": "In the terrestrial realms, where the farmland and forest hold sway, stands the Apple Tree, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. From its body folk derive wood and leaf, a boon to trade and craft. Thus the Apple Tree marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "narrative": "In the terrestrial realms, where the farmland and forest hold sway, stands the Apple Tree, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Apple, names born of custom and need. From its body folk derive wood and leaf, a boon to trade and craft. Thus the Apple Tree marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
     "tiers": {
       "food_tier": [
         "common",
@@ -422,7 +458,9 @@
       ],
       "luxury_tier": []
     },
-    "alt_names": [],
+    "alt_names": [
+      "Apple"
+    ],
     "toxicity_notes": "Seeds contain cyanogenic glycosides; avoid large quantities",
     "foraging_notes": "Grafted varieties persist in abandoned orchards",
     "sowing_season": "spring",
@@ -532,6 +570,22 @@
     ]
   },
   {
+    "id": "arfaj",
+    "common_name": "Arfaj",
+    "growth_form": "shrub",
+    "regions": [
+      "arid"
+    ],
+    "habitats": [
+      "desert"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the arid realms, where desert holds sway, stands the Arfaj, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Arfaj marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true
+  },
+  {
     "id": "arrowhead",
     "common_name": "Arrowhead",
     "growth_form": "herb",
@@ -560,6 +614,28 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Arrowroot, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Arrowroot marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "arrowwood_shrub",
+    "common_name": "Arrowwood Shrub",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Arrowwood Shrub, a shrub of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Arrowwood, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Arrowwood Shrub marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Arrowwood"
+    ],
+    "edible_parts": [
+      "fruit"
+    ],
+    "medicinal": true
   },
   {
     "id": "artemisia",
@@ -704,6 +780,35 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Azalea, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Azalea marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "azolla_fern",
+    "common_name": "Azolla Fern",
+    "growth_form": "algae",
+    "regions": [
+      "aquatic_fresh"
+    ],
+    "habitats": [
+      "wetland",
+      "lake"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "algae",
+        "harvest_season": "summer"
+      }
+    ],
+    "narrative": "In the aquatic fresh realms, where the wetland and lake hold sway, stands the Azolla Fern, a algae of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Azolla and Carolina Azolla, names born of custom and need. From its body folk derive algae, a boon to trade and craft. Thus the Azolla Fern marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Azolla",
+      "Carolina Azolla"
+    ],
+    "edible_parts": [
+      "leaf"
+    ],
+    "medicinal": false
+  },
+  {
     "id": "badia_desert_hyssop",
     "common_name": "Badia Desert Hyssop",
     "growth_form": "herb",
@@ -827,6 +932,51 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Bamboo, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Bamboo marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "banana_plant",
+    "common_name": "Banana Plant",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fiber",
+        "harvest_season": "year-round"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the farmland and forest hold sway, stands the Banana Plant, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Banana, names born of custom and need. From its body folk derive fiber, a boon to trade and craft. Thus the Banana Plant marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Banana"
+    ],
+    "edible_parts": [
+      "fruit"
+    ]
+  },
+  {
+    "id": "bank_cress",
+    "common_name": "Bank Cress",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "riverlands"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where riverlands holds sway, stands the Bank Cress, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Bank Cress marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ]
   },
   {
     "id": "baobab",
@@ -977,6 +1127,42 @@
     ]
   },
   {
+    "id": "bay_laurel",
+    "common_name": "Bay Laurel",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf",
+        "harvest_season": "year-round"
+      },
+      {
+        "type": "spice",
+        "harvest_season": "year-round"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the farmland and forest hold sway, stands the Bay Laurel, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Bay, names born of custom and need. From its body folk derive leaf and spice, a boon to trade and craft. Thus the Bay Laurel marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Bay"
+    ],
+    "edible_parts": [
+      "leaf"
+    ],
+    "medicinal": true,
+    "culinary_uses": [
+      "soups",
+      "stews"
+    ]
+  },
+  {
     "id": "bay-laurel",
     "common_name": "Bay laurel",
     "growth_form": "tree",
@@ -1019,6 +1205,46 @@
     "alt_names": [
       "Cardinal Flower"
     ]
+  },
+  {
+    "id": "bear_corn",
+    "common_name": "Bear Corn",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "medicine"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Bear Corn, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive medicine, a boon to trade and craft. Thus the Bear Corn marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true
+  },
+  {
+    "id": "bearberry",
+    "common_name": "Bearberry",
+    "growth_form": "shrub",
+    "regions": [
+      "cold"
+    ],
+    "habitats": [
+      "tundra",
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the cold realms, where the tundra and forest hold sway, stands the Bearberry, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its fruit sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Bearberry marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "medicinal": true
   },
   {
     "id": "beech",
@@ -1079,6 +1305,24 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Belladonna, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Belladonna marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "belle_isle_cress",
+    "common_name": "Belle Isle Cress",
+    "growth_form": "herb",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the wetlands transitional realms, where wetland holds sway, stands the Belle Isle Cress, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Belle Isle Cress marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ]
   },
   {
     "id": "bergamot",
@@ -1218,6 +1462,24 @@
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Birch polypore, a mushroom of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive mushroom, a boon to trade and craft. Thus the Birch polypore marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "bird_s_nest_fern",
+    "common_name": "Bird's Nest Fern",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Bird's Nest Fern, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Bird's Nest, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Bird's Nest Fern marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Bird's Nest"
+    ]
+  },
+  {
     "id": "bird-cherry",
     "common_name": "Bird cherry",
     "growth_form": "tree",
@@ -1231,6 +1493,25 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Bird cherry, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Bird cherry marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "bitter_nightshade",
+    "common_name": "Bitter Nightshade",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "hills"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where the forest and hills hold sway, stands the Bitter Nightshade, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Bitter Nightshade marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true,
+    "toxic": true,
+    "toxicity_notes": "Unripe berries and leaves are poisonous."
   },
   {
     "id": "bitter-orange",
@@ -1263,6 +1544,149 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Bitter vetch, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Bitter vetch marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "bittercress",
+    "common_name": "Bittercress",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where wetland holds sway, stands the Bittercress, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Bittercress marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "foraging_notes": "Used fresh for peppery greens."
+  },
+  {
+    "id": "bitterweed",
+    "common_name": "Bitterweed",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where grassland holds sway, stands the Bitterweed, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Bitterweed marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "toxic": true,
+    "toxicity_notes": "Causes off-flavors in milk if grazed."
+  },
+  {
+    "id": "black_alder",
+    "common_name": "Black Alder",
+    "growth_form": "tree",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland",
+      "riverlands"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the wetlands transitional realms, where the wetland and riverlands hold sway, stands the Black Alder, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive wood, a boon to trade and craft. Thus the Black Alder marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true
+  },
+  {
+    "id": "black_ash",
+    "common_name": "Black Ash",
+    "growth_form": "tree",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the wetlands transitional realms, where wetland holds sway, stands the Black Ash, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive wood, a boon to trade and craft. Thus the Black Ash marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "black_birch",
+    "common_name": "Black Birch",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "hills"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the forest and hills hold sway, stands the Black Birch, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its sap sustain the hungry when prepared with care. From its body folk derive wood, a boon to trade and craft. Thus the Black Birch marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "sap"
+    ],
+    "culinary_uses": [
+      "syrups"
+    ]
+  },
+  {
+    "id": "black_cherry",
+    "common_name": "Black Cherry",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Black Cherry, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its fruit sustain the hungry when prepared with care. From its body folk derive wood, a boon to trade and craft. Thus the Black Cherry marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ]
+  },
+  {
+    "id": "black_eyed_susan",
+    "common_name": "Black-eyed Susan",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where grassland holds sway, stands the Black-eyed Susan, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Black-eyed Susan marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
     "id": "black_forest_morel_patch",
     "common_name": "Black Forest Morel Patch",
     "growth_form": "mushroom",
@@ -1293,6 +1717,73 @@
     "seasonality": "spring",
     "harvest_season": "spring",
     "growth_duration": "short flush"
+  },
+  {
+    "id": "black_hellebore",
+    "common_name": "Black Hellebore",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "hills"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where the forest and hills hold sway, stands the Black Hellebore, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Black Hellebore marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true,
+    "toxic": true,
+    "toxicity_notes": "Roots used sparingly in old remedies."
+  },
+  {
+    "id": "black_maple",
+    "common_name": "Black Maple",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Black Maple, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its sap sustain the hungry when prepared with care. From its body folk derive wood, a boon to trade and craft. Thus the Black Maple marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "sap"
+    ],
+    "culinary_uses": [
+      "syrup"
+    ]
+  },
+  {
+    "id": "black_nightshade",
+    "common_name": "Black Nightshade",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "urban"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where the farmland and urban hold sway, stands the Black Nightshade, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its fruit sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Black Nightshade marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ],
+    "medicinal": true,
+    "toxic": true,
+    "toxicity_notes": "Only fully ripe berries are safe to eat."
   },
   {
     "id": "black-pepper",
@@ -1340,6 +1831,72 @@
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Blackberry, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Blackberry marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "blackcap_raspberry",
+    "common_name": "Blackcap Raspberry",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "fruit",
+        "harvest_season": "summer"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the forest and farmland hold sway, stands the Blackcap Raspberry, a shrub of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Black Cap and Black Raspberry, names born of custom and need. From its body folk derive fruit, a boon to trade and craft. Thus the Blackcap Raspberry marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Black Cap",
+      "Black Raspberry"
+    ],
+    "edible_parts": [
+      "fruit"
+    ]
+  },
+  {
+    "id": "blackhaw",
+    "common_name": "Blackhaw",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "hills"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where the forest and hills hold sway, stands the Blackhaw, a shrub of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. Among diverse tongues it is hailed as Blackhaw Viburnum, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Blackhaw marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Blackhaw Viburnum"
+    ],
+    "edible_parts": [
+      "fruit"
+    ],
+    "medicinal": true
+  },
+  {
+    "id": "blackiehead",
+    "common_name": "Blackiehead",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where grassland holds sway, stands the Blackiehead, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Blackiehead marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
     "id": "blackthorn-sloe",
     "common_name": "Blackthorn (sloe)",
     "growth_form": "tree",
@@ -1359,6 +1916,24 @@
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Blackthorn (sloe), a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. From its body folk derive fruit, a boon to trade and craft. Thus the Blackthorn (sloe) marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "blackweed",
+    "common_name": "Blackweed",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Blackweed, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Black-weed, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Blackweed marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Black-weed"
+    ]
+  },
+  {
     "id": "bladderwrack",
     "common_name": "Bladderwrack",
     "growth_form": "seaweed",
@@ -1374,6 +1949,83 @@
     "narrative": "In the aquatic salt realms, where coastal holds sway, stands the Bladderwrack, a seaweed of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Bladderwrack marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "blue_ash",
+    "common_name": "Blue Ash",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Blue Ash, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive wood, a boon to trade and craft. Thus the Blue Ash marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "blue_bindweed",
+    "common_name": "Blue Bindweed",
+    "growth_form": "vine",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Blue Bindweed, a vine of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Blue Bindweed marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "blue_oak",
+    "common_name": "Blue Oak",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hills",
+      "grassland"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the hills and grassland hold sway, stands the Blue Oak, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its nut sustain the hungry when prepared with care. From its body folk derive wood, a boon to trade and craft. Thus the Blue Oak marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "nut"
+    ]
+  },
+  {
+    "id": "blue_of_the_heavens",
+    "common_name": "Blue of the Heavens",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where grassland holds sway, stands the Blue of the Heavens, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Blue-of-the-heavens, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Blue of the Heavens marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Blue-of-the-heavens"
+    ]
+  },
+  {
     "id": "blueberry",
     "common_name": "Blueberry",
     "growth_form": "shrub",
@@ -1387,6 +2039,68 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Blueberry, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Blueberry marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "blueberry_cornel",
+    "common_name": "Blueberry Cornel",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Blueberry Cornel, a shrub of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Blueberry Cornel marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ]
+  },
+  {
+    "id": "bluntleaf_milkweed",
+    "common_name": "Bluntleaf Milkweed",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland",
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where the grassland and wetland hold sway, stands the Bluntleaf Milkweed, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Blunt-leaved Milkweed, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Bluntleaf Milkweed marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Blunt-leaved Milkweed"
+    ],
+    "medicinal": true,
+    "toxic": true,
+    "toxicity_notes": "Milky sap is irritating without careful preparation."
+  },
+  {
+    "id": "bolean_birch",
+    "common_name": "Bolean Birch",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "hills"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the forest and hills hold sway, stands the Bolean Birch, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive wood, a boon to trade and craft. Thus the Bolean Birch marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true
   },
   {
     "id": "borage",
@@ -1446,6 +2160,82 @@
     ]
   },
   {
+    "id": "boston_sword_fern",
+    "common_name": "Boston Sword Fern",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "urban",
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where the urban and forest hold sway, stands the Boston Sword Fern, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Boston Fern, Sword Fern and Boston Fern or Sword Fern, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Boston Sword Fern marks the turning of the seasons and gives haven to small beasts within its shade.",
+    "alt_names": [
+      "Boston Fern",
+      "Sword Fern",
+      "Boston Fern or Sword Fern"
+    ]
+  },
+  {
+    "id": "bow_wood",
+    "common_name": "Bow Wood",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland",
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the grassland and forest hold sway, stands the Bow Wood, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Bow-wood, names born of custom and need. From its body folk derive wood, a boon to trade and craft. Thus the Bow Wood marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Bow-wood"
+    ]
+  },
+  {
+    "id": "boxelder_maple",
+    "common_name": "Boxelder Maple",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "riverlands",
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the riverlands and farmland hold sway, stands the Boxelder Maple, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its sap sustain the hungry when prepared with care. Among diverse tongues it is hailed as Ash-leaved Maple and Boxelder, names born of custom and need. From its body folk derive wood, a boon to trade and craft. Thus the Boxelder Maple marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Ash-leaved Maple",
+      "Boxelder"
+    ],
+    "edible_parts": [
+      "sap"
+    ],
+    "culinary_uses": [
+      "syrup"
+    ]
+  },
+  {
     "id": "boxwood",
     "common_name": "Boxwood",
     "growth_form": "shrub",
@@ -1458,7 +2248,10 @@
     "cultivated": false,
     "edible": true,
     "byproducts": [],
-    "narrative": "In the terrestrial realms, where forest holds sway, stands the Boxwood, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Boxwood marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Boxwood, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. Among diverse tongues it is hailed as Box, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Boxwood marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Box"
+    ]
   },
   {
     "id": "bracken-fern",
@@ -1474,6 +2267,79 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Bracken fern, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Bracken fern marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "brilliant_coneflower",
+    "common_name": "Brilliant Coneflower",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where grassland holds sway, stands the Brilliant Coneflower, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Brilliant Coneflower marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "bristly_dewberry",
+    "common_name": "Bristly Dewberry",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "grassland"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where the forest and grassland hold sway, stands the Bristly Dewberry, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its fruit sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Bristly Dewberry marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ]
+  },
+  {
+    "id": "bristly_groundberry",
+    "common_name": "Bristly Groundberry",
+    "growth_form": "shrub",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Bristly Groundberry, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its fruit sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Bristly Groundberry marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ]
+  },
+  {
+    "id": "brittlebush",
+    "common_name": "Brittlebush",
+    "growth_form": "shrub",
+    "regions": [
+      "arid"
+    ],
+    "habitats": [
+      "desert"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "resin",
+        "harvest_season": "dry season"
+      }
+    ],
+    "narrative": "In the arid realms, where desert holds sway, stands the Brittlebush, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive resin, a boon to trade and craft. Thus the Brittlebush marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true
   },
   {
     "id": "broad-beans",
@@ -1517,6 +2383,44 @@
     ]
   },
   {
+    "id": "broadleaf_herb",
+    "common_name": "Broadleaf Herb",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Broadleaf Herb, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Broadleaf, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Broadleaf Herb marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Broadleaf"
+    ]
+  },
+  {
+    "id": "broadleaf_plantain",
+    "common_name": "Broadleaf Plantain",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "urban"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where the farmland and urban hold sway, stands the Broadleaf Plantain, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Broadleaf Plantain marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ],
+    "medicinal": true
+  },
+  {
     "id": "broom-scotch-broom",
     "common_name": "Broom (scotch broom)",
     "growth_form": "shrub",
@@ -1534,6 +2438,51 @@
       }
     ],
     "narrative": "In the terrestrial realms, where hills holds sway, stands the Broom (scotch broom), a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive herb, a boon to trade and craft. Thus the Broom (scotch broom) marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "brown_betty",
+    "common_name": "Brown Betty",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where grassland holds sway, stands the Brown Betty, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Brown Betty marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "brown_daisy",
+    "common_name": "Brown Daisy",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where grassland holds sway, stands the Brown Daisy, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Brown Daisy marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "brown_eyed_susan",
+    "common_name": "Brown-eyed Susan",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where grassland holds sway, stands the Brown-eyed Susan, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Brown-eyed Susan marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
     "id": "buckthorn",
@@ -1566,6 +2515,57 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Buckwheat, a grass of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Buckwheat marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "buffalo_weed",
+    "common_name": "Buffalo Weed",
+    "growth_form": "herb",
+    "regions": [
+      "arid"
+    ],
+    "habitats": [
+      "desert",
+      "grassland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the arid realms, where the desert and grassland hold sway, stands the Buffalo Weed, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Buffalo Weed marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "bulbous_cress",
+    "common_name": "Bulbous Cress",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Bulbous Cress, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Bulbous Cress marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "leaf"
+    ]
+  },
+  {
+    "id": "bull_nettle",
+    "common_name": "Bull Nettle",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where grassland holds sway, stands the Bull Nettle, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Bull Nettle marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "toxic": true,
+    "toxicity_notes": "Stinging hairs cause welts on contact."
+  },
+  {
     "id": "bullace-plum",
     "common_name": "Bullace plum",
     "growth_form": "tree",
@@ -1596,6 +2596,30 @@
     "narrative": "In the aquatic fresh realms, where wetland holds sway, stands the Bulrush, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Bulrush marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "bur_oak",
+    "common_name": "Bur Oak",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland",
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the grassland and forest hold sway, stands the Bur Oak, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its nut sustain the hungry when prepared with care. From its body folk derive wood, a boon to trade and craft. Thus the Bur Oak marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "nut"
+    ]
+  },
+  {
     "id": "butterbur",
     "common_name": "Butterbur",
     "growth_form": "herb",
@@ -1609,6 +2633,38 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where wetland holds sway, stands the Butterbur, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Butterbur marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "butterfly_flower",
+    "common_name": "Butterfly Flower",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where grassland holds sway, stands the Butterfly Flower, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Butterfly Flower marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true
+  },
+  {
+    "id": "butterfly_weed",
+    "common_name": "Butterfly Weed",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where grassland holds sway, stands the Butterfly Weed, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Butterfly Weed marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true
   },
   {
     "id": "cabbage",
@@ -1702,6 +2758,29 @@
     ]
   },
   {
+    "id": "cabinet_cherry",
+    "common_name": "Cabinet Cherry",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Cabinet Cherry, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruit sustain the hungry when prepared with care. From its body folk derive wood, a boon to trade and craft. Thus the Cabinet Cherry marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ]
+  },
+  {
     "id": "cacao",
     "common_name": "Cacao",
     "growth_form": "herb",
@@ -1717,6 +2796,118 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Cacao, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Cacao marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "california_bay_laurel",
+    "common_name": "California Bay Laurel",
+    "growth_form": "tree",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal",
+      "hills"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "leaf",
+        "harvest_season": "year-round"
+      }
+    ],
+    "narrative": "In the coastal realms, where the coastal and hills hold sway, stands the California Bay Laurel, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as California Bay, names born of custom and need. From its body folk derive leaf, a boon to trade and craft. Thus the California Bay Laurel marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "California Bay"
+    ],
+    "edible_parts": [
+      "leaf"
+    ],
+    "medicinal": true,
+    "culinary_uses": [
+      "savory stews"
+    ]
+  },
+  {
+    "id": "california_buckeye",
+    "common_name": "California Buckeye",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "hills",
+      "grassland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where the hills and grassland hold sway, stands the California Buckeye, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Buckeye (California Buckeye), names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the California Buckeye marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Buckeye (California Buckeye)"
+    ],
+    "medicinal": true,
+    "toxic": true,
+    "toxicity_notes": "Seeds are poisonous unless thoroughly leached."
+  },
+  {
+    "id": "california_sycamore",
+    "common_name": "California Sycamore",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "riverlands"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where riverlands holds sway, stands the California Sycamore, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive wood, a boon to trade and craft. Thus the California Sycamore marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "california_thistle",
+    "common_name": "California Thistle",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where grassland holds sway, stands the California Thistle, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the California Thistle marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "california_walnut",
+    "common_name": "California Walnut",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "hills"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the farmland and hills hold sway, stands the California Walnut, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its nut sustain the hungry when prepared with care. From its body folk derive wood, a boon to trade and craft. Thus the California Walnut marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "nut"
+    ]
+  },
+  {
     "id": "camellia",
     "common_name": "Camellia",
     "growth_form": "herb",
@@ -1730,6 +2921,128 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Camellia, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Camellia marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "canada_root",
+    "common_name": "Canada Root",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "medicine"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Canada Root, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive medicine, a boon to trade and craft. Thus the Canada Root marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true
+  },
+  {
+    "id": "canada_thistle",
+    "common_name": "Canada Thistle",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Canada Thistle, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Canada Thistle marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "cancer_jalap",
+    "common_name": "Cancer Jalap",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "medicine"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Cancer Jalap, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive medicine, a boon to trade and craft. Thus the Cancer Jalap marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "medicinal": true
+  },
+  {
+    "id": "cane_ash",
+    "common_name": "Cane Ash",
+    "growth_form": "tree",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the wetlands transitional realms, where wetland holds sway, stands the Cane Ash, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive wood, a boon to trade and craft. Thus the Cane Ash marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "canoe_birch",
+    "common_name": "Canoe Birch",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "lake",
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "bark",
+        "harvest_season": "spring"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the lake and forest hold sway, stands the Canoe Birch, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its sap sustain the hungry when prepared with care. From its body folk derive bark, a boon to trade and craft. Thus the Canoe Birch marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "sap"
+    ]
+  },
+  {
+    "id": "canyon_sycamore",
+    "common_name": "Canyon Sycamore",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "riverlands"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where riverlands holds sway, stands the Canyon Sycamore, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Arizona Sycamore, names born of custom and need. From its body folk derive wood, a boon to trade and craft. Thus the Canyon Sycamore marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Arizona Sycamore"
+    ]
   },
   {
     "id": "caper",
@@ -1941,6 +3254,21 @@
     ]
   },
   {
+    "id": "carrot_weed",
+    "common_name": "Carrot Weed",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Carrot Weed, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Carrot Weed marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
     "id": "carrots",
     "common_name": "Carrots",
     "growth_form": "herb",
@@ -1954,6 +3282,22 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Carrots, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Carrots marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "cart_track_plant",
+    "common_name": "Cart Track Plant",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "urban"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where the farmland and urban hold sway, stands the Cart Track Plant, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Cart Track Plant marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
     "id": "cassava",
@@ -2024,6 +3368,27 @@
     "alt_names": [
       "Catalan Safrà"
     ]
+  },
+  {
+    "id": "catalina_ironwood",
+    "common_name": "Catalina Ironwood",
+    "growth_form": "tree",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal",
+      "hills"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the coastal realms, where the coastal and hills hold sway, stands the Catalina Ironwood, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. From its body folk derive wood, a boon to trade and craft. Thus the Catalina Ironwood marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
     "id": "catnip",
@@ -2156,6 +3521,30 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Chamomile, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Chamomile marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "champion_oak",
+    "common_name": "Champion Oak",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "hills"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the forest and hills hold sway, stands the Champion Oak, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its nut sustain the hungry when prepared with care. From its body folk derive wood, a boon to trade and craft. Thus the Champion Oak marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "nut"
+    ]
+  },
+  {
     "id": "chanterelle",
     "common_name": "Chanterelle",
     "alt_names": [
@@ -2251,6 +3640,29 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Cherry, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Cherry marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "cherry_birch",
+    "common_name": "Cherry Birch",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Cherry Birch, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its sap sustain the hungry when prepared with care. From its body folk derive wood, a boon to trade and craft. Thus the Cherry Birch marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "sap"
+    ]
+  },
+  {
     "id": "chervil",
     "common_name": "Chervil",
     "growth_form": "herb",
@@ -2264,6 +3676,30 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Chervil, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Chervil marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "chestnut",
+    "common_name": "Chestnut",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the farmland and forest hold sway, stands the Chestnut, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its nut sustain the hungry when prepared with care. From its body folk derive wood, a boon to trade and craft. Thus the Chestnut marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "nut"
+    ]
   },
   {
     "id": "chestnut-oak",
@@ -2383,6 +3819,21 @@
     "narrative": "In the terrestrial realms, where grassland holds sway, stands the Chicory, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Chicory marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "chigger_flower",
+    "common_name": "Chigger Flower",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "grassland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where grassland holds sway, stands the Chigger Flower, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Chigger Flower marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
     "id": "chihuahuan_agave_stand",
     "common_name": "Chihuahuan Agave Stand",
     "growth_form": "herb",
@@ -2441,6 +3892,44 @@
       }
     ],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Chives, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. From its body folk derive herb, a boon to trade and craft. Thus the Chives marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "christmas_fern",
+    "common_name": "Christmas Fern",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Christmas Fern, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. No notable craft is wrought from it, save what necessity contrives. Thus the Christmas Fern marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "chrysanthemum",
+    "common_name": "Chrysanthemum",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "urban"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where the farmland and urban hold sway, stands the Chrysanthemum, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its flower sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Chrysanthemum marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "flower"
+    ],
+    "culinary_uses": [
+      "tea",
+      "garnish"
+    ]
   },
   {
     "id": "cinnamon",
@@ -2625,6 +4114,32 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where grassland holds sway, stands the Comfrey, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Comfrey marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "common_bean",
+    "common_name": "Common Bean",
+    "growth_form": "vine",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "seed",
+        "harvest_season": "late summer"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Common Bean, a vine of note. Tilled and tended by folk, it answers well to plough and garden row. Its seed sustain the hungry when prepared with care. Among diverse tongues it is hailed as Bean, names born of custom and need. From its body folk derive seed, a boon to trade and craft. Thus the Common Bean marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Bean"
+    ],
+    "edible_parts": [
+      "seed"
+    ]
   },
   {
     "id": "common-reed-phragmites",
@@ -3158,6 +4673,26 @@
     "alt_names": [
       "Calamus"
     ]
+  },
+  {
+    "id": "desert_apple",
+    "common_name": "Desert Apple",
+    "growth_form": "shrub",
+    "regions": [
+      "arid"
+    ],
+    "habitats": [
+      "desert"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the arid realms, where desert holds sway, stands the Desert Apple, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Apple of Sodom, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Desert Apple marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Apple of Sodom"
+    ],
+    "toxic": true,
+    "toxicity_notes": "Latex-filled pods are inedible and irritating."
   },
   {
     "id": "dewberry-bramble",
@@ -3969,6 +5504,30 @@
     ]
   },
   {
+    "id": "flowering_dogwood",
+    "common_name": "Flowering Dogwood",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Flowering Dogwood, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as American Dogwood, names born of custom and need. From its body folk derive wood, a boon to trade and craft. Thus the Flowering Dogwood marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "American Dogwood"
+    ],
+    "medicinal": true
+  },
+  {
     "id": "fly-agaric",
     "common_name": "Fly agaric",
     "growth_form": "mushroom",
@@ -4721,6 +6280,27 @@
     "narrative": "In the aquatic fresh realms, where lake holds sway, stands the Hornwort, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Hornwort marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "horse_nettle",
+    "common_name": "Horse Nettle",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Horse Nettle, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Carolina Horse Nettle, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Horse Nettle marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Carolina Horse Nettle"
+    ],
+    "medicinal": true,
+    "toxic": true,
+    "toxicity_notes": "Spiny stems and poisonous berries."
+  },
+  {
     "id": "horseradish",
     "common_name": "Horseradish",
     "growth_form": "herb",
@@ -5046,6 +6626,27 @@
     ],
     "alt_names": [
       "Floating Watercress"
+    ]
+  },
+  {
+    "id": "island_cress",
+    "common_name": "Island Cress",
+    "growth_form": "herb",
+    "regions": [
+      "coastal"
+    ],
+    "habitats": [
+      "coastal"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the coastal realms, where coastal holds sway, stands the Island Cress, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Bermuda Cress, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Island Cress marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Bermuda Cress"
+    ],
+    "edible_parts": [
+      "leaf"
     ]
   },
   {
@@ -6544,6 +8145,28 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Marshmallow (Althaea), a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. From its body folk derive root, a boon to trade and craft. Thus the Marshmallow (Althaea) marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "meadow_nightshade",
+    "common_name": "Meadow Nightshade",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "grassland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where the forest and grassland hold sway, stands the Meadow Nightshade, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as American Nightshade, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Meadow Nightshade marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "American Nightshade"
+    ],
+    "medicinal": true,
+    "toxic": true,
+    "toxicity_notes": "Berries contain solanine unless fully ripe."
+  },
+  {
     "id": "meadowsweet",
     "common_name": "Meadowsweet",
     "growth_form": "herb",
@@ -6657,6 +8280,31 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Millet, a grass of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Millet marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "miniature_rose",
+    "common_name": "Miniature Rose",
+    "growth_form": "shrub",
+    "regions": [
+      "urban"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the urban realms, where urban holds sway, stands the Miniature Rose, a shrub of note. Tilled and tended by folk, it answers well to plough and garden row. Its flower sustain the hungry when prepared with care. Among diverse tongues it is hailed as Baby Rose, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Miniature Rose marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Baby Rose"
+    ],
+    "edible_parts": [
+      "flower"
+    ],
+    "culinary_uses": [
+      "candied petals",
+      "teas"
+    ]
+  },
+  {
     "id": "mint",
     "common_name": "Mint",
     "growth_form": "herb",
@@ -6730,6 +8378,31 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where wetland holds sway, stands the Moss, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Moss marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "mountain_tea_shrub",
+    "common_name": "Mountain Tea Shrub",
+    "growth_form": "shrub",
+    "regions": [
+      "highland"
+    ],
+    "habitats": [
+      "mountains"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the highland realms, where mountains holds sway, stands the Mountain Tea Shrub, a shrub of note. It springs forth unbidden, owing nothing to the care of humankind. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as Appalachian Tea, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Mountain Tea Shrub marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Appalachian Tea"
+    ],
+    "edible_parts": [
+      "leaf"
+    ],
+    "medicinal": true,
+    "culinary_uses": [
+      "herbal tea"
+    ]
   },
   {
     "id": "mugwort",
@@ -6863,6 +8536,25 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Neem, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Neem marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "nestled_anthurium",
+    "common_name": "Nestled Anthurium",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest",
+      "urban"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where the forest and urban hold sway, stands the Nestled Anthurium, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Bird's Nest Plant, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Nestled Anthurium marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Bird's Nest Plant"
+    ]
   },
   {
     "id": "nettle",
@@ -7154,7 +8846,7 @@
         "type": "wood"
       }
     ],
-    "narrative": "In the terrestrial realms, where the forest and hills hold sway, stands the Occitanian Truffle Oak, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruiting body sustain the hungry when prepared with care. Among diverse tongues it is hailed as Truffle Oak Grove, names born of custom and need. From its body folk derive fruiting body and wood, a boon to trade and craft. Thus the Occitanian Truffle Oak marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "narrative": "In the terrestrial realms, where the forest and hills hold sway, stands the Occitanian Truffle Oak, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its fruiting body sustain the hungry when prepared with care. Among diverse tongues it is hailed as Truffle Oak Grove, names born of custom and need. From its body folk derive mushroom and wood, a boon to trade and craft. Thus the Occitanian Truffle Oak marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
     "edible_parts": [
       "fruiting body"
     ],
@@ -7500,6 +9192,33 @@
       ],
       "luxury_tier": []
     }
+  },
+  {
+    "id": "paddy_rice",
+    "common_name": "Paddy Rice",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "wetland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "grain",
+        "harvest_season": "autumn"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the farmland and wetland hold sway, stands the Paddy Rice, a grass of note. Tilled and tended by folk, it answers well to plough and garden row. Its grain sustain the hungry when prepared with care. Among diverse tongues it is hailed as Asian Rice, names born of custom and need. From its body folk derive grain, a boon to trade and craft. Thus the Paddy Rice marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Asian Rice"
+    ],
+    "edible_parts": [
+      "grain"
+    ]
   },
   {
     "id": "palace_courtyard_lime",
@@ -7855,6 +9574,31 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Peppermint, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Peppermint marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "peppery_cress",
+    "common_name": "Peppery Cress",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Peppery Cress, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its leaf sustain the hungry when prepared with care. Among diverse tongues it is hailed as American Cress, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Peppery Cress marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "American Cress"
+    ],
+    "edible_parts": [
+      "leaf"
+    ],
+    "culinary_uses": [
+      "salads",
+      "garnish"
+    ]
   },
   {
     "id": "persimmon",
@@ -8660,6 +10404,29 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Rue, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Rue marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "rum_cherry",
+    "common_name": "Rum Cherry",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "wood",
+        "harvest_season": "winter"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Rum Cherry, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its fruit sustain the hungry when prepared with care. From its body folk derive wood, a boon to trade and craft. Thus the Rum Cherry marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "edible_parts": [
+      "fruit"
+    ]
+  },
+  {
     "id": "russula",
     "common_name": "Russula mushrooms",
     "growth_form": "mushroom",
@@ -8916,6 +10683,32 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Sarsaparilla, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Sarsaparilla marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "savanna_rice",
+    "common_name": "Savanna Rice",
+    "growth_form": "grass",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "grain",
+        "harvest_season": "late summer"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where farmland holds sway, stands the Savanna Rice, a grass of note. Tilled and tended by folk, it answers well to plough and garden row. Its grain sustain the hungry when prepared with care. Among diverse tongues it is hailed as African Rice, names born of custom and need. From its body folk derive grain, a boon to trade and craft. Thus the Savanna Rice marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "African Rice"
+    ],
+    "edible_parts": [
+      "grain"
+    ]
   },
   {
     "id": "savory",
@@ -9504,6 +11297,28 @@
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Sweet woodruff, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Sweet woodruff marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "tall_hellebore",
+    "common_name": "Tall Hellebore",
+    "growth_form": "herb",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland",
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the wetlands transitional realms, where the wetland and forest hold sway, stands the Tall Hellebore, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Big Hellebore, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Tall Hellebore marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Big Hellebore"
+    ],
+    "medicinal": true,
+    "toxic": true,
+    "toxicity_notes": "Roots used carefully for traditional remedies."
+  },
+  {
     "id": "tamarillo",
     "common_name": "Tamarillo",
     "growth_form": "herb",
@@ -9796,6 +11611,43 @@
     ]
   },
   {
+    "id": "true_cinnamon",
+    "common_name": "True Cinnamon",
+    "growth_form": "tree",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "farmland",
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": true,
+    "byproducts": [
+      {
+        "type": "bark",
+        "harvest_season": "dry season"
+      },
+      {
+        "type": "spice",
+        "harvest_season": "year-round"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where the farmland and forest hold sway, stands the True Cinnamon, a tree of note. Tilled and tended by folk, it answers well to plough and garden row. Its bark sustain the hungry when prepared with care. Among diverse tongues it is hailed as (True) Cinnamon, names born of custom and need. From its body folk derive bark and spice, a boon to trade and craft. Thus the True Cinnamon marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "(True) Cinnamon"
+    ],
+    "edible_parts": [
+      "bark"
+    ],
+    "medicinal": true,
+    "toxic": false,
+    "culinary_uses": [
+      "spice blends",
+      "infusions"
+    ]
+  },
+  {
     "id": "truffle",
     "common_name": "Truffle",
     "growth_form": "mushroom",
@@ -10082,6 +11934,24 @@
     "narrative": "In the terrestrial realms, where farmland holds sway, stands the Vanilla, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Vanilla marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "velvet_violet",
+    "common_name": "Velvet Violet",
+    "growth_form": "herb",
+    "regions": [
+      "urban"
+    ],
+    "habitats": [
+      "urban"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the urban realms, where urban holds sway, stands the Velvet Violet, a herb of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as African Violet, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Velvet Violet marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "African Violet"
+    ]
+  },
+  {
     "id": "violet",
     "common_name": "Violet",
     "growth_form": "herb",
@@ -10312,6 +12182,27 @@
     }
   },
   {
+    "id": "white_hellebore",
+    "common_name": "White Hellebore",
+    "growth_form": "herb",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the wetlands transitional realms, where wetland holds sway, stands the White Hellebore, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as American White Hellebore, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the White Hellebore marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "American White Hellebore"
+    ],
+    "medicinal": true,
+    "toxic": true,
+    "toxicity_notes": "Highly poisonous roots and foliage."
+  },
+  {
     "id": "white-water-lily",
     "common_name": "White water lily",
     "growth_form": "herb",
@@ -10325,6 +12216,29 @@
     "edible": true,
     "byproducts": [],
     "narrative": "In the aquatic fresh realms, where lake holds sway, stands the White water lily, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the White water lily marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "wild_pellitory",
+    "common_name": "Wild Pellitory",
+    "growth_form": "herb",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [
+      {
+        "type": "medicine"
+      }
+    ],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Wild Pellitory, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Bastard Pellitory, names born of custom and need. From its body folk derive medicine, a boon to trade and craft. Thus the Wild Pellitory marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Bastard Pellitory"
+    ],
+    "medicinal": true
   },
   {
     "id": "wild-celery",
@@ -10402,6 +12316,28 @@
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Willow, a tree of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. No notable craft is wrought from it, save what necessity contrives. Thus the Willow marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
   },
   {
+    "id": "winterberry_holly",
+    "common_name": "Winterberry Holly",
+    "growth_form": "shrub",
+    "regions": [
+      "wetlands_transitional"
+    ],
+    "habitats": [
+      "wetland",
+      "forest"
+    ],
+    "cultivated": true,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the wetlands transitional realms, where the wetland and forest hold sway, stands the Winterberry Holly, a shrub of note. Tilled and tended by folk, it answers well to plough and garden row. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as American Winterberry, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Winterberry Holly marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "American Winterberry"
+    ],
+    "medicinal": true,
+    "toxic": true,
+    "toxicity_notes": "Bright berries cause stomach upset when eaten."
+  },
+  {
     "id": "woad",
     "common_name": "Woad",
     "growth_form": "herb",
@@ -10438,6 +12374,27 @@
       }
     ],
     "narrative": "In the terrestrial realms, where forest holds sway, stands the Wood sorrel, a herb of note. It springs forth unbidden, owing nothing to the care of humankind. Its parts sustain the hungry when prepared with care. From its body folk derive leaf, a boon to trade and craft. Thus the Wood sorrel marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study."
+  },
+  {
+    "id": "woodland_bittersweet",
+    "common_name": "Woodland Bittersweet",
+    "growth_form": "vine",
+    "regions": [
+      "terrestrial"
+    ],
+    "habitats": [
+      "forest"
+    ],
+    "cultivated": false,
+    "edible": false,
+    "byproducts": [],
+    "narrative": "In the terrestrial realms, where forest holds sway, stands the Woodland Bittersweet, a vine of note. It springs forth unbidden, owing nothing to the care of humankind. Yet its flesh is shunned at table, for it brings ill to those who partake. Among diverse tongues it is hailed as Bittersweet, names born of custom and need. No notable craft is wrought from it, save what necessity contrives. Thus the Woodland Bittersweet marks the turning of the seasons and gives haven to small beasts within its shade. This additional detail underscores the complex relationship between people and the natural world, inviting further observation and study.",
+    "alt_names": [
+      "Bittersweet"
+    ],
+    "medicinal": true,
+    "toxic": true,
+    "toxicity_notes": "Decorative berries are unsafe to eat."
   },
   {
     "id": "wormwood",


### PR DESCRIPTION
## Summary
- add 87 new animal records covering common pets, livestock, and wildlife while wiring alias coverage for entries such as cattle, domestic pigs, sheep, and deer
- add 93 new plant records spanning crops, ornamentals, and wild species with location-free display names and aliases for their real-world names
- refresh generated narratives so the new creatures and plants follow the repository’s descriptive template

## Testing
- npm run validate
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c97c599f78832583c59e8541303c7a