### PR TITLE
Retheme calendar constellations for seasonal variety

### DIFF
--- a/assets/data/calendar.js
+++ b/assets/data/calendar.js
@@ -1,0 +1,219 @@
+export const DAYS_PER_MONTH = 28;
+export const MONTH_COUNT = 13;
+export const DAYS_PER_YEAR = DAYS_PER_MONTH * MONTH_COUNT;
+
+export const MONTHS = [
+  {
+    index: 0,
+    name: 'Vernal Crown',
+    shortName: 'Vernal',
+    constellation: 'Vernal Crown',
+    season: 'Spring',
+    description:
+      'A circlet of seven stars called the Vernal Crown blooms over the horizon, marking spring\'s first festivals.',
+  },
+  {
+    index: 1,
+    name: 'Grove Serpent',
+    shortName: 'Grove',
+    constellation: 'Grove Serpent',
+    season: 'Spring',
+    description:
+      'The Grove Serpent winds between twin oaks, a stellar serpent said to wake the forests after winter\'s sleep.',
+  },
+  {
+    index: 2,
+    name: 'Sky Shepherd',
+    shortName: 'Shepherd',
+    constellation: 'Sky Shepherd',
+    season: 'Spring',
+    description:
+      'Folktales claim the Sky Shepherd guides migrating beasts across the night, promising fertile pastures.',
+  },
+  {
+    index: 3,
+    name: 'Thunder Roc',
+    shortName: 'Roc',
+    constellation: 'Thunder Roc',
+    season: 'Summer',
+    description:
+      'The Thunder Roc spreads storm-feathered wings, warning travelers of booming summer squalls.',
+  },
+  {
+    index: 4,
+    name: 'Sunforge Lion',
+    shortName: 'Sunforge',
+    constellation: 'Sunforge Lion',
+    season: 'Summer',
+    description:
+      'A mane of molten light forms the Sunforge Lion, symbolizing the relentless heat of high summer.',
+  },
+  {
+    index: 5,
+    name: 'Mirage Stag',
+    shortName: 'Mirage',
+    constellation: 'Mirage Stag',
+    season: 'Summer',
+    description:
+      'Shimmering antlers arch across the zenith, the Mirage Stag leading caravans through wavering heat.',
+  },
+  {
+    index: 6,
+    name: 'Harvest Crown',
+    shortName: 'Harvest',
+    constellation: 'Harvest Crown',
+    season: 'Autumn',
+    description:
+      'Reapers celebrate the Harvest Crown, a halo of stars that ripens grain beneath its glow.',
+  },
+  {
+    index: 7,
+    name: 'Ashen Fox',
+    shortName: 'Fox',
+    constellation: 'Ashen Fox',
+    season: 'Autumn',
+    description:
+      'Storykeepers track the Ashen Fox as it darts through falling leaves, heralding chilly winds.',
+  },
+  {
+    index: 8,
+    name: 'Twilight Loom',
+    shortName: 'Loom',
+    constellation: 'Twilight Loom',
+    season: 'Autumn',
+    description:
+      'The Twilight Loom threads violet light across dusk skies, said to weave hearthward paths home.',
+  },
+  {
+    index: 9,
+    name: 'Frostbound Ram',
+    shortName: 'Ram',
+    constellation: 'Frostbound Ram',
+    season: 'Winter',
+    description:
+      'The Frostbound Ram charges ahead of winter\'s first snow, its horns gleaming with frostfire.',
+  },
+  {
+    index: 10,
+    name: 'Glacier Leviathan',
+    shortName: 'Glacier',
+    constellation: 'Glacier Leviathan',
+    season: 'Winter',
+    description:
+      'Legends speak of the Glacier Leviathan slumbering beneath frozen seas, stirring during the longest nights.',
+  },
+  {
+    index: 11,
+    name: 'Nocturne Compass',
+    shortName: 'Nocturne',
+    constellation: 'Nocturne Compass',
+    season: 'Winter',
+    description:
+      'Navigators align by the Nocturne Compass, a four-point star that points toward hidden midwinter stars.',
+  },
+  {
+    index: 12,
+    name: 'Aurora Piper',
+    shortName: 'Piper',
+    constellation: 'Aurora Piper',
+    season: 'Winter',
+    description:
+      'The Aurora Piper plays luminous notes that sweep color over the sky, beckoning spring\'s return.',
+  },
+];
+
+function toAbsoluteDay(date) {
+  return date.year * DAYS_PER_YEAR + date.monthIndex * DAYS_PER_MONTH + (date.day - 1);
+}
+
+function fromAbsoluteDay(dayNumber) {
+  let year = Math.floor(dayNumber / DAYS_PER_YEAR);
+  let dayOfYear = dayNumber % DAYS_PER_YEAR;
+  if (dayOfYear < 0) {
+    dayOfYear += DAYS_PER_YEAR;
+    year -= 1;
+  }
+  const monthIndex = Math.floor(dayOfYear / DAYS_PER_MONTH);
+  const day = (dayOfYear % DAYS_PER_MONTH) + 1;
+  return { year, monthIndex, day };
+}
+
+export function normalizeDate(date) {
+  return fromAbsoluteDay(toAbsoluteDay(date));
+}
+
+export function advanceDate(date, days) {
+  return fromAbsoluteDay(toAbsoluteDay(date) + days);
+}
+
+export function compareDates(a, b) {
+  const diff = toAbsoluteDay(a) - toAbsoluteDay(b);
+  if (diff < 0) return -1;
+  if (diff > 0) return 1;
+  return 0;
+}
+
+export function isSameDate(a, b) {
+  return compareDates(a, b) === 0;
+}
+
+export function dayOfYear(date) {
+  const absolute = toAbsoluteDay(date);
+  const startOfYear = date.year * DAYS_PER_YEAR;
+  return absolute - startOfYear + 1;
+}
+
+export function getMonth(index) {
+  return MONTHS[(index % MONTH_COUNT + MONTH_COUNT) % MONTH_COUNT];
+}
+
+export function getSeasonForDate(date) {
+  return getMonth(date.monthIndex).season;
+}
+
+export function formatCalendarDate(date) {
+  const month = getMonth(date.monthIndex);
+  return `${date.day} ${month.name}, ${date.year}`;
+}
+
+export function dateKey(date) {
+  const month = String(date.monthIndex + 1).padStart(2, '0');
+  const day = String(date.day).padStart(2, '0');
+  return `${date.year}-${month}-${day}`;
+}
+
+export class TidefallCalendar {
+  constructor(start) {
+    const base = {
+      year: (start === null || start === void 0 ? void 0 : start.year) ?? 732,
+      monthIndex: (start === null || start === void 0 ? void 0 : start.monthIndex) ?? 0,
+      day: (start === null || start === void 0 ? void 0 : start.day) ?? 1,
+    };
+    this.current = normalizeDate(base);
+  }
+
+  today() {
+    return Object.assign({}, this.current);
+  }
+
+  season() {
+    return getSeasonForDate(this.current);
+  }
+
+  advance(days = 1) {
+    this.current = advanceDate(this.current, days);
+    return this.today();
+  }
+
+  setDate(date) {
+    this.current = normalizeDate(date);
+  }
+
+  rewind(days = 1) {
+    return this.advance(-days);
+  }
+
+  formatCurrentDate() {
+    return formatCalendarDate(this.current);
+  }
+}

--- a/assets/data/calendar.ts
+++ b/assets/data/calendar.ts
@@ -1,0 +1,237 @@
+export type CalendarSeason = 'Spring' | 'Summer' | 'Autumn' | 'Winter';
+export interface MonthDefinition {
+  index: number;
+  name: string;
+  shortName: string;
+  constellation: string;
+  season: CalendarSeason;
+  description: string;
+}
+
+export interface CalendarDate {
+  year: number;
+  monthIndex: number;
+  day: number;
+}
+
+export const DAYS_PER_MONTH = 28;
+export const MONTH_COUNT = 13;
+export const DAYS_PER_YEAR = DAYS_PER_MONTH * MONTH_COUNT;
+
+export const MONTHS: MonthDefinition[] = [
+  {
+    index: 0,
+    name: 'Vernal Crown',
+    shortName: 'Vernal',
+    constellation: 'Vernal Crown',
+    season: 'Spring',
+    description:
+      'A circlet of seven stars called the Vernal Crown blooms over the horizon, marking spring\'s first festivals.',
+  },
+  {
+    index: 1,
+    name: 'Grove Serpent',
+    shortName: 'Grove',
+    constellation: 'Grove Serpent',
+    season: 'Spring',
+    description:
+      'The Grove Serpent winds between twin oaks, a stellar serpent said to wake the forests after winter\'s sleep.',
+  },
+  {
+    index: 2,
+    name: 'Sky Shepherd',
+    shortName: 'Shepherd',
+    constellation: 'Sky Shepherd',
+    season: 'Spring',
+    description:
+      'Folktales claim the Sky Shepherd guides migrating beasts across the night, promising fertile pastures.',
+  },
+  {
+    index: 3,
+    name: 'Thunder Roc',
+    shortName: 'Roc',
+    constellation: 'Thunder Roc',
+    season: 'Summer',
+    description:
+      'The Thunder Roc spreads storm-feathered wings, warning travelers of booming summer squalls.',
+  },
+  {
+    index: 4,
+    name: 'Sunforge Lion',
+    shortName: 'Sunforge',
+    constellation: 'Sunforge Lion',
+    season: 'Summer',
+    description:
+      'A mane of molten light forms the Sunforge Lion, symbolizing the relentless heat of high summer.',
+  },
+  {
+    index: 5,
+    name: 'Mirage Stag',
+    shortName: 'Mirage',
+    constellation: 'Mirage Stag',
+    season: 'Summer',
+    description:
+      'Shimmering antlers arch across the zenith, the Mirage Stag leading caravans through wavering heat.',
+  },
+  {
+    index: 6,
+    name: 'Harvest Crown',
+    shortName: 'Harvest',
+    constellation: 'Harvest Crown',
+    season: 'Autumn',
+    description:
+      'Reapers celebrate the Harvest Crown, a halo of stars that ripens grain beneath its glow.',
+  },
+  {
+    index: 7,
+    name: 'Ashen Fox',
+    shortName: 'Fox',
+    constellation: 'Ashen Fox',
+    season: 'Autumn',
+    description:
+      'Storykeepers track the Ashen Fox as it darts through falling leaves, heralding chilly winds.',
+  },
+  {
+    index: 8,
+    name: 'Twilight Loom',
+    shortName: 'Loom',
+    constellation: 'Twilight Loom',
+    season: 'Autumn',
+    description:
+      'The Twilight Loom threads violet light across dusk skies, said to weave hearthward paths home.',
+  },
+  {
+    index: 9,
+    name: 'Frostbound Ram',
+    shortName: 'Ram',
+    constellation: 'Frostbound Ram',
+    season: 'Winter',
+    description:
+      'The Frostbound Ram charges ahead of winter\'s first snow, its horns gleaming with frostfire.',
+  },
+  {
+    index: 10,
+    name: 'Glacier Leviathan',
+    shortName: 'Glacier',
+    constellation: 'Glacier Leviathan',
+    season: 'Winter',
+    description:
+      'Legends speak of the Glacier Leviathan slumbering beneath frozen seas, stirring during the longest nights.',
+  },
+  {
+    index: 11,
+    name: 'Nocturne Compass',
+    shortName: 'Nocturne',
+    constellation: 'Nocturne Compass',
+    season: 'Winter',
+    description:
+      'Navigators align by the Nocturne Compass, a four-point star that points toward hidden midwinter stars.',
+  },
+  {
+    index: 12,
+    name: 'Aurora Piper',
+    shortName: 'Piper',
+    constellation: 'Aurora Piper',
+    season: 'Winter',
+    description:
+      'The Aurora Piper plays luminous notes that sweep color over the sky, beckoning spring\'s return.',
+  },
+];
+
+function toAbsoluteDay(date: CalendarDate): number {
+  return date.year * DAYS_PER_YEAR + date.monthIndex * DAYS_PER_MONTH + (date.day - 1);
+}
+
+function fromAbsoluteDay(dayNumber: number): CalendarDate {
+  let year = Math.floor(dayNumber / DAYS_PER_YEAR);
+  let dayOfYear = dayNumber % DAYS_PER_YEAR;
+  if (dayOfYear < 0) {
+    dayOfYear += DAYS_PER_YEAR;
+    year -= 1;
+  }
+  const monthIndex = Math.floor(dayOfYear / DAYS_PER_MONTH);
+  const day = (dayOfYear % DAYS_PER_MONTH) + 1;
+  return { year, monthIndex, day };
+}
+
+export function normalizeDate(date: CalendarDate): CalendarDate {
+  return fromAbsoluteDay(toAbsoluteDay(date));
+}
+
+export function advanceDate(date: CalendarDate, days: number): CalendarDate {
+  return fromAbsoluteDay(toAbsoluteDay(date) + days);
+}
+
+export function compareDates(a: CalendarDate, b: CalendarDate): number {
+  const diff = toAbsoluteDay(a) - toAbsoluteDay(b);
+  if (diff < 0) return -1;
+  if (diff > 0) return 1;
+  return 0;
+}
+
+export function isSameDate(a: CalendarDate, b: CalendarDate): boolean {
+  return compareDates(a, b) === 0;
+}
+
+export function dayOfYear(date: CalendarDate): number {
+  const absolute = toAbsoluteDay(date);
+  const startOfYear = date.year * DAYS_PER_YEAR;
+  return absolute - startOfYear + 1;
+}
+
+export function getMonth(index: number): MonthDefinition {
+  return MONTHS[(index % MONTH_COUNT + MONTH_COUNT) % MONTH_COUNT];
+}
+
+export function getSeasonForDate(date: CalendarDate): CalendarSeason {
+  return getMonth(date.monthIndex).season;
+}
+
+export function formatCalendarDate(date: CalendarDate): string {
+  const month = getMonth(date.monthIndex);
+  return `${date.day} ${month.name}, ${date.year}`;
+}
+
+export function dateKey(date: CalendarDate): string {
+  const month = String(date.monthIndex + 1).padStart(2, '0');
+  const day = String(date.day).padStart(2, '0');
+  return `${date.year}-${month}-${day}`;
+}
+
+export class TidefallCalendar {
+  private current: CalendarDate;
+
+  constructor(start?: Partial<CalendarDate>) {
+    const base: CalendarDate = {
+      year: start?.year ?? 732,
+      monthIndex: start?.monthIndex ?? 0,
+      day: start?.day ?? 1,
+    };
+    this.current = normalizeDate(base);
+  }
+
+  today(): CalendarDate {
+    return { ...this.current };
+  }
+
+  season(): CalendarSeason {
+    return getSeasonForDate(this.current);
+  }
+
+  advance(days = 1): CalendarDate {
+    this.current = advanceDate(this.current, days);
+    return this.today();
+  }
+
+  setDate(date: CalendarDate): void {
+    this.current = normalizeDate(date);
+  }
+
+  rewind(days = 1): CalendarDate {
+    return this.advance(-days);
+  }
+
+  formatCurrentDate(): string {
+    return formatCalendarDate(this.current);
+  }
+}

--- a/assets/data/locations.js
+++ b/assets/data/locations.js
@@ -16,6 +16,7 @@ export function createLocation(name, mapFile, description = "") {
         population: undefined,
         quests: [],
         questBoards: {},
+        ownership: undefined,
     };
 }
 function createQuest(title, description, opts = {}) {
@@ -90,11 +91,6 @@ function addQuestBoards(loc) {
         }
     });
     loc.questBoards = boards;
-    Object.keys(boards).forEach((boardName) => {
-        if (!loc.pointsOfInterest.buildings.includes(boardName)) {
-            loc.pointsOfInterest.buildings.push(boardName);
-        }
-    });
     const allQuests = Object.values(boards).reduce((arr, q) => arr.concat(q), []);
     loc.quests.push(...allQuests);
 }

--- a/assets/data/name_generator.js
+++ b/assets/data/name_generator.js
@@ -1,0 +1,284 @@
+const HUMAN_NAMES = {
+    commoner: {
+        male: [
+            'Arel',
+            'Brann',
+            'Dovan',
+            'Elric',
+            'Garen',
+            'Hullen',
+            'Ilyan',
+            'Joran',
+            'Kale',
+            'Malen',
+            'Torv',
+            'Vel',
+            'Yorsen',
+        ],
+        female: [
+            'Brisa',
+            'Deryn',
+            'Helda',
+            'Jessa',
+            'Lileth',
+            'Maera',
+            'Maris',
+            'Neral',
+            'Nyla',
+            'Riala',
+            'Selka',
+            'Seraphine',
+            'Tarsa',
+            'Varla',
+        ],
+        nonbinary: ['Aelis', 'Galen', 'Mave', 'Ryn', 'Sera'],
+        family: [
+            'Tidemold',
+            'Saltbound',
+            'Cliffbloom',
+            'Driftfell',
+            'Foamfield',
+            'Gullwind',
+            'Harborwind',
+            'Mistflower',
+            'Moorlight',
+            'Seabreeze',
+            'Seawisp',
+            'Saltmeadow',
+            'Sunmellow',
+            'Tideflock',
+            'Windward',
+        ],
+    },
+    artisan: {
+        male: ['Calder', 'Corin', 'Daska', 'Dorel', 'Galen', 'Korin', 'Marlen', 'Perrin'],
+        female: ['Aurelia', 'Eliane', 'Ilvara', 'Marlenna', 'Selene', 'Serapha', 'Tella'],
+        nonbinary: ['Aris', 'Cerin', 'Lior', 'Mira'],
+        family: [
+            'Anchorfast',
+            'Brinebark',
+            'Brinemarrow',
+            'Cristalle',
+            'Threadneedle',
+            'Woodhand',
+            'Seawind',
+            'Saltroot',
+            'Emberflask',
+            'Leafpress',
+        ],
+    },
+    guild: {
+        male: ['Brakka', 'Darel', 'Pell', 'Storm', 'Sella', 'Tolen', 'Yarik'],
+        female: ['Aelric', 'Liora', 'Maren', 'Mira', 'Neris', 'Seren', 'Ysa'],
+        nonbinary: ['Corvel', 'Rellis', 'Valen'],
+        family: ['Ironbent', 'Stormkeel', 'Crestshield', 'Rollingwave', 'Saltmaster', 'Calderis', 'Selkanet', 'Stonebridge'],
+    },
+    noble: {
+        male: ['Delmar', 'Highran', 'Lysandor', 'Marlon', 'Thalen'],
+        female: ['Aurena', 'Calisse', 'Lyselle', 'Serenna', 'Veleth'],
+        nonbinary: ['Aurel', 'Selian'],
+        family: ['Highward', 'Delmare', 'Lyrecrown', 'Marblefinch', 'Aurora', 'Goldleaf'],
+    },
+    clergy: {
+        male: ['Callus', 'Helion', 'Maerin', 'Torlan'],
+        female: ['Maela', 'Sunya', 'Tideia', 'Vara'],
+        nonbinary: ['Grels', 'Lumin'],
+        family: ['Tideborn', 'Tidecaller', 'Sunward', 'Greensoul', 'Harvestmother', 'Shieldmarch'],
+    },
+    military: {
+        male: ['Arel', 'Brisa', 'Ilyan', 'Kass', 'Orven'],
+        female: ['Brisa', 'Nyla', 'Selune', 'Tersa'],
+        nonbinary: ['Hullen', 'Ryn', 'Yorsen'],
+        family: ['Gatewatch', 'Shieldmarch', 'Tidewatcher', 'Ironwatch'],
+    },
+    academic: {
+        male: ['Bright', 'Callis', 'Rellis', 'Thalen'],
+        female: ['Ilvara', 'Mera', 'Selise', 'Varia'],
+        nonbinary: ['Aeris', 'Lior', 'Quill'],
+        family: ['Brightmere', 'Leafward', 'Quillion', 'Starweaver', 'Cristalle'],
+    },
+    any: {
+        male: [],
+        female: [],
+        nonbinary: [],
+        family: [],
+    },
+};
+const ELF_NAMES = {
+    any: {
+        male: ['Aelar', 'Theron', 'Fenian', 'Lethar'],
+        female: ['Aelene', 'Sylvaris', 'Thalisa', 'Liarel'],
+        nonbinary: ['Caelith', 'Rythian', 'Velis'],
+        family: ['Moonglade', 'Silverfrond', 'Starwind', 'Riverwhisper', 'Leafglade'],
+    },
+    commoner: { male: [], female: [], nonbinary: [], family: [] },
+    artisan: { male: [], female: [], nonbinary: [], family: [] },
+    guild: { male: [], female: [], nonbinary: [], family: [] },
+    noble: { male: [], female: [], nonbinary: [], family: [] },
+    clergy: { male: [], female: [], nonbinary: [], family: [] },
+    military: { male: [], female: [], nonbinary: [], family: [] },
+    academic: { male: [], female: [], nonbinary: [], family: [] },
+};
+const DWARF_NAMES = {
+    any: {
+        male: ['Borin', 'Karrin', 'Rurik', 'Thorin'],
+        female: ['Dagna', 'Hildi', 'Mava', 'Sigrid'],
+        nonbinary: ['Astri', 'Broden', 'Lorn'],
+        family: ['Stoneforge', 'Ironvein', 'Coppervein', 'Stormhammer', 'Deepdelve'],
+    },
+    commoner: { male: [], female: [], nonbinary: [], family: [] },
+    artisan: { male: [], female: [], nonbinary: [], family: [] },
+    guild: { male: [], female: [], nonbinary: [], family: [] },
+    noble: { male: [], female: [], nonbinary: [], family: [] },
+    clergy: { male: [], female: [], nonbinary: [], family: [] },
+    military: { male: [], female: [], nonbinary: [], family: [] },
+    academic: { male: [], female: [], nonbinary: [], family: [] },
+};
+const HALFLING_NAMES = {
+    any: {
+        male: ['Perrin', 'Milo', 'Thom', 'Wylan'],
+        female: ['Lily', 'Tamsin', 'Briala', 'Rysa'],
+        nonbinary: ['Brindle', 'Fen', 'Quince'],
+        family: ['Tealeaf', 'Underbough', 'Fairbarrel', 'Goodbarrel', 'Greenbottle'],
+    },
+    commoner: { male: [], female: [], nonbinary: [], family: [] },
+    artisan: { male: [], female: [], nonbinary: [], family: [] },
+    guild: { male: [], female: [], nonbinary: [], family: [] },
+    noble: { male: [], female: [], nonbinary: [], family: [] },
+    clergy: { male: [], female: [], nonbinary: [], family: [] },
+    military: { male: [], female: [], nonbinary: [], family: [] },
+    academic: { male: [], female: [], nonbinary: [], family: [] },
+};
+const NAME_DATA = {
+    Human: HUMAN_NAMES,
+    Elf: ELF_NAMES,
+    Dwarf: DWARF_NAMES,
+    Halfling: HALFLING_NAMES,
+};
+const DEFAULT_RACE = 'Human';
+const DEFAULT_SEX = 'Female';
+const DEFAULT_STATION = 'commoner';
+const usedGivenNames = new Map();
+const usedFamilyNames = new Map();
+const familyRegistry = new Map();
+function stationKey(race, station, sex) {
+    return `${race}:${station}:${sex}`;
+}
+function familyKey(race, station) {
+    return `${race}:${station}`;
+}
+function getStationData(race, station) {
+    const raceData = NAME_DATA[race] || NAME_DATA[DEFAULT_RACE];
+    const data = raceData[station];
+    if (data && (data.male.length || data.female.length || data.nonbinary.length || data.family.length)) {
+        return data;
+    }
+    return raceData.any;
+}
+function ensureSet(map, key) {
+    let set = map.get(key);
+    if (!set) {
+        set = new Set();
+        map.set(key, set);
+    }
+    return set;
+}
+function pickFromList(list, used, allowReuse) {
+    for (const value of list) {
+        if (!used.has(value)) {
+            used.add(value);
+            return value;
+        }
+    }
+    if (!list.length) {
+        return '';
+    }
+    if (allowReuse) {
+        const choice = list[0];
+        used.clear();
+        used.add(choice);
+        return choice;
+    }
+    used.clear();
+    const choice = list[0];
+    used.add(choice);
+    return choice;
+}
+function pickGivenName(race, station, sex, allowReuse) {
+    const stationData = getStationData(race, station);
+    const key = stationKey(race, station, sex);
+    const used = ensureSet(usedGivenNames, key);
+    let candidates = [];
+    if (sex === 'Male') {
+        candidates = stationData.male.length ? stationData.male : stationData.female.concat(stationData.nonbinary);
+    }
+    else if (sex === 'Female') {
+        candidates = stationData.female.length ? stationData.female : stationData.male.concat(stationData.nonbinary);
+    }
+    else {
+        candidates = stationData.nonbinary.length
+            ? stationData.nonbinary
+            : stationData.male.concat(stationData.female);
+    }
+    if (!candidates.length) {
+        candidates = ['Adventurer'];
+    }
+    return pickFromList(candidates, used, allowReuse);
+}
+function pickFamilyName(race, station, allowReuse) {
+    const stationData = getStationData(race, station);
+    const key = familyKey(race, station);
+    const used = ensureSet(usedFamilyNames, key);
+    const candidates = stationData.family.length ? stationData.family : ['Freelancer'];
+    return pickFromList(candidates, used, allowReuse);
+}
+export function registerFamily(key, familyName, opts = {}) {
+    const race = opts.race || DEFAULT_RACE;
+    const station = opts.station || DEFAULT_STATION;
+    familyRegistry.set(key, { familyName, race, station });
+    const used = ensureSet(usedFamilyNames, familyKey(race, station));
+    used.add(familyName);
+}
+export function clearNameGenerator() {
+    usedGivenNames.clear();
+    usedFamilyNames.clear();
+    familyRegistry.clear();
+}
+export function generateNpcName(options = {}) {
+    var _a;
+    const race = options.race || DEFAULT_RACE;
+    const station = options.station || DEFAULT_STATION;
+    const sex = options.sex || DEFAULT_SEX;
+    const allowReuse = (_a = options.allowReuse) !== null && _a !== void 0 ? _a : false;
+    let familyName;
+    if (options.familyKey) {
+        const existing = familyRegistry.get(options.familyKey);
+        if (existing) {
+            familyName = existing.familyName;
+        }
+        else if (options.familyName) {
+            familyName = options.familyName;
+            registerFamily(options.familyKey, familyName, { race, station });
+        }
+        else {
+            familyName = pickFamilyName(race, station, allowReuse);
+            registerFamily(options.familyKey, familyName, { race, station });
+        }
+    }
+    else if (options.familyName) {
+        familyName = options.familyName;
+    }
+    else {
+        familyName = pickFamilyName(race, station, allowReuse);
+    }
+    const givenName = pickGivenName(race, station, sex, allowReuse);
+    const fullName = `${givenName} ${familyName}`.trim();
+    return {
+        race,
+        sex,
+        station,
+        givenName,
+        familyName,
+        fullName,
+    };
+}

--- a/assets/data/name_generator.ts
+++ b/assets/data/name_generator.ts
@@ -1,0 +1,347 @@
+export type Race = 'Human' | 'Elf' | 'Dwarf' | 'Halfling';
+export type Sex = 'Male' | 'Female' | 'Nonbinary';
+export type Station =
+  | 'commoner'
+  | 'artisan'
+  | 'guild'
+  | 'noble'
+  | 'clergy'
+  | 'military'
+  | 'academic';
+
+export interface NameOptions {
+  race?: Race;
+  sex?: Sex;
+  station?: Station;
+  familyKey?: string;
+  familyName?: string;
+  allowReuse?: boolean;
+}
+
+export interface GeneratedNpcName {
+  race: Race;
+  sex: Sex;
+  station: Station;
+  givenName: string;
+  familyName: string;
+  fullName: string;
+}
+
+type StationNameSet = {
+  male: string[];
+  female: string[];
+  nonbinary: string[];
+  family: string[];
+};
+
+type RaceNameData = Record<Station | 'any', StationNameSet>;
+
+const HUMAN_NAMES: RaceNameData = {
+  commoner: {
+    male: [
+      'Arel',
+      'Brann',
+      'Dovan',
+      'Elric',
+      'Garen',
+      'Hullen',
+      'Ilyan',
+      'Joran',
+      'Kale',
+      'Malen',
+      'Torv',
+      'Vel',
+      'Yorsen',
+    ],
+    female: [
+      'Brisa',
+      'Deryn',
+      'Helda',
+      'Jessa',
+      'Lileth',
+      'Maera',
+      'Maris',
+      'Neral',
+      'Nyla',
+      'Riala',
+      'Selka',
+      'Seraphine',
+      'Tarsa',
+      'Varla',
+    ],
+    nonbinary: ['Aelis', 'Galen', 'Mave', 'Ryn', 'Sera'],
+    family: [
+      'Tidemold',
+      'Saltbound',
+      'Cliffbloom',
+      'Driftfell',
+      'Foamfield',
+      'Gullwind',
+      'Harborwind',
+      'Mistflower',
+      'Moorlight',
+      'Seabreeze',
+      'Seawisp',
+      'Saltmeadow',
+      'Sunmellow',
+      'Tideflock',
+      'Windward',
+    ],
+  },
+  artisan: {
+    male: ['Calder', 'Corin', 'Daska', 'Dorel', 'Galen', 'Korin', 'Marlen', 'Perrin'],
+    female: ['Aurelia', 'Eliane', 'Ilvara', 'Marlenna', 'Selene', 'Serapha', 'Tella'],
+    nonbinary: ['Aris', 'Cerin', 'Lior', 'Mira'],
+    family: [
+      'Anchorfast',
+      'Brinebark',
+      'Brinemarrow',
+      'Cristalle',
+      'Threadneedle',
+      'Woodhand',
+      'Seawind',
+      'Saltroot',
+      'Emberflask',
+      'Leafpress',
+    ],
+  },
+  guild: {
+    male: ['Brakka', 'Darel', 'Pell', 'Storm', 'Sella', 'Tolen', 'Yarik'],
+    female: ['Aelric', 'Liora', 'Maren', 'Mira', 'Neris', 'Seren', 'Ysa'],
+    nonbinary: ['Corvel', 'Rellis', 'Valen'],
+    family: ['Ironbent', 'Stormkeel', 'Crestshield', 'Rollingwave', 'Saltmaster', 'Calderis', 'Selkanet', 'Stonebridge'],
+  },
+  noble: {
+    male: ['Delmar', 'Highran', 'Lysandor', 'Marlon', 'Thalen'],
+    female: ['Aurena', 'Calisse', 'Lyselle', 'Serenna', 'Veleth'],
+    nonbinary: ['Aurel', 'Selian'],
+    family: ['Highward', 'Delmare', 'Lyrecrown', 'Marblefinch', 'Aurora', 'Goldleaf'],
+  },
+  clergy: {
+    male: ['Callus', 'Helion', 'Maerin', 'Torlan'],
+    female: ['Maela', 'Sunya', 'Tideia', 'Vara'],
+    nonbinary: ['Grels', 'Lumin'],
+    family: ['Tideborn', 'Tidecaller', 'Sunward', 'Greensoul', 'Harvestmother', 'Shieldmarch'],
+  },
+  military: {
+    male: ['Arel', 'Brisa', 'Ilyan', 'Kass', 'Orven'],
+    female: ['Brisa', 'Nyla', 'Selune', 'Tersa'],
+    nonbinary: ['Hullen', 'Ryn', 'Yorsen'],
+    family: ['Gatewatch', 'Shieldmarch', 'Tidewatcher', 'Ironwatch'],
+  },
+  academic: {
+    male: ['Bright', 'Callis', 'Rellis', 'Thalen'],
+    female: ['Ilvara', 'Mera', 'Selise', 'Varia'],
+    nonbinary: ['Aeris', 'Lior', 'Quill'],
+    family: ['Brightmere', 'Leafward', 'Quillion', 'Starweaver', 'Cristalle'],
+  },
+  any: {
+    male: [],
+    female: [],
+    nonbinary: [],
+    family: [],
+  },
+};
+
+const ELF_NAMES: RaceNameData = {
+  any: {
+    male: ['Aelar', 'Theron', 'Fenian', 'Lethar'],
+    female: ['Aelene', 'Sylvaris', 'Thalisa', 'Liarel'],
+    nonbinary: ['Caelith', 'Rythian', 'Velis'],
+    family: ['Moonglade', 'Silverfrond', 'Starwind', 'Riverwhisper', 'Leafglade'],
+  },
+  commoner: { male: [], female: [], nonbinary: [], family: [] },
+  artisan: { male: [], female: [], nonbinary: [], family: [] },
+  guild: { male: [], female: [], nonbinary: [], family: [] },
+  noble: { male: [], female: [], nonbinary: [], family: [] },
+  clergy: { male: [], female: [], nonbinary: [], family: [] },
+  military: { male: [], female: [], nonbinary: [], family: [] },
+  academic: { male: [], female: [], nonbinary: [], family: [] },
+};
+
+const DWARF_NAMES: RaceNameData = {
+  any: {
+    male: ['Borin', 'Karrin', 'Rurik', 'Thorin'],
+    female: ['Dagna', 'Hildi', 'Mava', 'Sigrid'],
+    nonbinary: ['Astri', 'Broden', 'Lorn'],
+    family: ['Stoneforge', 'Ironvein', 'Coppervein', 'Stormhammer', 'Deepdelve'],
+  },
+  commoner: { male: [], female: [], nonbinary: [], family: [] },
+  artisan: { male: [], female: [], nonbinary: [], family: [] },
+  guild: { male: [], female: [], nonbinary: [], family: [] },
+  noble: { male: [], female: [], nonbinary: [], family: [] },
+  clergy: { male: [], female: [], nonbinary: [], family: [] },
+  military: { male: [], female: [], nonbinary: [], family: [] },
+  academic: { male: [], female: [], nonbinary: [], family: [] },
+};
+
+const HALFLING_NAMES: RaceNameData = {
+  any: {
+    male: ['Perrin', 'Milo', 'Thom', 'Wylan'],
+    female: ['Lily', 'Tamsin', 'Briala', 'Rysa'],
+    nonbinary: ['Brindle', 'Fen', 'Quince'],
+    family: ['Tealeaf', 'Underbough', 'Fairbarrel', 'Goodbarrel', 'Greenbottle'],
+  },
+  commoner: { male: [], female: [], nonbinary: [], family: [] },
+  artisan: { male: [], female: [], nonbinary: [], family: [] },
+  guild: { male: [], female: [], nonbinary: [], family: [] },
+  noble: { male: [], female: [], nonbinary: [], family: [] },
+  clergy: { male: [], female: [], nonbinary: [], family: [] },
+  military: { male: [], female: [], nonbinary: [], family: [] },
+  academic: { male: [], female: [], nonbinary: [], family: [] },
+};
+
+const NAME_DATA: Record<Race, RaceNameData> = {
+  Human: HUMAN_NAMES,
+  Elf: ELF_NAMES,
+  Dwarf: DWARF_NAMES,
+  Halfling: HALFLING_NAMES,
+};
+
+const DEFAULT_RACE: Race = 'Human';
+const DEFAULT_SEX: Sex = 'Female';
+const DEFAULT_STATION: Station = 'commoner';
+
+const usedGivenNames = new Map<string, Set<string>>();
+const usedFamilyNames = new Map<string, Set<string>>();
+const familyRegistry = new Map<string, { familyName: string; race: Race; station: Station }>();
+
+function stationKey(race: Race, station: Station, sex: Sex) {
+  return `${race}:${station}:${sex}`;
+}
+
+function familyKey(race: Race, station: Station) {
+  return `${race}:${station}`;
+}
+
+function getStationData(race: Race, station: Station): StationNameSet {
+  const raceData = NAME_DATA[race] || NAME_DATA[DEFAULT_RACE];
+  const data = raceData[station];
+  if (data && (data.male.length || data.female.length || data.nonbinary.length || data.family.length)) {
+    return data;
+  }
+  return raceData.any;
+}
+
+function ensureSet(map: Map<string, Set<string>>, key: string) {
+  let set = map.get(key);
+  if (!set) {
+    set = new Set();
+    map.set(key, set);
+  }
+  return set;
+}
+
+function pickFromList(list: string[], used: Set<string>, allowReuse?: boolean): string {
+  for (const value of list) {
+    if (!used.has(value)) {
+      used.add(value);
+      return value;
+    }
+  }
+  if (!list.length) {
+    return '';
+  }
+  if (allowReuse) {
+    const choice = list[0];
+    used.clear();
+    used.add(choice);
+    return choice;
+  }
+  used.clear();
+  const choice = list[0];
+  used.add(choice);
+  return choice;
+}
+
+function pickGivenName(
+  race: Race,
+  station: Station,
+  sex: Sex,
+  allowReuse?: boolean,
+): string {
+  const stationData = getStationData(race, station);
+  const key = stationKey(race, station, sex);
+  const used = ensureSet(usedGivenNames, key);
+  let candidates: string[] = [];
+  if (sex === 'Male') {
+    candidates = stationData.male.length ? stationData.male : stationData.female.concat(stationData.nonbinary);
+  } else if (sex === 'Female') {
+    candidates = stationData.female.length ? stationData.female : stationData.male.concat(stationData.nonbinary);
+  } else {
+    candidates = stationData.nonbinary.length
+      ? stationData.nonbinary
+      : stationData.male.concat(stationData.female);
+  }
+  if (!candidates.length) {
+    candidates = ['Adventurer'];
+  }
+  return pickFromList(candidates, used, allowReuse);
+}
+
+function pickFamilyName(
+  race: Race,
+  station: Station,
+  allowReuse?: boolean,
+): string {
+  const stationData = getStationData(race, station);
+  const key = familyKey(race, station);
+  const used = ensureSet(usedFamilyNames, key);
+  const candidates = stationData.family.length ? stationData.family : ['Freelancer'];
+  return pickFromList(candidates, used, allowReuse);
+}
+
+export function registerFamily(
+  key: string,
+  familyName: string,
+  opts: { race?: Race; station?: Station } = {},
+) {
+  const race = opts.race || DEFAULT_RACE;
+  const station = opts.station || DEFAULT_STATION;
+  familyRegistry.set(key, { familyName, race, station });
+  const used = ensureSet(usedFamilyNames, familyKey(race, station));
+  used.add(familyName);
+}
+
+export function clearNameGenerator() {
+  usedGivenNames.clear();
+  usedFamilyNames.clear();
+  familyRegistry.clear();
+}
+
+export function generateNpcName(options: NameOptions = {}): GeneratedNpcName {
+  const race = options.race || DEFAULT_RACE;
+  const station = options.station || DEFAULT_STATION;
+  const sex = options.sex || DEFAULT_SEX;
+  const allowReuse = options.allowReuse ?? false;
+
+  let familyName: string;
+  if (options.familyKey) {
+    const existing = familyRegistry.get(options.familyKey);
+    if (existing) {
+      familyName = existing.familyName;
+    } else if (options.familyName) {
+      familyName = options.familyName;
+      registerFamily(options.familyKey, familyName, { race, station });
+    } else {
+      familyName = pickFamilyName(race, station, allowReuse);
+      registerFamily(options.familyKey, familyName, { race, station });
+    }
+  } else if (options.familyName) {
+    familyName = options.familyName;
+  } else {
+    familyName = pickFamilyName(race, station, allowReuse);
+  }
+
+  const givenName = pickGivenName(race, station, sex, allowReuse);
+  const fullName = `${givenName} ${familyName}`.trim();
+
+  return {
+    race,
+    sex,
+    station,
+    givenName,
+    familyName,
+    fullName,
+  };
+}

--- a/assets/data/waves_break_registry.js
+++ b/assets/data/waves_break_registry.js
@@ -1,0 +1,1171 @@
+const GROUP_BINDINGS = {
+    farmland: { region: "waves_break", habitat: 'farmland', district: 'Farmlands' },
+    port: { region: "waves_break", habitat: 'coastal', district: 'Harbor Ward' },
+    upper: { region: "waves_break", habitat: 'urban', district: 'Upper Ward' },
+    terns: { region: "waves_break", habitat: 'urban', district: 'Little Terns' },
+    greensoul: { region: "waves_break", habitat: 'urban', district: 'Greensoul Hill' },
+    gardens: { region: "waves_break", habitat: 'urban', district: 'Lower Gardens' },
+    highroad: { region: "waves_break", habitat: 'urban', district: 'High Road' },
+};
+const DEFAULT_GROUP_BINDING = { region: "waves_break", habitat: 'urban', district: "Wave's Break" };
+const CLAMP_VALUE = (value, min, max) => Math.min(max, Math.max(min, value));
+function getGroupBinding(group) {
+    const base = GROUP_BINDINGS[group];
+    if (!base)
+        return Object.assign({}, DEFAULT_GROUP_BINDING);
+    return Object.assign({}, base);
+}
+function extractSeasons(text) {
+    const seasons = new Set();
+    if (/spring/.test(text))
+        seasons.add('Spring');
+    if (/(summer|midsummer)/.test(text))
+        seasons.add('Summer');
+    if (/(autumn|fall|harvest)/.test(text))
+        seasons.add('Autumn');
+    if (/(winter|frost|snow)/.test(text))
+        seasons.add('Winter');
+    if (/(dry-season|dry season)/.test(text)) {
+        seasons.add('Summer');
+        seasons.add('Autumn');
+    }
+    if (/(monsoon|rainy|wet season)/.test(text)) {
+        seasons.add('Spring');
+        seasons.add('Autumn');
+    }
+    return Array.from(seasons);
+}
+function detectUrgency(text) {
+    if (/(emergency|immediate|urgent|rush|levy|alarm)/.test(text))
+        return 'emergency';
+    if (/(surge|reinforce|supplement|muster|shortfall|boost)/.test(text))
+        return 'elevated';
+    return 'routine';
+}
+function parseLaborConditionForVisibility(condition, business) {
+    const raw = [condition === null || condition === void 0 ? void 0 : condition.season, condition === null || condition === void 0 ? void 0 : condition.trigger, condition === null || condition === void 0 ? void 0 : condition.description]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+    const seasons = extractSeasons(raw);
+    const requiresStorm = /(storm|gale|squall|tempest|hurricane|deluge|seawall|breach|surge)/.test(raw);
+    const requiresFlood = /(flood|overflow|washout|inundated|breach|spillway)/.test(raw);
+    const requiresDry = /(dry|drought|kiln|low humidity|sun-baked|parched|dust)/.test(raw) && !requiresFlood;
+    const requiresHarvest = /(harvest|vintage|press|picking|shear|gather|reap|trawl)/.test(raw);
+    const requiresFestival = /(festival|faire|games|regatta|tournament|celebration|market day|pageant)/.test(raw);
+    const requiresCold = /(winter|frost|ice|snow|blizzard|cold snap)/.test(raw);
+    const requiresHeat = requiresDry || /(summer|heat|scorch|kiln|dry-season)/.test(raw);
+    const urgency = detectUrgency(raw);
+    let baseDemand = 0.35;
+    if (business.category === 'security' || business.category === 'logistics')
+        baseDemand += 0.05;
+    if (business.category === 'support')
+        baseDemand -= 0.05;
+    if (urgency === 'elevated')
+        baseDemand += 0.2;
+    if (urgency === 'emergency')
+        baseDemand += 0.4;
+    if (requiresStorm || requiresFlood)
+        baseDemand += 0.2;
+    if (requiresDry)
+        baseDemand += 0.12;
+    if (requiresHarvest)
+        baseDemand += 0.15;
+    if (requiresFestival)
+        baseDemand += 0.1;
+    const eventTag = requiresStorm
+        ? 'storm_response'
+        : requiresFlood
+            ? 'flood_relief'
+            : requiresDry
+                ? 'dry_spell'
+                : requiresHarvest
+                    ? 'harvest'
+                    : requiresFestival
+                        ? 'festival'
+                        : undefined;
+    return {
+        seasons,
+        requiresStorm,
+        requiresDry,
+        requiresFlood,
+        requiresHarvest,
+        requiresFestival,
+        requiresCold,
+        requiresHeat,
+        urgency,
+        baseDemand,
+        eventTag,
+    };
+}
+function shouldAllowSeason(seasons, currentSeason) {
+    if (!seasons.length)
+        return true;
+    return seasons.includes(currentSeason);
+}
+function applyQuestVisibilityToBusiness(business, binding) {
+    var _a;
+    const quests = business.quests || [];
+    quests.forEach((quest, index) => {
+        const laborCondition = (_a = business.laborConditions) === null || _a === void 0 ? void 0 : _a[index];
+        quest.laborCondition = laborCondition;
+        const baseBinding = Object.assign({ region: binding.region, habitat: binding.habitat, district: binding.district, business: business.name });
+        quest.visibilityBinding = quest.visibilityBinding
+            ? Object.assign(Object.assign({}, quest.visibilityBinding), baseBinding) : baseBinding;
+        if (!quest.visibility) {
+            quest.visibility = createQuestVisibilityRule(business, laborCondition);
+        }
+    });
+}
+function createQuestVisibilityRule(business, condition) {
+    const parsed = parseLaborConditionForVisibility(condition, business);
+    const trigger = condition === null || condition === void 0 ? void 0 : condition.trigger;
+    return (context) => {
+        const { weather, random, binding } = context;
+        if (!shouldAllowSeason(parsed.seasons, weather.season)) {
+            return {
+                available: false,
+                demand: 0.05,
+                reason: `Work resumes in ${parsed.seasons.join(', ') || 'the proper season'}.`,
+                eventTag: parsed.eventTag,
+            };
+        }
+        if (parsed.requiresStorm) {
+            const eventActive = weather.storm || weather.floodRisk !== 'none' || weather.outlook.stormLikely;
+            if (!eventActive) {
+                return {
+                    available: false,
+                    demand: 0.1,
+                    reason: 'Awaiting storm or surge conditions.',
+                    eventTag: parsed.eventTag,
+                };
+            }
+        }
+        if (parsed.requiresFlood) {
+            const floodActive = weather.floodRisk !== 'none' || weather.trend.wetSpellDays >= 4 || weather.outlook.floodLikely;
+            if (!floodActive) {
+                return {
+                    available: false,
+                    demand: 0.12,
+                    reason: 'Flood controls currently holding.',
+                    eventTag: parsed.eventTag,
+                };
+            }
+        }
+        if (parsed.requiresDry) {
+            const dryActive = weather.droughtStage !== 'none' || weather.trend.drySpellDays >= 3 || weather.outlook.drySpellLikely;
+            if (!dryActive) {
+                return {
+                    available: false,
+                    demand: 0.12,
+                    reason: 'Moisture levels sufficient; dry-run not yet needed.',
+                    eventTag: parsed.eventTag,
+                };
+            }
+        }
+        if (parsed.requiresHarvest) {
+            const harvestSeason = weather.season === 'Autumn' || weather.season === 'Summer';
+            if (!harvestSeason) {
+                return {
+                    available: false,
+                    demand: 0.08,
+                    reason: 'Harvest crews wait for fields to ripen.',
+                    eventTag: parsed.eventTag,
+                };
+            }
+        }
+        if (parsed.requiresFestival) {
+            const festivalWindow = weather.season === 'Summer' || weather.season === 'Spring' || random() < 0.2;
+            if (!festivalWindow) {
+                return {
+                    available: false,
+                    demand: 0.08,
+                    reason: 'No festival preparations scheduled.',
+                    eventTag: parsed.eventTag,
+                };
+            }
+        }
+        if (parsed.requiresCold && weather.temperatureC > 6) {
+            return {
+                available: false,
+                demand: 0.06,
+                reason: 'Conditions are too mild for winter tasks.',
+                eventTag: parsed.eventTag,
+            };
+        }
+        if (parsed.requiresHeat && weather.temperatureC < 10 && weather.season !== 'Summer') {
+            return {
+                available: false,
+                demand: 0.06,
+                reason: 'Heat-dependent work paused until warmer days.',
+                eventTag: parsed.eventTag,
+            };
+        }
+        let demand = parsed.baseDemand;
+        demand += weather.outlook.demandModifier;
+        if (parsed.requiresDry && weather.droughtStage === 'warning')
+            demand += 0.25;
+        if (parsed.requiresStorm && weather.storm)
+            demand += 0.2;
+        if (parsed.requiresFlood && weather.floodRisk === 'warning')
+            demand += 0.25;
+        if (parsed.requiresHarvest && weather.season === 'Autumn')
+            demand += 0.2;
+        if (parsed.urgency === 'routine' && weather.trend.drySpellDays > 5)
+            demand += 0.08;
+        if (binding.habitat === 'farmland' && weather.droughtStage !== 'none')
+            demand += 0.05;
+        if (binding.habitat === 'coastal' && weather.storm)
+            demand += 0.05;
+        demand = CLAMP_VALUE(demand, 0.05, 0.95);
+        const available = random() < demand;
+        return {
+            available,
+            demand,
+            reason: available
+                ? trigger || 'Work crews are being mustered.'
+                : 'Quotas already filled for this rotation.',
+            eventTag: parsed.eventTag,
+        };
+    };
+}
+const FARMLAND_BUSINESSES = [
+    "Bayside Brickworks",
+    "Brackenshore Croft",
+    "Cliffblossom Hives",
+    "Cliffbreak Quarry",
+    "Coast Road Watchtower",
+    "Copperbrook Forge",
+    "Driftfell Meadow",
+    "East Road to Mountain Top",
+    "Foamfield Flax Farm",
+    "Greenridge Polder",
+    "Gulls' Orchard",
+    "Gullwind Mill",
+    "Harborwind Dairy",
+    "Mistflower Apiary",
+    "Moorlight Flats",
+    "Netmaker's Co-op",
+    "North Gate",
+    "Saltcrest Vineyard & Winery",
+    "Saltmarsh Granary",
+    "Saltmeadow Potato Farm",
+    "Seabreeze Oat Farm",
+    "Seawisp Plum Orchard",
+    "South Gate",
+    "Sunmellow Grove",
+    "Tideflock Stockyards",
+    "Tidewatcher Lighthouse",
+    "Tidewheel Watermill",
+    "Wavecut Stoneworks",
+    "Windward Berry Vineyard & Winery",
+];
+const PORT_BUSINESSES = [
+    "Harborwatch Trading House",
+    "Stormkeel Shipwrights",
+    "Harbor Guard Naval Yard",
+    "Saltworks",
+    "Fishmongers' Row",
+    "The Ropewalk",
+];
+const UPPER_WARD_BUSINESSES = [
+    "Governor's Keep",
+    "Hall of Records",
+    "Mercantile Exchange",
+    "Master Jeweler's Guildhall",
+    "Highward Vintners' Salon",
+    "Aurelian Apothecarium & Perfumery",
+];
+const LITTLE_TERNS_BUSINESSES = [
+    "Guild of Smiths",
+    "Timberwave Carpenters' Guild",
+    "Carvers' and Fletchers' Hall",
+    "The Gilded Needle Clothiers",
+    "Brine & Bark Tannery",
+    "Seawind Sailmakers' Hall",
+];
+const GREENSOUL_HILL_BUSINESSES = [
+    "Grand Library of Wave's Break",
+    "Arcanists' Enclave",
+    "Herbal Conservatory",
+    "Skyline Academy",
+    "Temple of the Tides",
+    "Candlewrights' Guild",
+];
+const LOWER_GARDENS_BUSINESSES = [
+    "Quayside Greens Market",
+    "South Gate Market",
+    "Seastone Arena",
+    "Wisteria Pavilion",
+    "Anchor's Toast Brewery",
+    "Sunleaf Inn",
+];
+const HIGH_ROAD_BUSINESSES = [
+    "Adventurers' Guildhall",
+    "Rolling Wave Coachworks",
+    "Wavehide Leather Guild",
+    "Shield & Sail Armsmiths",
+    "Gatewatch Barracks",
+    "Stonebridge Caravanserai",
+];
+const FARMLAND_BOARD_PLAN = {
+    "North Gate Labor Postings": [
+        "Bayside Brickworks",
+        "Cliffbreak Quarry",
+        "Coast Road Watchtower",
+        "Copperbrook Forge",
+        "East Road to Mountain Top",
+        "Greenridge Polder",
+        "Mistflower Apiary",
+        "Netmaker's Co-op",
+        "North Gate",
+        "Tidewatcher Lighthouse",
+        "Tidewheel Watermill",
+        "Wavecut Stoneworks",
+    ],
+    "South Gate Field Contracts": [
+        "Brackenshore Croft",
+        "Cliffblossom Hives",
+        "Driftfell Meadow",
+        "Foamfield Flax Farm",
+        "Gulls' Orchard",
+        "Gullwind Mill",
+        "Harborwind Dairy",
+        "Moorlight Flats",
+        "Saltcrest Vineyard & Winery",
+        "Saltmarsh Granary",
+        "Saltmeadow Potato Farm",
+        "Seabreeze Oat Farm",
+        "Seawisp Plum Orchard",
+        "South Gate",
+        "Sunmellow Grove",
+        "Tideflock Stockyards",
+        "Windward Berry Vineyard & Winery",
+    ],
+};
+const PORT_BOARD_PLAN = {
+    "Harborwatch Quay Ledger": ["Harborwatch Trading House"],
+    "Stormkeel Slipway Mast": ["Stormkeel Shipwrights"],
+    "Naval Yard Muster Wall": ["Harbor Guard Naval Yard"],
+    "Saltworks Evaporation Gate": ["Saltworks"],
+    "Fishmongers' Stall Hooks": ["Fishmongers' Row"],
+    "Ropewalk Entry Plaques": ["The Ropewalk"],
+};
+const UPPER_WARD_BOARD_PLAN = {
+    "Governor's Keep Gatehouse Registry": ["Governor's Keep", "Hall of Records"],
+    "Highward Mercantile Ledger": ["Mercantile Exchange", "Highward Vintners' Salon"],
+    "Adventurers' Guild Liaison Counter": [
+        "Master Jeweler's Guildhall",
+        "Aurelian Apothecarium & Perfumery",
+    ],
+};
+const LITTLE_TERNS_BOARD_PLAN = {
+    "Guild of Smiths Forge Gate": ["Guild of Smiths"],
+    "Timberwave Yard Posting": ["Timberwave Carpenters' Guild"],
+    "Carvers' Hall Chisel Board": ["Carvers' and Fletchers' Hall"],
+    "Gilded Needle Facade Placards": ["The Gilded Needle Clothiers"],
+    "Brine & Bark Headhouse": ["Brine & Bark Tannery"],
+    "Seawind Loft Rail": ["Seawind Sailmakers' Hall"],
+};
+const GREENSOUL_HILL_BOARD_PLAN = {
+    "Grand Library Request Desk": ["Grand Library of Wave's Break"],
+    "Arcanists' Gatehouse Wards": ["Arcanists' Enclave"],
+    "Herbal Conservatory Loggia": ["Herbal Conservatory"],
+    "Skyline Academy Posting Column": ["Skyline Academy"],
+    "Temple of the Tides Ledger": ["Temple of the Tides"],
+    "Candlewrights' Guild Lantern Wall": ["Candlewrights' Guild"],
+};
+const LOWER_GARDENS_BOARD_PLAN = {
+    "South Gate Market Posting Wall": [
+        "South Gate Market",
+        "Quayside Greens Market",
+        "Anchor's Toast Brewery",
+    ],
+    "Arena Promenade Notices": ["Seastone Arena", "Wisteria Pavilion", "Sunleaf Inn"],
+};
+const HIGH_ROAD_BOARD_PLAN = {
+    "Adventurers' Guild Contract Archive": ["Adventurers' Guildhall"],
+    "Caravan Square Contract Wall": [
+        "Rolling Wave Coachworks",
+        "Wavehide Leather Guild",
+        "Shield & Sail Armsmiths",
+        "Stonebridge Caravanserai",
+    ],
+    "Gatewatch Muster Board": ["Gatewatch Barracks"],
+};
+const ALL_BUSINESS_GROUPS = new Map([
+    ["farmland", FARMLAND_BUSINESSES],
+    ["port", PORT_BUSINESSES],
+    ["upper", UPPER_WARD_BUSINESSES],
+    ["terns", LITTLE_TERNS_BUSINESSES],
+    ["greensoul", GREENSOUL_HILL_BUSINESSES],
+    ["gardens", LOWER_GARDENS_BUSINESSES],
+    ["highroad", HIGH_ROAD_BUSINESSES],
+]);
+const ALL_BOARD_PLANS = [
+    FARMLAND_BOARD_PLAN,
+    PORT_BOARD_PLAN,
+    UPPER_WARD_BOARD_PLAN,
+    LITTLE_TERNS_BOARD_PLAN,
+    GREENSOUL_HILL_BOARD_PLAN,
+    LOWER_GARDENS_BOARD_PLAN,
+    HIGH_ROAD_BOARD_PLAN,
+];
+function cloneQuestForBoard(quest, boardName, businessName, binding) {
+    const visibilityBinding = Object.assign(Object.assign({}, binding), { board: boardName, business: businessName });
+    const notes = quest.notes
+        ? `${quest.notes} Posted on the ${boardName}; report to ${businessName}.`
+        : `Posted on the ${boardName}; report to ${businessName}.`;
+    return Object.assign(Object.assign({}, quest), { notes, visibilityBinding: quest.visibilityBinding
+            ? Object.assign(Object.assign({}, quest.visibilityBinding), visibilityBinding) : visibilityBinding });
+}
+function filterBusinesses(businesses, names) {
+    if (!(businesses === null || businesses === void 0 ? void 0 : businesses.length))
+        return [];
+    const allowed = new Set(names);
+    return businesses.filter((business) => allowed.has(business.name));
+}
+function collectBoardQuests(businesses, plan, binding) {
+    if (!(businesses === null || businesses === void 0 ? void 0 : businesses.length))
+        return {};
+    const index = new Map(businesses.map((b) => [b.name, b]));
+    const boards = {};
+    Object.entries(plan).forEach(([boardName, businessNames]) => {
+        const quests = [];
+        businessNames.forEach((name) => {
+            const business = index.get(name);
+            if (!business)
+                return;
+            business.quests.forEach((quest) => {
+                quests.push(cloneQuestForBoard(quest, boardName, business.name, binding));
+            });
+        });
+        if (quests.length) {
+            boards[boardName] = quests;
+        }
+    });
+    return boards;
+}
+const WAVES_BREAK_BUSINESS_OWNERS = {
+    // Farmlands and hinterland holdings
+    "Bayside Brickworks": {
+        owner: "Tidemold Kiln-Family",
+        stewards: ["Master Kilner Varla Tidemold"],
+        notes: "Harborworks charters the Tidemolds to keep coastal brick supplies moving.",
+    },
+    "Brackenshore Croft": {
+        owner: "Saltbound Terrace Estate",
+        stewards: ["Field-reeve Maera Saltbound"],
+        notes: "Stone-terraced barley fields leased from the Saltbound family to trusted reeves.",
+    },
+    "Cliffblossom Hives": {
+        owner: "Cliffbloom Apiarists",
+        stewards: ["Honeywarden Sera Cliffbloom"],
+        notes: "Cliffbloom cousins rotate stewardship of the cliffside apiaries each season.",
+    },
+    "Cliffbreak Quarry": {
+        owner: "Cliffbreak Stone Consortium",
+        stewards: ["Foreman Brann Cliffbreak"],
+        notes: "Stone blocks cut under Cliffbreak contracts for harbor walls and export orders.",
+    },
+    "Coast Road Watchtower": {
+        owner: "Wave's Break",
+        stewards: ["Gatewatch Command Council"],
+        notes: "City watch captains rotate garrison command on coastal beacons.",
+    },
+    "Copperbrook Forge": {
+        owner: "Copperbrook Forgehold",
+        stewards: ["Smith Barun Copperbrook"],
+        notes: "Forgehold turns out hinges, plowshares, and tool repairs for the northern farms.",
+    },
+    "Driftfell Meadow": {
+        owner: "Driftfell Pastoral Estate",
+        stewards: ["Steward Elwin Driftfell"],
+        notes: "Estate leases meadow grazing to drover families supporting Gatewatch mounts.",
+    },
+    "East Road to Mountain Top": {
+        owner: "Wave's Break",
+        stewards: ["Road Warden Arel"],
+        notes: "Municipal wardens patrol the vital overland artery toward Mountain Top caravans.",
+    },
+    "Foamfield Flax Farm": {
+        owner: "Foamfield Kinstead",
+        stewards: ["Farmholder Deryn Foamfield"],
+        notes: "Foamfield kin spin flax for sailcloth and canvas bound for the harbor.",
+    },
+    "Greenridge Polder": {
+        owner: "Tidebinder Family Trust",
+        stewards: ["Reeve Galen Tidebinder"],
+        notes: "Levees and sluices carved by the Tidebinder trust keep reclaimed marshland fertile.",
+    },
+    "Gulls' Orchard": {
+        owner: "Seafeather Orchard Family",
+        stewards: ["Orchard Mistress Riala Seafeather"],
+        notes: "Seafeather ciders fill Greensoul cellars and South Gate presses.",
+    },
+    "Gullwind Mill": {
+        owner: "Gullwind Milling House",
+        stewards: ["Master Miller Joran Gullwind"],
+        notes: "Millstones grind grain for Saltmarsh granaries and caravan flour rations.",
+    },
+    "Harborwind Dairy": {
+        owner: "Harborwind Dairy Clan",
+        stewards: ["Matron Helda Harborwind"],
+        notes: "Butter and soft cheeses travel daily to the South Gate markets.",
+    },
+    "Mistflower Apiary": {
+        owner: "Mistflower Apiarists",
+        stewards: ["Keeper Lileth Mistflower"],
+        notes: "Perfumed honeys bound for Greensoul apothecaries are bottled here.",
+    },
+    "Moorlight Flats": {
+        owner: "Moorlight Drovers' Estate",
+        stewards: ["Herdmaster Vel Moorlight"],
+        notes: "Moorlight family contracts pasture to drovers fattening caravans' draft herds.",
+    },
+    "Netmaker's Co-op": {
+        owner: "Selkanet Cooperative",
+        stewards: ["Factor Selka Tideknot"],
+        notes: "Selkanet knotters lease looms along the riverbank under Harborworks quotas.",
+    },
+    "North Gate": {
+        owner: "Wave's Break",
+        stewards: ["Gate Sergeant Hullen"],
+        notes: "City gate operations fall under the Gatewatch barracks commander's remit.",
+    },
+    "Saltcrest Vineyard & Winery": {
+        owner: "Saltcrest Vintner Estate",
+        stewards: ["Master Vintner Aelric Saltcrest"],
+        notes: "Saltcrest casks age in cliffside vaults before shipping inland.",
+    },
+    "Saltmarsh Granary": {
+        owner: "Wave's Break",
+        stewards: ["Keeper Torv Saltmarsh"],
+        notes: "City granary holds gate tithe grain and fleet provisions under civic contract.",
+    },
+    "Saltmeadow Potato Farm": {
+        owner: "Saltmeadow Family Holding",
+        stewards: ["Farmer Ina Saltmeadow"],
+        notes: "Saltmeadow rows keep the city supplied with tubers during winter.",
+    },
+    "Seabreeze Oat Farm": {
+        owner: "Seabreeze Grainstead",
+        stewards: ["Steward Neris Seabreeze"],
+        notes: "Oat harvests feed caravan teams bound for the East Road.",
+    },
+    "Seawisp Plum Orchard": {
+        owner: "Seawisp Orchard Collective",
+        stewards: ["Harvestkeeper Lora Seawisp"],
+        notes: "Orchard families share tenancy while the Seawisp matriarch controls exports.",
+    },
+    "South Gate": {
+        owner: "Wave's Break",
+        stewards: ["Captain Brisa Gatewatch"],
+        notes: "Southern gate patrols muster under Gatewatch command.",
+    },
+    "Sunmellow Grove": {
+        owner: "Dawnbloom Estate",
+        stewards: ["Sunmellow Grove Council"],
+        notes: "The Dawnbloom line leases plots to grove tenders producing aromatic fruits.",
+    },
+    "Tideflock Stockyards": {
+        owner: "Tideflock Drover Family",
+        stewards: ["Steward Mara Tideflock"],
+        notes: "Drover clans stage livestock bound for harbor barges and caravans.",
+    },
+    "Tidewatcher Lighthouse": {
+        owner: "Wave's Break",
+        stewards: ["Keeper Malen Tidewatcher"],
+        notes: "Guard engineers maintain the beacon and its sea-ward wards.",
+    },
+    "Tidewheel Watermill": {
+        owner: "Wave's Break",
+        stewards: ["Millwright Jessa Tidewheel"],
+        notes: "Municipal leases keep grain grinding for Saltmarsh stores even in flood season.",
+    },
+    "Wavecut Stoneworks": {
+        owner: "Wavecut Masonry Family",
+        stewards: ["Master Mason Corin Wavecut"],
+        notes: "Wavecut blocks supply Greensoul projects and harbor stairs.",
+    },
+    "Windward Berry Vineyard & Winery": {
+        owner: "Windward Vineyard Estate",
+        stewards: ["Vintner Soren Windward"],
+        notes: "Windward vintners bottle berry wine prized by Highward salons.",
+    },
+    // Port district consortiums
+    "Harborwatch Trading House": {
+        owner: "Calderis Ledger-Family",
+        stewards: ["Factor Merina Calderis"],
+        notes: "Calderis auditors hold the bonded keys for noble cargoes.",
+    },
+    "Stormkeel Shipwrights": {
+        owner: "Stormkeel Dockwright Dynasty",
+        stewards: ["Foreman Daska Stormkeel"],
+        notes: "Stormkeel slips lay keels for royal cutters and merchant carracks alike.",
+    },
+    "Harbor Guard Naval Yard": {
+        owner: "Wave's Break",
+        stewards: ["Captain Yorsen of the Harbor Guard"],
+        notes: "Fleet tenders answer to the harbor admiralty office.",
+    },
+    "Saltworks": {
+        owner: "Saltmaster Family Cooperative",
+        stewards: ["Saltmaster Rinna"],
+        notes: "The Saltmaster kin boil brine for fleet rations under city quotas.",
+    },
+    "Fishmongers' Row": {
+        owner: "Selune-Osprey Fishmongers",
+        stewards: ["Dockmaster Selune Osprey"],
+        notes: "Pier stalls are rotated among Osprey cousins per tide schedule.",
+    },
+    "The Ropewalk": {
+        owner: "Strandbinder Cooperative",
+        stewards: ["Rope-master Galen Strandbinder"],
+        notes: "Longhouse spinners fulfill navy towline orders and harbor moorings.",
+    },
+    // Upper Ward charters
+    "Governor's Keep": {
+        owner: "Wave's Break",
+        stewards: ["Chamberlain Veleth"],
+        notes: "Civic bastion housing council chambers and vaults.",
+    },
+    "Hall of Records": {
+        owner: "Wave's Break",
+        stewards: ["Provost Malenne"],
+        notes: "Archive clerks maintain civic ledgers and deeds.",
+    },
+    "Mercantile Exchange": {
+        owner: "Dorel Mercantile Charter",
+        stewards: ["High Factor Dorel"],
+        notes: "Exchange tribunal brokers high-value contracts for noble investors.",
+    },
+    "Master Jeweler's Guildhall": {
+        owner: "Vain Jewelcraft Charter",
+        stewards: ["Master Jeweler Serapha Vain"],
+        notes: "Gemcutters and setters hold guild courts within the hall.",
+    },
+    "Highward Vintners' Salon": {
+        owner: "Highward Estate",
+        stewards: ["Sommelier Liora Highward"],
+        notes: "Private tasting rooms for noble vintages imported through Nobles' Quay.",
+    },
+    "Aurelian Apothecarium & Perfumery": {
+        owner: "Aurelian Lysenne Atelier",
+        stewards: ["Mistress Aurelia Lysenne"],
+        notes: "Perfumed tinctures crafted for Highward patrons and Greensoul healers.",
+    },
+    // Little Terns craft guilds
+    "Guild of Smiths": {
+        owner: "Ironbent Forgeclan",
+        stewards: ["Forge Captain Brakka Ironbent"],
+        notes: "Forge captaincy rotates through Ironbent lineages by guild vote.",
+    },
+    "Timberwave Carpenters' Guild": {
+        owner: "Woodhand Timber Charter",
+        stewards: ["Guildmistress Tella Woodhand"],
+        notes: "Woodhand families lease lumberyards and oversee apprentice crews.",
+    },
+    "Carvers' and Fletchers' Hall": {
+        owner: "Thornwright Carving Family",
+        stewards: ["Foreman Kale Thornwright"],
+        notes: "Thornwright foremen keep arrow and carving orders moving.",
+    },
+    "The Gilded Needle Clothiers": {
+        owner: "Threadneedle Atelier",
+        stewards: ["Mistress Seraphine Threadneedle"],
+        notes: "Threadneedle couturiers fit nobles and caravan masters alike.",
+    },
+    "Brine & Bark Tannery": {
+        owner: "Brinebark Tanning Family",
+        stewards: ["Steward Pell Brinebark"],
+        notes: "Hide curing yards that feed Wavehide leatherworks.",
+    },
+    "Seawind Sailmakers' Hall": {
+        owner: "Seawind Rigging Family",
+        stewards: ["Forewoman Maris Seawind"],
+        notes: "Sail looms stretch canvas for harbor barques and river luggers.",
+    },
+    // Greensoul Hill orders
+    "Grand Library of Wave's Break": {
+        owner: "Wave's Break",
+        stewards: ["Chief Archivist Rellis"],
+        notes: "Civic library chartered to preserve guild records and histories.",
+    },
+    "Arcanists' Enclave": {
+        owner: "Starweaver Arcanum Trust",
+        stewards: ["Archmage Selene Starweaver"],
+        notes: "Magister council licenses rituals and research.",
+    },
+    "Herbal Conservatory": {
+        owner: "Leafward Conservatory Estate",
+        stewards: ["Conservator Mera Leafward"],
+        notes: "Leafward apothecaries cultivate rare specimens for healers.",
+    },
+    "Skyline Academy": {
+        owner: "Brightmere Scholastic Charter",
+        stewards: ["Dean Callus Brightmere"],
+        notes: "Scholars train navigators, engineers, and court scribes.",
+    },
+    "Temple of the Tides": {
+        owner: "Tideborn Clerical House",
+        stewards: ["High Priestess Maela Tideborn"],
+        notes: "Temple guardians oversee coastal rites and pilgrim offerings.",
+    },
+    "Candlewrights' Guild": {
+        owner: "Candlewright Artisan Line",
+        stewards: ["Guildmaster Oren Candlewright"],
+        notes: "Waxmasters contract festival illuminations and civic beacons.",
+    },
+    // Lower Gardens and cultural quarter
+    "Quayside Greens Market": {
+        owner: "Greenside Market Council",
+        stewards: ["Steward Jessa Greenside"],
+        notes: "Greenside council allocates stalls to herb growers and foragers.",
+    },
+    "South Gate Market": {
+        owner: "Wave's Break",
+        stewards: ["Marketwarden Tarsa Hollow"],
+        notes: "South Gate market ground maintained by civic wardens.",
+    },
+    "Seastone Arena": {
+        owner: "Wave's Break",
+        stewards: ["Arena Master Garen Seastone"],
+        notes: "Arena master reports to the governor for games and levy musters.",
+    },
+    "Wisteria Pavilion": {
+        owner: "Neral Wisterian Estate",
+        stewards: ["Maestro Neral Wisterian"],
+        notes: "Recital hall hosting guild salons and noble performances.",
+    },
+    "Anchor's Toast Brewery": {
+        owner: "Anchorfast Brewing Family",
+        stewards: ["Brewmaster Tolen Anchorfast"],
+        notes: "Brew kettles feed the market taverns and caravan casks.",
+    },
+    "Sunleaf Inn": {
+        owner: "Sunleaf Hospitality Family",
+        stewards: ["Innkeeper Lysa Sunleaf"],
+        notes: "Garden court inn favored by scholars and visiting merchants.",
+    },
+    // High Road district contracts
+    "Adventurers' Guildhall": {
+        owner: "Crestshield Guild Charter",
+        stewards: ["Guildmaster Ryn Crestshield"],
+        notes: "Guild charter authorized by the crown and city governor.",
+    },
+    "Rolling Wave Coachworks": {
+        owner: "Rollingwave Coach Consortium",
+        stewards: ["Foreman Darel Rollingwave"],
+        notes: "Coachwright crews refit wagons before departure on the High Road.",
+    },
+    "Wavehide Leather Guild": {
+        owner: "Pell Leatherwright Family",
+        stewards: ["Guildmaster Pell"],
+        notes: "Leatherwright line oversees harness and armor commissions.",
+    },
+    "Shield & Sail Armsmiths": {
+        owner: "Sella Shieldwright Family",
+        stewards: ["Master Armorer Sella"],
+        notes: "Armsmith cooperative allied with Gatewatch contracts.",
+    },
+    "Gatewatch Barracks": {
+        owner: "Wave's Break",
+        stewards: ["Captain Ilyan Gatewatch"],
+        notes: "Barracks houses the Shieldbearer cadre and gate patrols.",
+    },
+    "Stonebridge Caravanserai": {
+        owner: "Nyla Stonebridge Trust",
+        stewards: ["Steward Nyla Stonebridge"],
+        notes: "Stonebridge trust rents bays to caravans staging in the High Road district.",
+    },
+};
+const WAVES_BREAK_BUILDING_OWNERS = {
+    // Port promenades
+    "Warehouse Row": {
+        owner: "Wave's Break",
+        stewards: ["Harborworks Quartermaster Lysa Tallis"],
+        notes: "Municipal bonded storage watched by harbor inspectors.",
+    },
+    "Nobles' Quay": {
+        owner: "House Delmare Quaywrights",
+        stewards: ["Harbormaster Vell Delmare"],
+        notes: "Reserved slips leased to highborn fleets through Delmare factors.",
+    },
+    "Merchants' Wharf": {
+        owner: "Merrow Syndicate",
+        stewards: ["Factor Alis Merrow"],
+        notes: "Syndicate factors rotate berths for merchant caravels.",
+    },
+    "Fisherman's Pier": {
+        owner: "Hookfin Netters",
+        stewards: ["Mistress Daila Hookfin"],
+        notes: "Pier space apportioned among Hookfin and Osprey fishing crews.",
+    },
+    "Brinebarrel Coopers": {
+        owner: "Brinebarrel Cooperage Family",
+        stewards: ["Cooper Hest Brinebarrel"],
+        notes: "Barrelwrights supply kegs for salters and breweries alike.",
+    },
+    "Shrine of the Deep Current": {
+        owner: "Tidecaller Priesthood",
+        stewards: ["Oracle Maerin Tidecaller"],
+        notes: "Dockside sailors leave offerings before each voyage.",
+    },
+    "Statue of the Sea-Mother": {
+        owner: "Wave's Break",
+        notes: "Civic monument maintained by harbor masons.",
+    },
+    "The Salty Gull": {
+        owner: "Gullring Hospitality",
+        stewards: ["Proprietor Edda Gullring"],
+        notes: "Favored tavern of fisher crews and visiting traders.",
+    },
+    "The Tideway Inn": {
+        owner: "Tideway Innkeep Family",
+        stewards: ["Innkeeper Dovan Tideway"],
+        notes: "Quayside inn welcoming caravan quartermasters waiting on cargo.",
+    },
+    "Navigator's Trust & Chart House": {
+        owner: "Chartwright Collegium",
+        stewards: ["Chartmaster Rhyl Chartwright"],
+        notes: "Map rooms track every convoy and tide across the gulf.",
+    },
+    // Upper Ward salons
+    "Marble Finch Supper Club": {
+        owner: "Marblefinch Gastronomy House",
+        stewards: ["Chef Aurel Marblefinch"],
+        notes: "Invitation-only suppers for the governor's council and visiting nobles.",
+    },
+    "Highward Terraces": {
+        owner: "Highward Estate",
+        stewards: ["Sommelier Liora Highward"],
+        notes: "Tiered gardens connecting the salon to Noble rowhouses.",
+    },
+    "Plaza of Banners": {
+        owner: "Wave's Break",
+        notes: "Ceremonial plaza displaying guild and caravan colors.",
+    },
+    "Goldleaf Atelier": {
+        owner: "Goldleaf Artisan Estate",
+        stewards: ["Master Crafter Irelle Goldleaf"],
+        notes: "Commission studio for noble regalia and ceremony gifts.",
+    },
+    "Engravers' Guild": {
+        owner: "Etchline Guild Family",
+        stewards: ["Guildmaster Corvel Etchline"],
+        notes: "Seal presses and insignia plates for civic offices.",
+    },
+    "Glassmakers' Hall": {
+        owner: "Cristalle Glasswright Circle",
+        stewards: ["Mistress Aurelia Cristalle"],
+        notes: "Master glassblowers share furnaces for noble commissions.",
+    },
+    "Crystal Tide Glassworks": {
+        owner: "Cristalle Glasswright Circle",
+        stewards: ["Journeyman Lysa Cristalle"],
+        notes: "Cooling galleries for stained panes exported to Coral Keep.",
+    },
+    "The Argent Griffin Inn": {
+        owner: "Argentgriff Hostelry",
+        stewards: ["Innkeeper Orel Argentgriff"],
+        notes: "Luxurious suites for dignitaries and guildmasters.",
+    },
+    // Craft ward extensions
+    "Tidefire Forge": {
+        owner: "Ironbent Forgeclan",
+        stewards: ["Forge Captain Brakka Ironbent"],
+        notes: "Guild forge dedicated to masterwork commissions.",
+    },
+    "Lumber Yard and Carpenter's Hall": {
+        owner: "Woodhand Timber Charter",
+        stewards: ["Guildmistress Tella Woodhand"],
+        notes: "Shared yard supplying beams to shipwrights and builders.",
+    },
+    "Threadneedle Hall": {
+        owner: "Threadneedle Atelier",
+        stewards: ["Mistress Seraphine Threadneedle"],
+        notes: "Pattern vault and journeyman dormitory for clothiers.",
+    },
+    "Seastone Ceramics": {
+        owner: "Seastone Kiln Family",
+        stewards: ["Potter Neris Seastone"],
+        notes: "Glazed tableware favored in Highward salons.",
+    },
+    "Brinemarrow Press": {
+        owner: "Brinemarrow Print Family",
+        stewards: ["Printer Hallen Brinemarrow"],
+        notes: "Broadside press handling guild notices and tavern playbills.",
+    },
+    "Tern Hook Butchery": {
+        owner: "Hooke & Tern Family",
+        stewards: ["Butcher Mara Hooke"],
+        notes: "Harbor butchers preparing catches for market stalls.",
+    },
+    "Driftwood Smokehouse": {
+        owner: "Driftwood Smoker Family",
+        stewards: ["Smokemaster Pell Driftwood"],
+        notes: "Cured fish destined for caravans and the Gatewatch mess.",
+    },
+    "Gull's Galley": {
+        owner: "Gullwharf Family",
+        stewards: ["Chef Ilven Gullwharf"],
+        notes: "Dockside eatery known for gull-egg pies and chowders.",
+    },
+    "Dockside Exchange Plaza": {
+        owner: "Wave's Break",
+        notes: "Open plaza where caravan factors meet arriving captains.",
+    },
+    "Saltroot Remedies": {
+        owner: "Saltroot Apothecaries",
+        stewards: ["Herbalist Vela Saltroot"],
+        notes: "Remedy counter for sailors and laborers nursing injuries.",
+    },
+    "Tern Harbor Commons": {
+        owner: "Wave's Break",
+        notes: "Common green hosting fisher markets and coastal festivals.",
+    },
+    "Cobbler's Square": {
+        owner: "Wave's Break",
+        stewards: ["Cobblers' Guild Matron Edda Pebblestep"],
+        notes: "Shared courtyard for bootmakers and leather patchers.",
+    },
+    "Grain Mills": {
+        owner: "Wave's Break",
+        stewards: ["Miller Council of Saltmarsh"],
+        notes: "City-controlled mills grinding tithe grain for gate markets.",
+    },
+    "The Emberflask Alchemist": {
+        owner: "Emberflask Family",
+        stewards: ["Alchemist Joral Emberflask"],
+        notes: "Streetfront atelier distilling tonics for caravan guards.",
+    },
+    "Tideglass Alchemical Atelier": {
+        owner: "Tideglass Distillers",
+        stewards: ["Mistress Helene Tideglass"],
+        notes: "Refined essences bound for Greensoul laboratories.",
+    },
+    "Shrine of the Craftfather": {
+        owner: "Craftfather Devotional Guild",
+        stewards: ["Forge Chaplain Dovan Brassmantle"],
+        notes: "Guild artisans seek blessings before major commissions.",
+    },
+    "The Wandering Coin Tavern": {
+        owner: "Coinstep Hospitality",
+        stewards: ["Keeper Jossa Coinstep"],
+        notes: "High Road watering hole for caravan guards and factors.",
+    },
+    // Greensoul Hill landmarks
+    "Greensoul Monastery": {
+        owner: "Greensoul Monastic Order",
+        stewards: ["Prior Selvan Greensoul"],
+        notes: "Scholars and healers study within the monastery cloisters.",
+    },
+    "The Arcanists' Enclave": {
+        owner: "Starweaver Arcanum Trust",
+        stewards: ["Archmage Selene Starweaver"],
+        notes: "Public receiving hall for the enclave's lectures and petitions.",
+    },
+    "Arc Runes Enchantery": {
+        owner: "Runeveil Enchanters",
+        stewards: ["Runesmith Sira Runeveil"],
+        notes: "Vaulted studios for inscription and spellwork commissions.",
+    },
+    "Ink and Quill Hall": {
+        owner: "Quillion Scribes' Circle",
+        stewards: ["Archscribe Mel Quillion"],
+        notes: "Scriptorium copying charters and illuminated histories.",
+    },
+    "Greensoul Press & Papermill": {
+        owner: "Leafpress Papermakers",
+        stewards: ["Master Miller Soren Leafpress"],
+        notes: "Papermill supplying codices for the library and guild halls.",
+    },
+    "Glass Eel Glassworks": {
+        owner: "Glass Eel Cooperative",
+        stewards: ["Journeyman Ryn Glass Eel"],
+        notes: "Specialty rods and vials for arcanists and apothecaries.",
+    },
+    "Shrine of the Dawnfather": {
+        owner: "Sunward Clergy",
+        stewards: ["Lightkeeper Vara Sunward"],
+        notes: "Morning devotions for scholars and guard captains.",
+    },
+    "The Whispering Garden": {
+        owner: "Wave's Break",
+        stewards: ["Garden Keeper Siala Whisper"],
+        notes: "Public meditation garden tended by monastery novices.",
+    },
+    "Royal Botanical Gardens": {
+        owner: "Wave's Break",
+        stewards: ["Curator Elian Thistlebright"],
+        notes: "Crown-funded conservatory cataloguing rare specimens.",
+    },
+    "Greensoul Amphitheater": {
+        owner: "Wave's Break",
+        notes: "Stone amphitheater for civic addresses and guild performances.",
+    },
+    "Sunleaf Terrace": {
+        owner: "Sunleaf Hospitality Family",
+        stewards: ["Innkeeper Lysa Sunleaf"],
+        notes: "Rooftop tea terrace adjoining the Sunleaf Inn.",
+    },
+    "Celestine Bathhouse & Springs": {
+        owner: "Celestine Bathhouse Guild",
+        stewards: ["Mistress Ravia Celestine"],
+        notes: "Mineral springs and steam rooms chartered to the Celestine family.",
+    },
+    "Aurora Amphitheater": {
+        owner: "Aurora Performance Trust",
+        stewards: ["Producer Valen Aurora"],
+        notes: "Indoor hall for bardic contests and magical displays.",
+    },
+    "Gilded Lyre Gallery": {
+        owner: "Lyrecrown Curators",
+        stewards: ["Curator Selise Lyrecrown"],
+        notes: "Gallery hosting sculpture and illuminated manuscripts.",
+    },
+    "The Glass Eel Tavern": {
+        owner: "Glass Eel Cooperative",
+        stewards: ["Innkeep Mara Glass Eel"],
+        notes: "Scholars' tavern tucked beside the arcanists' quarter.",
+    },
+    "The Grand Arena": {
+        owner: "Wave's Break",
+        notes: "Festival arena backing the Seastone complex for public spectacles.",
+    },
+    // Lower Gardens promenades
+    "Herbalists' Quarter": {
+        owner: "Herbalists' Guild",
+        stewards: ["Mistress Danel Greenroot"],
+        notes: "Cluster of stalls for rare herbs and tinctures.",
+    },
+    "Apiaries and Beekeepers": {
+        owner: "Apiarist Families Council",
+        stewards: ["Honeywarden Sera Cliffbloom"],
+        notes: "Urban hives maintained by Cliffbloom and Mistflower lines.",
+    },
+    "Oil Presses and Mills": {
+        owner: "Presswright Cooperative",
+        stewards: ["Master Presser Olun Presswright"],
+        notes: "Olive and nut presses run by Presswright and Foamfield crews.",
+    },
+    "Garden Gate Brewery & Taproom": {
+        owner: "Garden Gate Brewfamily",
+        stewards: ["Brewmistress Kelda Garden"],
+        notes: "Taproom sourcing honeyed ales from Anchor's Toast barrels.",
+    },
+    "Stonecutters' Guild": {
+        owner: "Stonehewer Guild",
+        stewards: ["Guildmaster Torin Stonehewer"],
+        notes: "Guild hall managing quarry quotas and mason apprentices.",
+    },
+    "Shrine of the Harvestmother": {
+        owner: "Harvestmother Matrons",
+        stewards: ["Matron Sela Harvestmother"],
+        notes: "Blessing hall for farmers and market gardeners.",
+    },
+    "Public Baths": {
+        owner: "Wave's Break",
+        notes: "Civic bathhouse drawing heated water from subterranean pipes.",
+    },
+    "Flower Gardens and Orchard Walks": {
+        owner: "Wave's Break",
+        stewards: ["Gardener Lira Bloom"],
+        notes: "Public promenades linking the botanical quarter to South Gate.",
+    },
+    "Bloomstage Theater": {
+        owner: "Bloomstage Troupe",
+        stewards: ["Director Falor Bloomstage"],
+        notes: "Playhouse famed for satirical dramas and festival operettas.",
+    },
+    "The Sunleaf Inn": {
+        owner: "Sunleaf Hospitality Family",
+        stewards: ["Innkeeper Lysa Sunleaf"],
+        notes: "Streetfront entrance and guest ledger wing of the Sunleaf Inn complex.",
+    },
+    "The Velvet Petal Brothel": {
+        owner: "Silkensong Matrons",
+        stewards: ["Madam Ysera Silkensong"],
+        notes: "Discrete establishment catering to visiting nobles and captains.",
+    },
+    // High Road service yards
+    "Iron Key Smithy": {
+        owner: "Ironkey Forge Family",
+        stewards: ["Smith Joral Ironkey"],
+        notes: "Forge crafting locksets and wagon hardware for caravans.",
+    },
+    "Salted Hide Tannery": {
+        owner: "Salted Hide Curriers",
+        stewards: ["Currier Mave Saltedhide"],
+        notes: "Tannery adjoining the Wavehide guild for raw hide processing.",
+    },
+    "Shrine of the Roadwarden": {
+        owner: "Roadwarden Order",
+        stewards: ["Marshal Theon Shieldmarch"],
+        notes: "Shrine where caravan guards swear oaths before departure.",
+    },
+    "Caravan Square": {
+        owner: "Wave's Break",
+        notes: "Staging plaza for caravan musters and pack-train inspections.",
+    },
+    "Wayfarer's Rest Tavern": {
+        owner: "Wayfarer Hearth Family",
+        stewards: ["Innkeep Dela Wayfarer"],
+        notes: "Roadhouse serving trail stews and quiet bunks.",
+    },
+    // Farmland support structures
+    "Harbor Hearth Bakery": {
+        owner: "Hearthoven Bakers",
+        stewards: ["Baker Thera Hearthoven"],
+        notes: "Bakery distributing loaves to gate barracks and caravans.",
+    },
+    "Tidehold Granary & Provisioners": {
+        owner: "Wave's Break",
+        stewards: ["Quartermaster Rel Tidehold"],
+        notes: "Provision yard stockpiling grain and tack for emergency levies.",
+    },
+};
+export function applyWavesBreakRegistry(locations) {
+    const wave = locations["Wave's Break"];
+    if (!wave)
+        return;
+    const businessGroups = new Map(Array.from(ALL_BUSINESS_GROUPS.entries()).map(([key, names]) => [
+        key,
+        filterBusinesses(wave.businesses, names),
+    ]));
+    const customBoards = {};
+    const boardPlans = [
+        ["farmland", FARMLAND_BOARD_PLAN],
+        ["port", PORT_BOARD_PLAN],
+        ["upper", UPPER_WARD_BOARD_PLAN],
+        ["terns", LITTLE_TERNS_BOARD_PLAN],
+        ["greensoul", GREENSOUL_HILL_BOARD_PLAN],
+        ["gardens", LOWER_GARDENS_BOARD_PLAN],
+        ["highroad", HIGH_ROAD_BOARD_PLAN],
+    ];
+    boardPlans.forEach(([key, plan]) => {
+        const businesses = businessGroups.get(key) || [];
+        const binding = getGroupBinding(key);
+        businesses.forEach((business) => applyQuestVisibilityToBusiness(business, binding));
+        const boards = collectBoardQuests(businesses, plan, binding);
+        Object.assign(customBoards, boards);
+    });
+    wave.questBoards = customBoards;
+    wave.quests = Object.values(customBoards).reduce((acc, quests) => acc.concat(quests), []);
+    wave.ownership = {
+        businesses: WAVES_BREAK_BUSINESS_OWNERS,
+        buildings: {
+            ...WAVES_BREAK_BUSINESS_OWNERS,
+            ...WAVES_BREAK_BUILDING_OWNERS,
+        },
+    };
+}
+export const WAVES_BREAK_REGISTRY = {
+    businessOwners: WAVES_BREAK_BUSINESS_OWNERS,
+    buildingOwners: {
+        ...WAVES_BREAK_BUSINESS_OWNERS,
+        ...WAVES_BREAK_BUILDING_OWNERS,
+    },
+    boardPlans: ALL_BOARD_PLANS,
+};

--- a/assets/data/waves_break_registry.ts
+++ b/assets/data/waves_break_registry.ts
@@ -1,0 +1,1288 @@
+import type {
+  BusinessProfile,
+  LaborCondition,
+  Location,
+  OwnershipDetail,
+  Quest,
+  QuestVisibilityBinding,
+  QuestVisibilityRule,
+} from "./locations.js";
+import type { Habitat } from './weather.js';
+
+type BoardPlan = Record<string, string[]>;
+
+type OwnershipMap = Record<string, OwnershipDetail>;
+
+type UrgencyLevel = 'routine' | 'elevated' | 'emergency';
+
+interface ParsedLaborDetails {
+  seasons: string[];
+  requiresStorm: boolean;
+  requiresDry: boolean;
+  requiresFlood: boolean;
+  requiresHarvest: boolean;
+  requiresFestival: boolean;
+  requiresCold: boolean;
+  requiresHeat: boolean;
+  urgency: UrgencyLevel;
+  baseDemand: number;
+  eventTag?: string;
+}
+
+const GROUP_BINDINGS: Record<string, QuestVisibilityBinding> = {
+  farmland: { region: "waves_break", habitat: 'farmland', district: 'Farmlands' },
+  port: { region: "waves_break", habitat: 'coastal', district: 'Harbor Ward' },
+  upper: { region: "waves_break", habitat: 'urban', district: 'Upper Ward' },
+  terns: { region: "waves_break", habitat: 'urban', district: 'Little Terns' },
+  greensoul: { region: "waves_break", habitat: 'urban', district: 'Greensoul Hill' },
+  gardens: { region: "waves_break", habitat: 'urban', district: 'Lower Gardens' },
+  highroad: { region: "waves_break", habitat: 'urban', district: 'High Road' },
+};
+
+const DEFAULT_GROUP_BINDING: QuestVisibilityBinding = {
+  region: "waves_break",
+  habitat: 'urban',
+  district: "Wave's Break",
+};
+
+function getGroupBinding(group: string): QuestVisibilityBinding {
+  const base = GROUP_BINDINGS[group];
+  if (!base) {
+    return { ...DEFAULT_GROUP_BINDING };
+  }
+  return { ...base };
+}
+
+function extractSeasons(text: string): string[] {
+  const seasons = new Set<string>();
+  if (/spring/.test(text)) seasons.add('Spring');
+  if (/(summer|midsummer)/.test(text)) seasons.add('Summer');
+  if (/(autumn|fall|harvest)/.test(text)) seasons.add('Autumn');
+  if (/(winter|frost|snow)/.test(text)) seasons.add('Winter');
+  if (/(dry-season|dry season)/.test(text)) {
+    seasons.add('Summer');
+    seasons.add('Autumn');
+  }
+  if (/(monsoon|rainy|wet season)/.test(text)) {
+    seasons.add('Spring');
+    seasons.add('Autumn');
+  }
+  return Array.from(seasons);
+}
+
+function detectUrgency(text: string): UrgencyLevel {
+  if (/(emergency|immediate|urgent|rush|levy|alarm)/.test(text)) {
+    return 'emergency';
+  }
+  if (/(surge|reinforce|supplement|muster|shortfall|boost)/.test(text)) {
+    return 'elevated';
+  }
+  return 'routine';
+}
+
+function parseLaborConditionForVisibility(
+  condition: LaborCondition | undefined,
+  business: BusinessProfile,
+): ParsedLaborDetails {
+  const raw = [condition?.season, condition?.trigger, condition?.description]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  const seasons = extractSeasons(raw);
+  const requiresStorm = /(storm|gale|squall|tempest|hurricane|deluge|seawall|breach|surge)/.test(raw);
+  const requiresFlood = /(flood|overflow|washout|inundated|breach|spillway)/.test(raw);
+  const requiresDry = /(dry|drought|kiln|low humidity|sun-baked|parched|dust)/.test(raw) && !requiresFlood;
+  const requiresHarvest = /(harvest|vintage|press|picking|shear|gather|reap|trawl)/.test(raw);
+  const requiresFestival = /(festival|faire|games|regatta|tournament|celebration|market day|pageant)/.test(raw);
+  const requiresCold = /(winter|frost|ice|snow|blizzard|cold snap)/.test(raw);
+  const requiresHeat = requiresDry || /(summer|heat|scorch|kiln|dry-season)/.test(raw);
+  const urgency = detectUrgency(raw);
+
+  let baseDemand = 0.35;
+  if (business.category === 'security' || business.category === 'logistics') {
+    baseDemand += 0.05;
+  }
+  if (business.category === 'support') {
+    baseDemand -= 0.05;
+  }
+
+  if (urgency === 'elevated') baseDemand += 0.2;
+  if (urgency === 'emergency') baseDemand += 0.4;
+  if (requiresStorm || requiresFlood) baseDemand += 0.2;
+  if (requiresDry) baseDemand += 0.12;
+  if (requiresHarvest) baseDemand += 0.15;
+  if (requiresFestival) baseDemand += 0.1;
+
+  const eventTag = requiresStorm
+    ? 'storm_response'
+    : requiresFlood
+    ? 'flood_relief'
+    : requiresDry
+    ? 'dry_spell'
+    : requiresHarvest
+    ? 'harvest'
+    : requiresFestival
+    ? 'festival'
+    : undefined;
+
+  return {
+    seasons,
+    requiresStorm,
+    requiresDry,
+    requiresFlood,
+    requiresHarvest,
+    requiresFestival,
+    requiresCold,
+    requiresHeat,
+    urgency,
+    baseDemand,
+    eventTag,
+  };
+}
+
+function shouldAllowSeason(
+  seasons: string[],
+  currentSeason: string,
+): boolean {
+  if (!seasons.length) return true;
+  return seasons.includes(currentSeason);
+}
+
+function applyQuestVisibilityToBusiness(
+  business: BusinessProfile,
+  binding: QuestVisibilityBinding,
+): void {
+  const quests = business.quests || [];
+  quests.forEach((quest, index) => {
+    const laborCondition = business.laborConditions[index];
+    quest.laborCondition = laborCondition;
+    const baseBinding: QuestVisibilityBinding = {
+      region: binding.region,
+      habitat: binding.habitat,
+      district: binding.district,
+      business: business.name,
+    };
+    quest.visibilityBinding = quest.visibilityBinding
+      ? { ...quest.visibilityBinding, ...baseBinding }
+      : baseBinding;
+    if (!quest.visibility) {
+      quest.visibility = createQuestVisibilityRule(business, laborCondition);
+    }
+  });
+}
+
+function createQuestVisibilityRule(
+  business: BusinessProfile,
+  condition: LaborCondition | undefined,
+): QuestVisibilityRule {
+  const parsed = parseLaborConditionForVisibility(condition, business);
+  const trigger = condition?.trigger;
+  return (context) => {
+    const { weather, random, binding } = context;
+    if (!shouldAllowSeason(parsed.seasons, weather.season)) {
+      return {
+        available: false,
+        demand: 0.05,
+        reason: `Work resumes in ${parsed.seasons.join(', ') || 'the proper season'}.`,
+        eventTag: parsed.eventTag,
+      };
+    }
+
+    if (parsed.requiresStorm) {
+      const eventActive =
+        weather.storm || weather.floodRisk !== 'none' || weather.outlook.stormLikely;
+      if (!eventActive) {
+        return {
+          available: false,
+          demand: 0.1,
+          reason: 'Awaiting storm or surge conditions.',
+          eventTag: parsed.eventTag,
+        };
+      }
+    }
+
+    if (parsed.requiresFlood) {
+      const floodActive =
+        weather.floodRisk !== 'none' || weather.trend.wetSpellDays >= 4 || weather.outlook.floodLikely;
+      if (!floodActive) {
+        return {
+          available: false,
+          demand: 0.12,
+          reason: 'Flood controls currently holding.',
+          eventTag: parsed.eventTag,
+        };
+      }
+    }
+
+    if (parsed.requiresDry) {
+      const dryActive =
+        weather.droughtStage !== 'none' || weather.trend.drySpellDays >= 3 || weather.outlook.drySpellLikely;
+      if (!dryActive) {
+        return {
+          available: false,
+          demand: 0.12,
+          reason: 'Moisture levels sufficient; dry-run not yet needed.',
+          eventTag: parsed.eventTag,
+        };
+      }
+    }
+
+    if (parsed.requiresHarvest) {
+      const harvestSeason = weather.season === 'Autumn' || weather.season === 'Summer';
+      if (!harvestSeason) {
+        return {
+          available: false,
+          demand: 0.08,
+          reason: 'Harvest crews wait for fields to ripen.',
+          eventTag: parsed.eventTag,
+        };
+      }
+    }
+
+    if (parsed.requiresFestival) {
+      const festivalWindow =
+        weather.season === 'Summer' || weather.season === 'Spring' || random() < 0.2;
+      if (!festivalWindow) {
+        return {
+          available: false,
+          demand: 0.08,
+          reason: 'No festival preparations scheduled.',
+          eventTag: parsed.eventTag,
+        };
+      }
+    }
+
+    if (parsed.requiresCold && weather.temperatureC > 6) {
+      return {
+        available: false,
+        demand: 0.06,
+        reason: 'Conditions are too mild for winter tasks.',
+        eventTag: parsed.eventTag,
+      };
+    }
+
+    if (parsed.requiresHeat && weather.temperatureC < 10 && weather.season !== 'Summer') {
+      return {
+        available: false,
+        demand: 0.06,
+        reason: 'Heat-dependent work paused until warmer days.',
+        eventTag: parsed.eventTag,
+      };
+    }
+
+    let demand = parsed.baseDemand;
+    demand += weather.outlook.demandModifier;
+    if (parsed.requiresDry && weather.droughtStage === 'warning') demand += 0.25;
+    if (parsed.requiresStorm && weather.storm) demand += 0.2;
+    if (parsed.requiresFlood && weather.floodRisk === 'warning') demand += 0.25;
+    if (parsed.requiresHarvest && weather.season === 'Autumn') demand += 0.2;
+    if (parsed.urgency === 'routine' && weather.trend.drySpellDays > 5) demand += 0.08;
+    if (binding.habitat === 'farmland' && weather.droughtStage !== 'none') demand += 0.05;
+    if (binding.habitat === 'coastal' && weather.storm) demand += 0.05;
+
+    demand = Math.max(0.05, Math.min(0.95, demand));
+
+    const roll = random();
+    const available = roll < demand;
+    return {
+      available,
+      demand,
+      reason:
+        available
+          ? trigger || 'Work crews are being mustered.'
+          : 'Quotas already filled for this rotation.',
+      eventTag: parsed.eventTag,
+    };
+  };
+}
+
+const FARMLAND_BUSINESSES = [
+  "Bayside Brickworks",
+  "Brackenshore Croft",
+  "Cliffblossom Hives",
+  "Cliffbreak Quarry",
+  "Coast Road Watchtower",
+  "Copperbrook Forge",
+  "Driftfell Meadow",
+  "East Road to Mountain Top",
+  "Foamfield Flax Farm",
+  "Greenridge Polder",
+  "Gulls' Orchard",
+  "Gullwind Mill",
+  "Harborwind Dairy",
+  "Mistflower Apiary",
+  "Moorlight Flats",
+  "Netmaker's Co-op",
+  "North Gate",
+  "Saltcrest Vineyard & Winery",
+  "Saltmarsh Granary",
+  "Saltmeadow Potato Farm",
+  "Seabreeze Oat Farm",
+  "Seawisp Plum Orchard",
+  "South Gate",
+  "Sunmellow Grove",
+  "Tideflock Stockyards",
+  "Tidewatcher Lighthouse",
+  "Tidewheel Watermill",
+  "Wavecut Stoneworks",
+  "Windward Berry Vineyard & Winery",
+];
+
+const PORT_BUSINESSES = [
+  "Harborwatch Trading House",
+  "Stormkeel Shipwrights",
+  "Harbor Guard Naval Yard",
+  "Saltworks",
+  "Fishmongers' Row",
+  "The Ropewalk",
+];
+
+const UPPER_WARD_BUSINESSES = [
+  "Governor's Keep",
+  "Hall of Records",
+  "Mercantile Exchange",
+  "Master Jeweler's Guildhall",
+  "Highward Vintners' Salon",
+  "Aurelian Apothecarium & Perfumery",
+];
+
+const LITTLE_TERNS_BUSINESSES = [
+  "Guild of Smiths",
+  "Timberwave Carpenters' Guild",
+  "Carvers' and Fletchers' Hall",
+  "The Gilded Needle Clothiers",
+  "Brine & Bark Tannery",
+  "Seawind Sailmakers' Hall",
+];
+
+const GREENSOUL_HILL_BUSINESSES = [
+  "Grand Library of Wave's Break",
+  "Arcanists' Enclave",
+  "Herbal Conservatory",
+  "Skyline Academy",
+  "Temple of the Tides",
+  "Candlewrights' Guild",
+];
+
+const LOWER_GARDENS_BUSINESSES = [
+  "Quayside Greens Market",
+  "South Gate Market",
+  "Seastone Arena",
+  "Wisteria Pavilion",
+  "Anchor's Toast Brewery",
+  "Sunleaf Inn",
+];
+
+const HIGH_ROAD_BUSINESSES = [
+  "Adventurers' Guildhall",
+  "Rolling Wave Coachworks",
+  "Wavehide Leather Guild",
+  "Shield & Sail Armsmiths",
+  "Gatewatch Barracks",
+  "Stonebridge Caravanserai",
+];
+
+const FARMLAND_BOARD_PLAN: BoardPlan = {
+  "North Gate Labor Postings": [
+    "Bayside Brickworks",
+    "Cliffbreak Quarry",
+    "Coast Road Watchtower",
+    "Copperbrook Forge",
+    "East Road to Mountain Top",
+    "Greenridge Polder",
+    "Mistflower Apiary",
+    "Netmaker's Co-op",
+    "North Gate",
+    "Tidewatcher Lighthouse",
+    "Tidewheel Watermill",
+    "Wavecut Stoneworks",
+  ],
+  "South Gate Field Contracts": [
+    "Brackenshore Croft",
+    "Cliffblossom Hives",
+    "Driftfell Meadow",
+    "Foamfield Flax Farm",
+    "Gulls' Orchard",
+    "Gullwind Mill",
+    "Harborwind Dairy",
+    "Moorlight Flats",
+    "Saltcrest Vineyard & Winery",
+    "Saltmarsh Granary",
+    "Saltmeadow Potato Farm",
+    "Seabreeze Oat Farm",
+    "Seawisp Plum Orchard",
+    "South Gate",
+    "Sunmellow Grove",
+    "Tideflock Stockyards",
+    "Windward Berry Vineyard & Winery",
+  ],
+};
+
+const PORT_BOARD_PLAN: BoardPlan = {
+  "Harborwatch Quay Ledger": ["Harborwatch Trading House"],
+  "Stormkeel Slipway Mast": ["Stormkeel Shipwrights"],
+  "Naval Yard Muster Wall": ["Harbor Guard Naval Yard"],
+  "Saltworks Evaporation Gate": ["Saltworks"],
+  "Fishmongers' Stall Hooks": ["Fishmongers' Row"],
+  "Ropewalk Entry Plaques": ["The Ropewalk"],
+};
+
+const UPPER_WARD_BOARD_PLAN: BoardPlan = {
+  "Governor's Keep Gatehouse Registry": ["Governor's Keep", "Hall of Records"],
+  "Highward Mercantile Ledger": ["Mercantile Exchange", "Highward Vintners' Salon"],
+  "Adventurers' Guild Liaison Counter": [
+    "Master Jeweler's Guildhall",
+    "Aurelian Apothecarium & Perfumery",
+  ],
+};
+
+const LITTLE_TERNS_BOARD_PLAN: BoardPlan = {
+  "Guild of Smiths Forge Gate": ["Guild of Smiths"],
+  "Timberwave Yard Posting": ["Timberwave Carpenters' Guild"],
+  "Carvers' Hall Chisel Board": ["Carvers' and Fletchers' Hall"],
+  "Gilded Needle Facade Placards": ["The Gilded Needle Clothiers"],
+  "Brine & Bark Headhouse": ["Brine & Bark Tannery"],
+  "Seawind Loft Rail": ["Seawind Sailmakers' Hall"],
+};
+
+const GREENSOUL_HILL_BOARD_PLAN: BoardPlan = {
+  "Grand Library Request Desk": ["Grand Library of Wave's Break"],
+  "Arcanists' Gatehouse Wards": ["Arcanists' Enclave"],
+  "Herbal Conservatory Loggia": ["Herbal Conservatory"],
+  "Skyline Academy Posting Column": ["Skyline Academy"],
+  "Temple of the Tides Ledger": ["Temple of the Tides"],
+  "Candlewrights' Guild Lantern Wall": ["Candlewrights' Guild"],
+};
+
+const LOWER_GARDENS_BOARD_PLAN: BoardPlan = {
+  "South Gate Market Posting Wall": [
+    "South Gate Market",
+    "Quayside Greens Market",
+    "Anchor's Toast Brewery",
+  ],
+  "Arena Promenade Notices": ["Seastone Arena", "Wisteria Pavilion", "Sunleaf Inn"],
+};
+
+const HIGH_ROAD_BOARD_PLAN: BoardPlan = {
+  "Adventurers' Guild Contract Archive": ["Adventurers' Guildhall"],
+  "Caravan Square Contract Wall": [
+    "Rolling Wave Coachworks",
+    "Wavehide Leather Guild",
+    "Shield & Sail Armsmiths",
+    "Stonebridge Caravanserai",
+  ],
+  "Gatewatch Muster Board": ["Gatewatch Barracks"],
+};
+
+const ALL_BUSINESS_GROUPS = new Map<string, string[]>([
+  ["farmland", FARMLAND_BUSINESSES],
+  ["port", PORT_BUSINESSES],
+  ["upper", UPPER_WARD_BUSINESSES],
+  ["terns", LITTLE_TERNS_BUSINESSES],
+  ["greensoul", GREENSOUL_HILL_BUSINESSES],
+  ["gardens", LOWER_GARDENS_BUSINESSES],
+  ["highroad", HIGH_ROAD_BUSINESSES],
+]);
+
+const ALL_BOARD_PLANS: BoardPlan[] = [
+  FARMLAND_BOARD_PLAN,
+  PORT_BOARD_PLAN,
+  UPPER_WARD_BOARD_PLAN,
+  LITTLE_TERNS_BOARD_PLAN,
+  GREENSOUL_HILL_BOARD_PLAN,
+  LOWER_GARDENS_BOARD_PLAN,
+  HIGH_ROAD_BOARD_PLAN,
+];
+
+function cloneQuestForBoard(
+  quest: Quest,
+  boardName: string,
+  businessName: string,
+  binding: QuestVisibilityBinding,
+): Quest {
+  const notes = quest.notes
+    ? `${quest.notes} Posted on the ${boardName}; report to ${businessName}.`
+    : `Posted on the ${boardName}; report to ${businessName}.`;
+  const visibilityBinding: QuestVisibilityBinding = {
+    ...binding,
+    board: boardName,
+    business: businessName,
+  };
+  return {
+    ...quest,
+    notes,
+    visibilityBinding: quest.visibilityBinding
+      ? { ...quest.visibilityBinding, ...visibilityBinding }
+      : visibilityBinding,
+  };
+}
+
+function filterBusinesses(
+  businesses: BusinessProfile[] | undefined,
+  names: string[],
+): BusinessProfile[] {
+  if (!businesses?.length) return [];
+  const allowed = new Set(names);
+  return businesses.filter((business) => allowed.has(business.name));
+}
+
+function collectBoardQuests(
+  businesses: BusinessProfile[] | undefined,
+  plan: BoardPlan,
+  binding: QuestVisibilityBinding,
+): Record<string, Quest[]> {
+  if (!businesses?.length) return {};
+  const index = new Map(businesses.map((b) => [b.name, b]));
+  const boards: Record<string, Quest[]> = {};
+  Object.entries(plan).forEach(([boardName, businessNames]) => {
+    const quests: Quest[] = [];
+    businessNames.forEach((name) => {
+      const business = index.get(name);
+      if (!business) return;
+      business.quests.forEach((quest) => {
+        quests.push(cloneQuestForBoard(quest, boardName, business.name, binding));
+      });
+    });
+    if (quests.length) {
+      boards[boardName] = quests;
+    }
+  });
+  return boards;
+}
+
+const WAVES_BREAK_BUSINESS_OWNERS: OwnershipMap = {
+  // Farmlands and hinterland holdings
+  "Bayside Brickworks": {
+    owner: "Tidemold Kiln-Family",
+    stewards: ["Master Kilner Varla Tidemold"],
+    notes: "Harborworks charters the Tidemolds to keep coastal brick supplies moving.",
+  },
+  "Brackenshore Croft": {
+    owner: "Saltbound Terrace Estate",
+    stewards: ["Field-reeve Maera Saltbound"],
+    notes: "Stone-terraced barley fields leased from the Saltbound family to trusted reeves.",
+  },
+  "Cliffblossom Hives": {
+    owner: "Cliffbloom Apiarists",
+    stewards: ["Honeywarden Sera Cliffbloom"],
+    notes: "Cliffbloom cousins rotate stewardship of the cliffside apiaries each season.",
+  },
+  "Cliffbreak Quarry": {
+    owner: "Cliffbreak Stone Consortium",
+    stewards: ["Foreman Brann Cliffbreak"],
+    notes: "Stone blocks cut under Cliffbreak contracts for harbor walls and export orders.",
+  },
+  "Coast Road Watchtower": {
+    owner: "Wave's Break",
+    stewards: ["Gatewatch Command Council"],
+    notes: "City watch captains rotate garrison command on coastal beacons.",
+  },
+  "Copperbrook Forge": {
+    owner: "Copperbrook Forgehold",
+    stewards: ["Smith Barun Copperbrook"],
+    notes: "Forgehold turns out hinges, plowshares, and tool repairs for the northern farms.",
+  },
+  "Driftfell Meadow": {
+    owner: "Driftfell Pastoral Estate",
+    stewards: ["Steward Elwin Driftfell"],
+    notes: "Estate leases meadow grazing to drover families supporting Gatewatch mounts.",
+  },
+  "East Road to Mountain Top": {
+    owner: "Wave's Break",
+    stewards: ["Road Warden Arel"],
+    notes: "Municipal wardens patrol the vital overland artery toward Mountain Top caravans.",
+  },
+  "Foamfield Flax Farm": {
+    owner: "Foamfield Kinstead",
+    stewards: ["Farmholder Deryn Foamfield"],
+    notes: "Foamfield kin spin flax for sailcloth and canvas bound for the harbor.",
+  },
+  "Greenridge Polder": {
+    owner: "Tidebinder Family Trust",
+    stewards: ["Reeve Galen Tidebinder"],
+    notes: "Levees and sluices carved by the Tidebinder trust keep reclaimed marshland fertile.",
+  },
+  "Gulls' Orchard": {
+    owner: "Seafeather Orchard Family",
+    stewards: ["Orchard Mistress Riala Seafeather"],
+    notes: "Seafeather ciders fill Greensoul cellars and South Gate presses.",
+  },
+  "Gullwind Mill": {
+    owner: "Gullwind Milling House",
+    stewards: ["Master Miller Joran Gullwind"],
+    notes: "Millstones grind grain for Saltmarsh granaries and caravan flour rations.",
+  },
+  "Harborwind Dairy": {
+    owner: "Harborwind Dairy Clan",
+    stewards: ["Matron Helda Harborwind"],
+    notes: "Butter and soft cheeses travel daily to the South Gate markets.",
+  },
+  "Mistflower Apiary": {
+    owner: "Mistflower Apiarists",
+    stewards: ["Keeper Lileth Mistflower"],
+    notes: "Perfumed honeys bound for Greensoul apothecaries are bottled here.",
+  },
+  "Moorlight Flats": {
+    owner: "Moorlight Drovers' Estate",
+    stewards: ["Herdmaster Vel Moorlight"],
+    notes: "Moorlight family contracts pasture to drovers fattening caravans' draft herds.",
+  },
+  "Netmaker's Co-op": {
+    owner: "Selkanet Cooperative",
+    stewards: ["Factor Selka Tideknot"],
+    notes: "Selkanet knotters lease looms along the riverbank under Harborworks quotas.",
+  },
+  "North Gate": {
+    owner: "Wave's Break",
+    stewards: ["Gate Sergeant Hullen"],
+    notes: "City gate operations fall under the Gatewatch barracks commander's remit.",
+  },
+  "Saltcrest Vineyard & Winery": {
+    owner: "Saltcrest Vintner Estate",
+    stewards: ["Master Vintner Aelric Saltcrest"],
+    notes: "Saltcrest casks age in cliffside vaults before shipping inland.",
+  },
+  "Saltmarsh Granary": {
+    owner: "Wave's Break",
+    stewards: ["Keeper Torv Saltmarsh"],
+    notes: "City granary holds gate tithe grain and fleet provisions under civic contract.",
+  },
+  "Saltmeadow Potato Farm": {
+    owner: "Saltmeadow Family Holding",
+    stewards: ["Farmer Ina Saltmeadow"],
+    notes: "Saltmeadow rows keep the city supplied with tubers during winter.",
+  },
+  "Seabreeze Oat Farm": {
+    owner: "Seabreeze Grainstead",
+    stewards: ["Steward Neris Seabreeze"],
+    notes: "Oat harvests feed caravan teams bound for the East Road.",
+  },
+  "Seawisp Plum Orchard": {
+    owner: "Seawisp Orchard Collective",
+    stewards: ["Harvestkeeper Lora Seawisp"],
+    notes: "Orchard families share tenancy while the Seawisp matriarch controls exports.",
+  },
+  "South Gate": {
+    owner: "Wave's Break",
+    stewards: ["Captain Brisa Gatewatch"],
+    notes: "Southern gate patrols muster under Gatewatch command.",
+  },
+  "Sunmellow Grove": {
+    owner: "Dawnbloom Estate",
+    stewards: ["Sunmellow Grove Council"],
+    notes: "The Dawnbloom line leases plots to grove tenders producing aromatic fruits.",
+  },
+  "Tideflock Stockyards": {
+    owner: "Tideflock Drover Family",
+    stewards: ["Steward Mara Tideflock"],
+    notes: "Drover clans stage livestock bound for harbor barges and caravans.",
+  },
+  "Tidewatcher Lighthouse": {
+    owner: "Wave's Break",
+    stewards: ["Keeper Malen Tidewatcher"],
+    notes: "Guard engineers maintain the beacon and its sea-ward wards.",
+  },
+  "Tidewheel Watermill": {
+    owner: "Wave's Break",
+    stewards: ["Millwright Jessa Tidewheel"],
+    notes: "Municipal leases keep grain grinding for Saltmarsh stores even in flood season.",
+  },
+  "Wavecut Stoneworks": {
+    owner: "Wavecut Masonry Family",
+    stewards: ["Master Mason Corin Wavecut"],
+    notes: "Wavecut blocks supply Greensoul projects and harbor stairs.",
+  },
+  "Windward Berry Vineyard & Winery": {
+    owner: "Windward Vineyard Estate",
+    stewards: ["Vintner Soren Windward"],
+    notes: "Windward vintners bottle berry wine prized by Highward salons.",
+  },
+  // Port district consortiums
+  "Harborwatch Trading House": {
+    owner: "Calderis Ledger-Family",
+    stewards: ["Factor Merina Calderis"],
+    notes: "Calderis auditors hold the bonded keys for noble cargoes.",
+  },
+  "Stormkeel Shipwrights": {
+    owner: "Stormkeel Dockwright Dynasty",
+    stewards: ["Foreman Daska Stormkeel"],
+    notes: "Stormkeel slips lay keels for royal cutters and merchant carracks alike.",
+  },
+  "Harbor Guard Naval Yard": {
+    owner: "Wave's Break",
+    stewards: ["Captain Yorsen of the Harbor Guard"],
+    notes: "Fleet tenders answer to the harbor admiralty office.",
+  },
+  "Saltworks": {
+    owner: "Saltmaster Family Cooperative",
+    stewards: ["Saltmaster Rinna"],
+    notes: "The Saltmaster kin boil brine for fleet rations under city quotas.",
+  },
+  "Fishmongers' Row": {
+    owner: "Selune-Osprey Fishmongers",
+    stewards: ["Dockmaster Selune Osprey"],
+    notes: "Pier stalls are rotated among Osprey cousins per tide schedule.",
+  },
+  "The Ropewalk": {
+    owner: "Strandbinder Cooperative",
+    stewards: ["Rope-master Galen Strandbinder"],
+    notes: "Longhouse spinners fulfill navy towline orders and harbor moorings.",
+  },
+  // Upper Ward charters
+  "Governor's Keep": {
+    owner: "Wave's Break",
+    stewards: ["Chamberlain Veleth"],
+    notes: "Civic bastion housing council chambers and vaults.",
+  },
+  "Hall of Records": {
+    owner: "Wave's Break",
+    stewards: ["Provost Malenne"],
+    notes: "Archive clerks maintain civic ledgers and deeds.",
+  },
+  "Mercantile Exchange": {
+    owner: "Dorel Mercantile Charter",
+    stewards: ["High Factor Dorel"],
+    notes: "Exchange tribunal brokers high-value contracts for noble investors.",
+  },
+  "Master Jeweler's Guildhall": {
+    owner: "Vain Jewelcraft Charter",
+    stewards: ["Master Jeweler Serapha Vain"],
+    notes: "Gemcutters and setters hold guild courts within the hall.",
+  },
+  "Highward Vintners' Salon": {
+    owner: "Highward Estate",
+    stewards: ["Sommelier Liora Highward"],
+    notes: "Private tasting rooms for noble vintages imported through Nobles' Quay.",
+  },
+  "Aurelian Apothecarium & Perfumery": {
+    owner: "Aurelian Lysenne Atelier",
+    stewards: ["Mistress Aurelia Lysenne"],
+    notes: "Perfumed tinctures crafted for Highward patrons and Greensoul healers.",
+  },
+  // Little Terns craft guilds
+  "Guild of Smiths": {
+    owner: "Ironbent Forgeclan",
+    stewards: ["Forge Captain Brakka Ironbent"],
+    notes: "Forge captaincy rotates through Ironbent lineages by guild vote.",
+  },
+  "Timberwave Carpenters' Guild": {
+    owner: "Woodhand Timber Charter",
+    stewards: ["Guildmistress Tella Woodhand"],
+    notes: "Woodhand families lease lumberyards and oversee apprentice crews.",
+  },
+  "Carvers' and Fletchers' Hall": {
+    owner: "Thornwright Carving Family",
+    stewards: ["Foreman Kale Thornwright"],
+    notes: "Thornwright foremen keep arrow and carving orders moving.",
+  },
+  "The Gilded Needle Clothiers": {
+    owner: "Threadneedle Atelier",
+    stewards: ["Mistress Seraphine Threadneedle"],
+    notes: "Threadneedle couturiers fit nobles and caravan masters alike.",
+  },
+  "Brine & Bark Tannery": {
+    owner: "Brinebark Tanning Family",
+    stewards: ["Steward Pell Brinebark"],
+    notes: "Hide curing yards that feed Wavehide leatherworks.",
+  },
+  "Seawind Sailmakers' Hall": {
+    owner: "Seawind Rigging Family",
+    stewards: ["Forewoman Maris Seawind"],
+    notes: "Sail looms stretch canvas for harbor barques and river luggers.",
+  },
+  // Greensoul Hill orders
+  "Grand Library of Wave's Break": {
+    owner: "Wave's Break",
+    stewards: ["Chief Archivist Rellis"],
+    notes: "Civic library chartered to preserve guild records and histories.",
+  },
+  "Arcanists' Enclave": {
+    owner: "Starweaver Arcanum Trust",
+    stewards: ["Archmage Selene Starweaver"],
+    notes: "Magister council licenses rituals and research.",
+  },
+  "Herbal Conservatory": {
+    owner: "Leafward Conservatory Estate",
+    stewards: ["Conservator Mera Leafward"],
+    notes: "Leafward apothecaries cultivate rare specimens for healers.",
+  },
+  "Skyline Academy": {
+    owner: "Brightmere Scholastic Charter",
+    stewards: ["Dean Callus Brightmere"],
+    notes: "Scholars train navigators, engineers, and court scribes.",
+  },
+  "Temple of the Tides": {
+    owner: "Tideborn Clerical House",
+    stewards: ["High Priestess Maela Tideborn"],
+    notes: "Temple guardians oversee coastal rites and pilgrim offerings.",
+  },
+  "Candlewrights' Guild": {
+    owner: "Candlewright Artisan Line",
+    stewards: ["Guildmaster Oren Candlewright"],
+    notes: "Waxmasters contract festival illuminations and civic beacons.",
+  },
+  // Lower Gardens and cultural quarter
+  "Quayside Greens Market": {
+    owner: "Greenside Market Council",
+    stewards: ["Steward Jessa Greenside"],
+    notes: "Greenside council allocates stalls to herb growers and foragers.",
+  },
+  "South Gate Market": {
+    owner: "Wave's Break",
+    stewards: ["Marketwarden Tarsa Hollow"],
+    notes: "South Gate market ground maintained by civic wardens.",
+  },
+  "Seastone Arena": {
+    owner: "Wave's Break",
+    stewards: ["Arena Master Garen Seastone"],
+    notes: "Arena master reports to the governor for games and levy musters.",
+  },
+  "Wisteria Pavilion": {
+    owner: "Neral Wisterian Estate",
+    stewards: ["Maestro Neral Wisterian"],
+    notes: "Recital hall hosting guild salons and noble performances.",
+  },
+  "Anchor's Toast Brewery": {
+    owner: "Anchorfast Brewing Family",
+    stewards: ["Brewmaster Tolen Anchorfast"],
+    notes: "Brew kettles feed the market taverns and caravan casks.",
+  },
+  "Sunleaf Inn": {
+    owner: "Sunleaf Hospitality Family",
+    stewards: ["Innkeeper Lysa Sunleaf"],
+    notes: "Garden court inn favored by scholars and visiting merchants.",
+  },
+  // High Road district contracts
+  "Adventurers' Guildhall": {
+    owner: "Crestshield Guild Charter",
+    stewards: ["Guildmaster Ryn Crestshield"],
+    notes: "Guild charter authorized by the crown and city governor.",
+  },
+  "Rolling Wave Coachworks": {
+    owner: "Rollingwave Coach Consortium",
+    stewards: ["Foreman Darel Rollingwave"],
+    notes: "Coachwright crews refit wagons before departure on the High Road.",
+  },
+  "Wavehide Leather Guild": {
+    owner: "Pell Leatherwright Family",
+    stewards: ["Guildmaster Pell"],
+    notes: "Leatherwright line oversees harness and armor commissions.",
+  },
+  "Shield & Sail Armsmiths": {
+    owner: "Sella Shieldwright Family",
+    stewards: ["Master Armorer Sella"],
+    notes: "Armsmith cooperative allied with Gatewatch contracts.",
+  },
+  "Gatewatch Barracks": {
+    owner: "Wave's Break",
+    stewards: ["Captain Ilyan Gatewatch"],
+    notes: "Barracks houses the Shieldbearer cadre and gate patrols.",
+  },
+  "Stonebridge Caravanserai": {
+    owner: "Nyla Stonebridge Trust",
+    stewards: ["Steward Nyla Stonebridge"],
+    notes: "Stonebridge trust rents bays to caravans staging in the High Road district.",
+  },
+};
+
+const WAVES_BREAK_BUILDING_OWNERS: OwnershipMap = {
+  // Port promenades
+  "Warehouse Row": {
+    owner: "Wave's Break",
+    stewards: ["Harborworks Quartermaster Lysa Tallis"],
+    notes: "Municipal bonded storage watched by harbor inspectors.",
+  },
+  "Nobles' Quay": {
+    owner: "House Delmare Quaywrights",
+    stewards: ["Harbormaster Vell Delmare"],
+    notes: "Reserved slips leased to highborn fleets through Delmare factors.",
+  },
+  "Merchants' Wharf": {
+    owner: "Merrow Syndicate",
+    stewards: ["Factor Alis Merrow"],
+    notes: "Syndicate factors rotate berths for merchant caravels.",
+  },
+  "Fisherman's Pier": {
+    owner: "Hookfin Netters",
+    stewards: ["Mistress Daila Hookfin"],
+    notes: "Pier space apportioned among Hookfin and Osprey fishing crews.",
+  },
+  "Brinebarrel Coopers": {
+    owner: "Brinebarrel Cooperage Family",
+    stewards: ["Cooper Hest Brinebarrel"],
+    notes: "Barrelwrights supply kegs for salters and breweries alike.",
+  },
+  "Shrine of the Deep Current": {
+    owner: "Tidecaller Priesthood",
+    stewards: ["Oracle Maerin Tidecaller"],
+    notes: "Dockside sailors leave offerings before each voyage.",
+  },
+  "Statue of the Sea-Mother": {
+    owner: "Wave's Break",
+    notes: "Civic monument maintained by harbor masons.",
+  },
+  "The Salty Gull": {
+    owner: "Gullring Hospitality",
+    stewards: ["Proprietor Edda Gullring"],
+    notes: "Favored tavern of fisher crews and visiting traders.",
+  },
+  "The Tideway Inn": {
+    owner: "Tideway Innkeep Family",
+    stewards: ["Innkeeper Dovan Tideway"],
+    notes: "Quayside inn welcoming caravan quartermasters waiting on cargo.",
+  },
+  "Navigator's Trust & Chart House": {
+    owner: "Chartwright Collegium",
+    stewards: ["Chartmaster Rhyl Chartwright"],
+    notes: "Map rooms track every convoy and tide across the gulf.",
+  },
+  // Upper Ward salons
+  "Marble Finch Supper Club": {
+    owner: "Marblefinch Gastronomy House",
+    stewards: ["Chef Aurel Marblefinch"],
+    notes: "Invitation-only suppers for the governor's council and visiting nobles.",
+  },
+  "Highward Terraces": {
+    owner: "Highward Estate",
+    stewards: ["Sommelier Liora Highward"],
+    notes: "Tiered gardens connecting the salon to Noble rowhouses.",
+  },
+  "Plaza of Banners": {
+    owner: "Wave's Break",
+    notes: "Ceremonial plaza displaying guild and caravan colors.",
+  },
+  "Goldleaf Atelier": {
+    owner: "Goldleaf Artisan Estate",
+    stewards: ["Master Crafter Irelle Goldleaf"],
+    notes: "Commission studio for noble regalia and ceremony gifts.",
+  },
+  "Engravers' Guild": {
+    owner: "Etchline Guild Family",
+    stewards: ["Guildmaster Corvel Etchline"],
+    notes: "Seal presses and insignia plates for civic offices.",
+  },
+  "Glassmakers' Hall": {
+    owner: "Cristalle Glasswright Circle",
+    stewards: ["Mistress Aurelia Cristalle"],
+    notes: "Master glassblowers share furnaces for noble commissions.",
+  },
+  "Crystal Tide Glassworks": {
+    owner: "Cristalle Glasswright Circle",
+    stewards: ["Journeyman Lysa Cristalle"],
+    notes: "Cooling galleries for stained panes exported to Coral Keep.",
+  },
+  "The Argent Griffin Inn": {
+    owner: "Argentgriff Hostelry",
+    stewards: ["Innkeeper Orel Argentgriff"],
+    notes: "Luxurious suites for dignitaries and guildmasters.",
+  },
+  // Craft ward extensions
+  "Tidefire Forge": {
+    owner: "Ironbent Forgeclan",
+    stewards: ["Forge Captain Brakka Ironbent"],
+    notes: "Guild forge dedicated to masterwork commissions.",
+  },
+  "Lumber Yard and Carpenter's Hall": {
+    owner: "Woodhand Timber Charter",
+    stewards: ["Guildmistress Tella Woodhand"],
+    notes: "Shared yard supplying beams to shipwrights and builders.",
+  },
+  "Threadneedle Hall": {
+    owner: "Threadneedle Atelier",
+    stewards: ["Mistress Seraphine Threadneedle"],
+    notes: "Pattern vault and journeyman dormitory for clothiers.",
+  },
+  "Seastone Ceramics": {
+    owner: "Seastone Kiln Family",
+    stewards: ["Potter Neris Seastone"],
+    notes: "Glazed tableware favored in Highward salons.",
+  },
+  "Brinemarrow Press": {
+    owner: "Brinemarrow Print Family",
+    stewards: ["Printer Hallen Brinemarrow"],
+    notes: "Broadside press handling guild notices and tavern playbills.",
+  },
+  "Tern Hook Butchery": {
+    owner: "Hooke & Tern Family",
+    stewards: ["Butcher Mara Hooke"],
+    notes: "Harbor butchers preparing catches for market stalls.",
+  },
+  "Driftwood Smokehouse": {
+    owner: "Driftwood Smoker Family",
+    stewards: ["Smokemaster Pell Driftwood"],
+    notes: "Cured fish destined for caravans and the Gatewatch mess.",
+  },
+  "Gull's Galley": {
+    owner: "Gullwharf Family",
+    stewards: ["Chef Ilven Gullwharf"],
+    notes: "Dockside eatery known for gull-egg pies and chowders.",
+  },
+  "Dockside Exchange Plaza": {
+    owner: "Wave's Break",
+    notes: "Open plaza where caravan factors meet arriving captains.",
+  },
+  "Saltroot Remedies": {
+    owner: "Saltroot Apothecaries",
+    stewards: ["Herbalist Vela Saltroot"],
+    notes: "Remedy counter for sailors and laborers nursing injuries.",
+  },
+  "Tern Harbor Commons": {
+    owner: "Wave's Break",
+    notes: "Common green hosting fisher markets and coastal festivals.",
+  },
+  "Cobbler's Square": {
+    owner: "Wave's Break",
+    stewards: ["Cobblers' Guild Matron Edda Pebblestep"],
+    notes: "Shared courtyard for bootmakers and leather patchers.",
+  },
+  "Grain Mills": {
+    owner: "Wave's Break",
+    stewards: ["Miller Council of Saltmarsh"],
+    notes: "City-controlled mills grinding tithe grain for gate markets.",
+  },
+  "The Emberflask Alchemist": {
+    owner: "Emberflask Family",
+    stewards: ["Alchemist Joral Emberflask"],
+    notes: "Streetfront atelier distilling tonics for caravan guards.",
+  },
+  "Tideglass Alchemical Atelier": {
+    owner: "Tideglass Distillers",
+    stewards: ["Mistress Helene Tideglass"],
+    notes: "Refined essences bound for Greensoul laboratories.",
+  },
+  "Shrine of the Craftfather": {
+    owner: "Craftfather Devotional Guild",
+    stewards: ["Forge Chaplain Dovan Brassmantle"],
+    notes: "Guild artisans seek blessings before major commissions.",
+  },
+  "The Wandering Coin Tavern": {
+    owner: "Coinstep Hospitality",
+    stewards: ["Keeper Jossa Coinstep"],
+    notes: "High Road watering hole for caravan guards and factors.",
+  },
+  // Greensoul Hill landmarks
+  "Greensoul Monastery": {
+    owner: "Greensoul Monastic Order",
+    stewards: ["Prior Selvan Greensoul"],
+    notes: "Scholars and healers study within the monastery cloisters.",
+  },
+  "The Arcanists' Enclave": {
+    owner: "Starweaver Arcanum Trust",
+    stewards: ["Archmage Selene Starweaver"],
+    notes: "Public receiving hall for the enclave's lectures and petitions.",
+  },
+  "Arc Runes Enchantery": {
+    owner: "Runeveil Enchanters",
+    stewards: ["Runesmith Sira Runeveil"],
+    notes: "Vaulted studios for inscription and spellwork commissions.",
+  },
+  "Ink and Quill Hall": {
+    owner: "Quillion Scribes' Circle",
+    stewards: ["Archscribe Mel Quillion"],
+    notes: "Scriptorium copying charters and illuminated histories.",
+  },
+  "Greensoul Press & Papermill": {
+    owner: "Leafpress Papermakers",
+    stewards: ["Master Miller Soren Leafpress"],
+    notes: "Papermill supplying codices for the library and guild halls.",
+  },
+  "Glass Eel Glassworks": {
+    owner: "Glass Eel Cooperative",
+    stewards: ["Journeyman Ryn Glass Eel"],
+    notes: "Specialty rods and vials for arcanists and apothecaries.",
+  },
+  "Shrine of the Dawnfather": {
+    owner: "Sunward Clergy",
+    stewards: ["Lightkeeper Vara Sunward"],
+    notes: "Morning devotions for scholars and guard captains.",
+  },
+  "The Whispering Garden": {
+    owner: "Wave's Break",
+    stewards: ["Garden Keeper Siala Whisper"],
+    notes: "Public meditation garden tended by monastery novices.",
+  },
+  "Royal Botanical Gardens": {
+    owner: "Wave's Break",
+    stewards: ["Curator Elian Thistlebright"],
+    notes: "Crown-funded conservatory cataloguing rare specimens.",
+  },
+  "Greensoul Amphitheater": {
+    owner: "Wave's Break",
+    notes: "Stone amphitheater for civic addresses and guild performances.",
+  },
+  "Sunleaf Terrace": {
+    owner: "Sunleaf Hospitality Family",
+    stewards: ["Innkeeper Lysa Sunleaf"],
+    notes: "Rooftop tea terrace adjoining the Sunleaf Inn.",
+  },
+  "Celestine Bathhouse & Springs": {
+    owner: "Celestine Bathhouse Guild",
+    stewards: ["Mistress Ravia Celestine"],
+    notes: "Mineral springs and steam rooms chartered to the Celestine family.",
+  },
+  "Aurora Amphitheater": {
+    owner: "Aurora Performance Trust",
+    stewards: ["Producer Valen Aurora"],
+    notes: "Indoor hall for bardic contests and magical displays.",
+  },
+  "Gilded Lyre Gallery": {
+    owner: "Lyrecrown Curators",
+    stewards: ["Curator Selise Lyrecrown"],
+    notes: "Gallery hosting sculpture and illuminated manuscripts.",
+  },
+  "The Glass Eel Tavern": {
+    owner: "Glass Eel Cooperative",
+    stewards: ["Innkeep Mara Glass Eel"],
+    notes: "Scholars' tavern tucked beside the arcanists' quarter.",
+  },
+  "The Grand Arena": {
+    owner: "Wave's Break",
+    notes: "Festival arena backing the Seastone complex for public spectacles.",
+  },
+  // Lower Gardens promenades
+  "Herbalists' Quarter": {
+    owner: "Herbalists' Guild",
+    stewards: ["Mistress Danel Greenroot"],
+    notes: "Cluster of stalls for rare herbs and tinctures.",
+  },
+  "Apiaries and Beekeepers": {
+    owner: "Apiarist Families Council",
+    stewards: ["Honeywarden Sera Cliffbloom"],
+    notes: "Urban hives maintained by Cliffbloom and Mistflower lines.",
+  },
+  "Oil Presses and Mills": {
+    owner: "Presswright Cooperative",
+    stewards: ["Master Presser Olun Presswright"],
+    notes: "Olive and nut presses run by Presswright and Foamfield crews.",
+  },
+  "Garden Gate Brewery & Taproom": {
+    owner: "Garden Gate Brewfamily",
+    stewards: ["Brewmistress Kelda Garden"],
+    notes: "Taproom sourcing honeyed ales from Anchor's Toast barrels.",
+  },
+  "Stonecutters' Guild": {
+    owner: "Stonehewer Guild",
+    stewards: ["Guildmaster Torin Stonehewer"],
+    notes: "Guild hall managing quarry quotas and mason apprentices.",
+  },
+  "Shrine of the Harvestmother": {
+    owner: "Harvestmother Matrons",
+    stewards: ["Matron Sela Harvestmother"],
+    notes: "Blessing hall for farmers and market gardeners.",
+  },
+  "Public Baths": {
+    owner: "Wave's Break",
+    notes: "Civic bathhouse drawing heated water from subterranean pipes.",
+  },
+  "Flower Gardens and Orchard Walks": {
+    owner: "Wave's Break",
+    stewards: ["Gardener Lira Bloom"],
+    notes: "Public promenades linking the botanical quarter to South Gate.",
+  },
+  "Bloomstage Theater": {
+    owner: "Bloomstage Troupe",
+    stewards: ["Director Falor Bloomstage"],
+    notes: "Playhouse famed for satirical dramas and festival operettas.",
+  },
+  "The Sunleaf Inn": {
+    owner: "Sunleaf Hospitality Family",
+    stewards: ["Innkeeper Lysa Sunleaf"],
+    notes: "Streetfront entrance and guest ledger wing of the Sunleaf Inn complex.",
+  },
+  "The Velvet Petal Brothel": {
+    owner: "Silkensong Matrons",
+    stewards: ["Madam Ysera Silkensong"],
+    notes: "Discrete establishment catering to visiting nobles and captains.",
+  },
+  // High Road service yards
+  "Iron Key Smithy": {
+    owner: "Ironkey Forge Family",
+    stewards: ["Smith Joral Ironkey"],
+    notes: "Forge crafting locksets and wagon hardware for caravans.",
+  },
+  "Salted Hide Tannery": {
+    owner: "Salted Hide Curriers",
+    stewards: ["Currier Mave Saltedhide"],
+    notes: "Tannery adjoining the Wavehide guild for raw hide processing.",
+  },
+  "Shrine of the Roadwarden": {
+    owner: "Roadwarden Order",
+    stewards: ["Marshal Theon Shieldmarch"],
+    notes: "Shrine where caravan guards swear oaths before departure.",
+  },
+  "Caravan Square": {
+    owner: "Wave's Break",
+    notes: "Staging plaza for caravan musters and pack-train inspections.",
+  },
+  "Wayfarer's Rest Tavern": {
+    owner: "Wayfarer Hearth Family",
+    stewards: ["Innkeep Dela Wayfarer"],
+    notes: "Roadhouse serving trail stews and quiet bunks.",
+  },
+  // Farmland support structures
+  "Harbor Hearth Bakery": {
+    owner: "Hearthoven Bakers",
+    stewards: ["Baker Thera Hearthoven"],
+    notes: "Bakery distributing loaves to gate barracks and caravans.",
+  },
+  "Tidehold Granary & Provisioners": {
+    owner: "Wave's Break",
+    stewards: ["Quartermaster Rel Tidehold"],
+    notes: "Provision yard stockpiling grain and tack for emergency levies.",
+  },
+};
+
+export function applyWavesBreakRegistry(locations: Record<string, Location>) {
+  const wave = locations["Wave's Break"];
+  if (!wave) return;
+
+  const businessGroups = new Map<string, BusinessProfile[]>(
+    Array.from(ALL_BUSINESS_GROUPS.entries()).map(([key, names]) => [
+      key,
+      filterBusinesses(wave.businesses, names),
+    ]),
+  );
+
+  const customBoards: Record<string, Quest[]> = {};
+  const boardPlans = [
+    ["farmland", FARMLAND_BOARD_PLAN],
+    ["port", PORT_BOARD_PLAN],
+    ["upper", UPPER_WARD_BOARD_PLAN],
+    ["terns", LITTLE_TERNS_BOARD_PLAN],
+    ["greensoul", GREENSOUL_HILL_BOARD_PLAN],
+    ["gardens", LOWER_GARDENS_BOARD_PLAN],
+    ["highroad", HIGH_ROAD_BOARD_PLAN],
+  ] as const;
+
+  boardPlans.forEach(([key, plan]) => {
+    const businesses = businessGroups.get(key) || [];
+    const binding = getGroupBinding(key);
+    businesses.forEach((business) => applyQuestVisibilityToBusiness(business, binding));
+    const boards = collectBoardQuests(businesses, plan, binding);
+    Object.assign(customBoards, boards);
+  });
+
+  wave.questBoards = customBoards;
+  wave.quests = Object.values(customBoards).reduce<Quest[]>(
+    (acc, quests) => acc.concat(quests),
+    [],
+  );
+
+  wave.ownership = {
+    businesses: WAVES_BREAK_BUSINESS_OWNERS,
+    buildings: {
+      ...WAVES_BREAK_BUSINESS_OWNERS,
+      ...WAVES_BREAK_BUILDING_OWNERS,
+    },
+  };
+}
+
+export const WAVES_BREAK_REGISTRY = {
+  businessOwners: WAVES_BREAK_BUSINESS_OWNERS,
+  buildingOwners: {
+    ...WAVES_BREAK_BUSINESS_OWNERS,
+    ...WAVES_BREAK_BUILDING_OWNERS,
+  },
+  boardPlans: ALL_BOARD_PLANS,
+};

--- a/assets/data/weather.js
+++ b/assets/data/weather.js
@@ -1,0 +1,424 @@
+import {
+  advanceDate,
+  compareDates,
+  dateKey,
+  dayOfYear,
+  getSeasonForDate,
+  normalizeDate,
+} from './calendar.js';
+
+const CLAMP = (value, min, max) => Math.min(max, Math.max(min, value));
+
+function hashString(value) {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function createDeterministicRandom(key) {
+  let state = hashString(key) || 1;
+  return () => {
+    state = (state * 1664525 + 1013904223) % 4294967296;
+    return (state >>> 0) / 4294967296;
+  };
+}
+
+export function deterministicRandom(key) {
+  return createDeterministicRandom(key)();
+}
+
+function cloneDate(date) {
+  return { year: date.year, monthIndex: date.monthIndex, day: date.day };
+}
+
+function createInitialState(soil) {
+  return {
+    soilMoisture: soil.baseMoisture,
+    dryStreak: 0,
+    wetStreak: 0,
+    lastStormDay: null,
+    lastSimulated: null,
+    lastReport: null,
+  };
+}
+
+function pickCondition(temperature, precipitationMm, isStorm, hasDrizzle, foggy) {
+  if (isStorm) return temperature <= 0 ? 'snow' : 'storm';
+  if (temperature <= -1 && precipitationMm > 0) return 'snow';
+  if (temperature <= 1 && precipitationMm > 0) return 'sleet';
+  if (precipitationMm > 3) return 'rain';
+  if (hasDrizzle) return 'drizzle';
+  if (foggy) return 'fog';
+  if (precipitationMm > 0) return 'partly cloudy';
+  return temperature > 25 ? 'clear' : 'partly cloudy';
+}
+
+function buildNarrative(condition, habitat, droughtStage, floodRisk, storm) {
+  const parts = [];
+  if (storm) {
+    parts.push('Squalls batter the coastline, sending crews scrambling.');
+  } else if (condition === 'rain' || condition === 'drizzle') {
+    parts.push('Steady precipitation keeps laborers working under tarps.');
+  } else if (condition === 'snow') {
+    parts.push('Wet snow weighs on rooftops and harbor ropes.');
+  } else if (condition === 'fog') {
+    parts.push('Fog settles in low, muting lantern light.');
+  } else if (condition === 'clear') {
+    parts.push('Bright skies give crews a full day of travel.');
+  }
+  if (droughtStage === 'warning') {
+    parts.push('Fields crack under the ongoing dry spell.');
+  } else if (droughtStage === 'watch') {
+    parts.push('Soil moisture is thinning across the ' + habitat + '.');
+  }
+  if (floodRisk === 'warning') {
+    parts.push('Ditches overflow and low alleys pool with water.');
+  } else if (floodRisk === 'watch') {
+    parts.push('Drainage crews keep an eye on runoff channels.');
+  }
+  return parts.join(' ');
+}
+
+function computeOutlook(rng, precipitation, soil, season, storm, soilMoisture, trend, temperature) {
+  const baseStormChance = precipitation.stormChance * (precipitation.chance + trend.wetSpellDays * 0.05);
+  const stormLikely = rng() < CLAMP(baseStormChance + (storm ? 0.2 : 0), 0, 0.95);
+  const droughtGap = CLAMP(soil.droughtThreshold - soilMoisture, -1, 1);
+  const drySpellLikely = rng() < CLAMP(0.15 + Math.max(0, droughtGap) * 0.8, 0, 0.95);
+  const floodLikely = rng() < CLAMP(Math.max(0, soilMoisture - soil.floodThreshold) * 1.2, 0, 0.9);
+  let expectedCondition = 'partly cloudy';
+  if (stormLikely) {
+    expectedCondition = temperature <= 0 ? 'snow' : 'storm';
+  } else if (drySpellLikely) {
+    expectedCondition = 'clear';
+  } else if (floodLikely) {
+    expectedCondition = 'rain';
+  }
+  const demandModifier = CLAMP(
+    (storm ? 0.15 : 0) +
+      (drySpellLikely ? 0.1 : 0) +
+      (floodLikely ? 0.1 : 0) +
+      (season === 'Autumn' ? 0.05 : 0),
+    -0.25,
+    0.4,
+  );
+  return { stormLikely, drySpellLikely, floodLikely, expectedCondition, demandModifier };
+}
+
+function updateSoil(state, soil, precipitationMm, evaporationRate, temperature, isStorm, currentDay) {
+  if (precipitationMm > 0) {
+    const absorption = CLAMP((precipitationMm / 25) * soil.infiltration, 0, 1);
+    state.soilMoisture = CLAMP(state.soilMoisture * soil.retention + absorption, 0, 1);
+    state.dryStreak = 0;
+    state.wetStreak += 1;
+    if (isStorm || precipitationMm > 12) {
+      state.lastStormDay = currentDay;
+    }
+  } else {
+    const heatFactor = temperature > 20 ? 1 + (temperature - 20) / 40 : 1;
+    state.soilMoisture = CLAMP(state.soilMoisture * soil.retention - evaporationRate * heatFactor, 0, 1);
+    state.dryStreak += 1;
+    state.wetStreak = 0;
+  }
+}
+
+function computeHydrologyFlags(state, soil) {
+  let droughtStage = 'none';
+  let floodRisk = 'none';
+  if (state.soilMoisture <= soil.droughtThreshold) {
+    droughtStage = state.dryStreak >= 4 ? 'warning' : 'watch';
+  }
+  if (state.soilMoisture >= soil.floodThreshold) {
+    floodRisk = state.wetStreak >= 3 ? 'warning' : 'watch';
+  }
+  return { droughtStage, floodRisk };
+}
+
+export class RegionalWeatherGenerator {
+  constructor(profiles, startDate) {
+    if (Array.isArray(profiles)) {
+      this.climates = Object.fromEntries(profiles.map((profile) => [profile.key, profile]));
+    } else {
+      this.climates = Object.assign({}, profiles);
+    }
+    this.states = new Map();
+    this.startDate = startDate ? normalizeDate(startDate) : { year: 732, monthIndex: 0, day: 1 };
+  }
+
+  reset(regionKey, habitat) {
+    if (regionKey && habitat) {
+      this.states.delete(this.stateKey(regionKey, habitat));
+      return;
+    }
+    if (regionKey) {
+      Array.from(this.states.keys()).forEach((key) => {
+        if (key.startsWith(`${regionKey}:`)) {
+          this.states.delete(key);
+        }
+      });
+      return;
+    }
+    this.states.clear();
+  }
+
+  getDailyWeather(regionKey, habitat, date) {
+    const climate = this.climates[regionKey];
+    if (!climate) {
+      throw new Error(`Unknown climate region: ${regionKey}`);
+    }
+    const habitatClimate = climate.habitats[habitat];
+    if (!habitatClimate) {
+      throw new Error(`No climate profile for habitat ${habitat} in ${regionKey}`);
+    }
+
+    const key = this.stateKey(regionKey, habitat);
+    let state = this.states.get(key);
+    if (!state) {
+      state = createInitialState(habitatClimate.soil);
+      this.states.set(key, state);
+    }
+
+    const targetDate = normalizeDate(date);
+
+    if (!state.lastSimulated) {
+      state.lastSimulated = advanceDate(this.startDate, -1);
+      state.lastReport = null;
+    }
+
+    if (compareDates(targetDate, state.lastSimulated) < 0) {
+      state = createInitialState(habitatClimate.soil);
+      state.lastSimulated = advanceDate(this.startDate, -1);
+      state.lastReport = null;
+      this.states.set(key, state);
+    }
+
+    while (compareDates(state.lastSimulated, targetDate) < 0) {
+      const nextDate = advanceDate(state.lastSimulated, 1);
+      const report = this.simulateDay(regionKey, habitat, habitatClimate, state, nextDate);
+      state.lastSimulated = cloneDate(nextDate);
+      state.lastReport = report;
+    }
+
+    if (!state.lastReport) {
+      state.lastReport = this.simulateDay(regionKey, habitat, habitatClimate, state, targetDate);
+      state.lastSimulated = cloneDate(targetDate);
+    }
+
+    return state.lastReport;
+  }
+
+  stateKey(regionKey, habitat) {
+    return `${regionKey}:${habitat}`;
+  }
+
+  simulateDay(regionKey, habitat, climate, state, date) {
+    const season = getSeasonForDate(date);
+    const rng = createDeterministicRandom(`${regionKey}:${habitat}:${dateKey(date)}`);
+
+    const tempProfile = climate.temperature[season];
+    const baseTemp = tempProfile.min + (tempProfile.max - tempProfile.min) * rng();
+    const temperatureC = baseTemp + (rng() - 0.5) * tempProfile.variability;
+
+    const humidityBase = climate.humidity[season];
+    const humidity = CLAMP(humidityBase + (rng() - 0.5) * 10, 35, 100);
+
+    const precipProfile = climate.precipitation[season];
+    const precipRoll = rng();
+    let precipitationMm = 0;
+    let isStorm = false;
+    let hasDrizzle = false;
+    let foggy = false;
+
+    if (precipRoll < precipProfile.chance) {
+      const intensity = precipProfile.minMm + (precipProfile.maxMm - precipProfile.minMm) * rng();
+      precipitationMm = Math.max(0, intensity);
+      isStorm = rng() < precipProfile.stormChance;
+      if (!isStorm && precipProfile.drizzleChance) {
+        hasDrizzle = rng() < precipProfile.drizzleChance;
+      }
+    } else if (precipProfile.fogChance && rng() < precipProfile.fogChance) {
+      foggy = true;
+    }
+
+    const condition = pickCondition(temperatureC, precipitationMm, isStorm, hasDrizzle, foggy);
+
+    updateSoil(
+      state,
+      climate.soil,
+      precipitationMm,
+      climate.evaporation[season],
+      temperatureC,
+      isStorm,
+      dayOfYear(date),
+    );
+
+    const { droughtStage, floodRisk } = computeHydrologyFlags(state, climate.soil);
+
+    const trend = {
+      drySpellDays: state.dryStreak,
+      wetSpellDays: state.wetStreak,
+      lastStormDaysAgo: state.lastStormDay != null ? dayOfYear(date) - state.lastStormDay : null,
+    };
+
+    const outlook = computeOutlook(
+      rng,
+      precipProfile,
+      climate.soil,
+      season,
+      isStorm,
+      state.soilMoisture,
+      trend,
+      temperatureC,
+    );
+
+    const narrative = buildNarrative(condition, habitat, droughtStage, floodRisk, isStorm);
+
+    return {
+      region: regionKey,
+      habitat,
+      date: cloneDate(date),
+      season,
+      temperatureC: Math.round(temperatureC * 10) / 10,
+      humidity: Math.round(humidity),
+      precipitationMm: Math.round(precipitationMm * 10) / 10,
+      condition,
+      soilMoisture: Math.round(state.soilMoisture * 100) / 100,
+      droughtStage,
+      floodRisk,
+      storm: isStorm,
+      trend,
+      outlook,
+      narrative,
+    };
+  }
+}
+
+const SPRING = { min: 6, max: 14, variability: 4 };
+const SUMMER = { min: 12, max: 22, variability: 5 };
+const AUTUMN = { min: 8, max: 16, variability: 4 };
+const WINTER = { min: 1, max: 9, variability: 5 };
+
+const FARMLAND_CLIMATE = {
+  temperature: {
+    Spring: SPRING,
+    Summer: { min: 14, max: 24, variability: 5 },
+    Autumn: AUTUMN,
+    Winter: { min: -1, max: 7, variability: 5 },
+  },
+  precipitation: {
+    Spring: { chance: 0.5, stormChance: 0.18, minMm: 2, maxMm: 18, drizzleChance: 0.2 },
+    Summer: { chance: 0.35, stormChance: 0.22, minMm: 1, maxMm: 20, drizzleChance: 0.1 },
+    Autumn: { chance: 0.55, stormChance: 0.25, minMm: 3, maxMm: 22, drizzleChance: 0.2 },
+    Winter: { chance: 0.45, stormChance: 0.2, minMm: 1, maxMm: 15, fogChance: 0.2 },
+  },
+  humidity: {
+    Spring: 74,
+    Summer: 70,
+    Autumn: 78,
+    Winter: 80,
+  },
+  evaporation: {
+    Spring: 0.02,
+    Summer: 0.035,
+    Autumn: 0.025,
+    Winter: 0.015,
+  },
+  soil: {
+    baseMoisture: 0.58,
+    infiltration: 0.7,
+    retention: 0.82,
+    droughtThreshold: 0.28,
+    floodThreshold: 0.82,
+  },
+};
+
+const COASTAL_CLIMATE = {
+  temperature: {
+    Spring: SPRING,
+    Summer: SUMMER,
+    Autumn: AUTUMN,
+    Winter: WINTER,
+  },
+  precipitation: {
+    Spring: { chance: 0.48, stormChance: 0.22, minMm: 2, maxMm: 20, fogChance: 0.18 },
+    Summer: { chance: 0.4, stormChance: 0.28, minMm: 1, maxMm: 24, drizzleChance: 0.12 },
+    Autumn: { chance: 0.6, stormChance: 0.3, minMm: 3, maxMm: 26, drizzleChance: 0.18 },
+    Winter: { chance: 0.5, stormChance: 0.24, minMm: 1, maxMm: 18, fogChance: 0.25 },
+  },
+  humidity: {
+    Spring: 82,
+    Summer: 78,
+    Autumn: 84,
+    Winter: 86,
+  },
+  evaporation: {
+    Spring: 0.018,
+    Summer: 0.03,
+    Autumn: 0.02,
+    Winter: 0.014,
+  },
+  soil: {
+    baseMoisture: 0.62,
+    infiltration: 0.55,
+    retention: 0.78,
+    droughtThreshold: 0.32,
+    floodThreshold: 0.8,
+  },
+};
+
+const URBAN_CLIMATE = {
+  temperature: {
+    Spring: SPRING,
+    Summer: { min: 14, max: 25, variability: 5 },
+    Autumn: AUTUMN,
+    Winter: { min: 2, max: 8, variability: 4 },
+  },
+  precipitation: {
+    Spring: { chance: 0.46, stormChance: 0.18, minMm: 1, maxMm: 16, fogChance: 0.15 },
+    Summer: { chance: 0.33, stormChance: 0.2, minMm: 1, maxMm: 18, drizzleChance: 0.12 },
+    Autumn: { chance: 0.5, stormChance: 0.24, minMm: 2, maxMm: 20, drizzleChance: 0.15 },
+    Winter: { chance: 0.42, stormChance: 0.18, minMm: 1, maxMm: 14, fogChance: 0.22 },
+  },
+  humidity: {
+    Spring: 72,
+    Summer: 68,
+    Autumn: 75,
+    Winter: 78,
+  },
+  evaporation: {
+    Spring: 0.018,
+    Summer: 0.03,
+    Autumn: 0.02,
+    Winter: 0.012,
+  },
+  soil: {
+    baseMoisture: 0.48,
+    infiltration: 0.42,
+    retention: 0.7,
+    droughtThreshold: 0.24,
+    floodThreshold: 0.72,
+  },
+};
+
+export const WAVES_BREAK_REGION_CLIMATE = {
+  key: 'waves_break',
+  label: "Wave's Break Littoral",
+  habitats: {
+    coastal: COASTAL_CLIMATE,
+    farmland: FARMLAND_CLIMATE,
+    urban: URBAN_CLIMATE,
+  },
+  prevailingWinds: 'Southerly sea breezes in spring, stiff western gales in autumn',
+  notes:
+    'Climate blends maritime spray with reclaimed lowlands; soil moisture swings govern city labor more than temperature extremes.',
+};
+
+export const DEFAULT_REGIONAL_CLIMATES = {
+  [WAVES_BREAK_REGION_CLIMATE.key]: WAVES_BREAK_REGION_CLIMATE,
+};
+
+export function createDefaultWeatherGenerator(startDate) {
+  return new RegionalWeatherGenerator(DEFAULT_REGIONAL_CLIMATES, startDate);
+}

--- a/assets/data/weather.ts
+++ b/assets/data/weather.ts
@@ -1,0 +1,574 @@
+import {
+  advanceDate,
+  compareDates,
+  dateKey,
+  dayOfYear,
+  getSeasonForDate,
+  normalizeDate,
+} from './calendar.js';
+import type { CalendarDate, CalendarSeason } from './calendar.js';
+
+export type Habitat = 'coastal' | 'farmland' | 'urban' | 'woodland' | 'mountain' | 'river';
+export type WeatherCondition =
+  | 'clear'
+  | 'partly cloudy'
+  | 'overcast'
+  | 'drizzle'
+  | 'rain'
+  | 'storm'
+  | 'fog'
+  | 'snow'
+  | 'sleet';
+
+interface TemperatureProfile {
+  min: number;
+  max: number;
+  variability: number;
+}
+
+interface PrecipitationProfile {
+  chance: number;
+  stormChance: number;
+  minMm: number;
+  maxMm: number;
+  fogChance?: number;
+  drizzleChance?: number;
+}
+
+interface HabitatSoilProfile {
+  baseMoisture: number;
+  infiltration: number;
+  retention: number;
+  droughtThreshold: number;
+  floodThreshold: number;
+}
+
+interface HabitatClimate {
+  temperature: Record<CalendarSeason, TemperatureProfile>;
+  precipitation: Record<CalendarSeason, PrecipitationProfile>;
+  humidity: Record<CalendarSeason, number>;
+  evaporation: Record<CalendarSeason, number>;
+  soil: HabitatSoilProfile;
+}
+
+export interface RegionClimateProfile {
+  key: string;
+  label: string;
+  habitats: Partial<Record<Habitat, HabitatClimate>>;
+  prevailingWinds?: string;
+  notes?: string;
+}
+
+interface WeatherState {
+  soilMoisture: number;
+  dryStreak: number;
+  wetStreak: number;
+  lastStormDay: number | null;
+  lastSimulated: CalendarDate | null;
+  lastReport: WeatherReport | null;
+}
+
+export interface WeatherTrend {
+  drySpellDays: number;
+  wetSpellDays: number;
+  lastStormDaysAgo: number | null;
+}
+
+export interface WeatherOutlook {
+  stormLikely: boolean;
+  drySpellLikely: boolean;
+  floodLikely: boolean;
+  expectedCondition: WeatherCondition;
+  demandModifier: number;
+}
+
+export interface WeatherReport {
+  region: string;
+  habitat: Habitat;
+  date: CalendarDate;
+  season: CalendarSeason;
+  temperatureC: number;
+  humidity: number;
+  precipitationMm: number;
+  condition: WeatherCondition;
+  soilMoisture: number;
+  droughtStage: 'none' | 'watch' | 'warning';
+  floodRisk: 'none' | 'watch' | 'warning';
+  storm: boolean;
+  trend: WeatherTrend;
+  outlook: WeatherOutlook;
+  narrative: string;
+}
+
+const CLAMP = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+function hashString(value: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function createDeterministicRandom(key: string): () => number {
+  let state = hashString(key) || 1;
+  return () => {
+    state = (state * 1664525 + 1013904223) % 4294967296;
+    return (state >>> 0) / 4294967296;
+  };
+}
+
+export function deterministicRandom(key: string): number {
+  return createDeterministicRandom(key)();
+}
+
+function cloneDate(date: CalendarDate): CalendarDate {
+  return { year: date.year, monthIndex: date.monthIndex, day: date.day };
+}
+
+function createInitialState(soil: HabitatSoilProfile): WeatherState {
+  return {
+    soilMoisture: soil.baseMoisture,
+    dryStreak: 0,
+    wetStreak: 0,
+    lastStormDay: null,
+    lastSimulated: null,
+    lastReport: null,
+  };
+}
+
+function pickCondition(
+  temperature: number,
+  precipitationMm: number,
+  isStorm: boolean,
+  hasDrizzle: boolean,
+  foggy: boolean,
+): WeatherCondition {
+  if (isStorm) return temperature <= 0 ? 'snow' : 'storm';
+  if (temperature <= -1 && precipitationMm > 0) return 'snow';
+  if (temperature <= 1 && precipitationMm > 0) return 'sleet';
+  if (precipitationMm > 3) return 'rain';
+  if (hasDrizzle) return 'drizzle';
+  if (foggy) return 'fog';
+  if (precipitationMm > 0) return 'partly cloudy';
+  return temperature > 25 ? 'clear' : 'partly cloudy';
+}
+
+function buildNarrative(
+  condition: WeatherCondition,
+  habitat: Habitat,
+  droughtStage: 'none' | 'watch' | 'warning',
+  floodRisk: 'none' | 'watch' | 'warning',
+  storm: boolean,
+): string {
+  const parts: string[] = [];
+  if (storm) {
+    parts.push('Squalls batter the coastline, sending crews scrambling.');
+  } else if (condition === 'rain' || condition === 'drizzle') {
+    parts.push('Steady precipitation keeps laborers working under tarps.');
+  } else if (condition === 'snow') {
+    parts.push('Wet snow weighs on rooftops and harbor ropes.');
+  } else if (condition === 'fog') {
+    parts.push('Fog settles in low, muting lantern light.');
+  } else if (condition === 'clear') {
+    parts.push('Bright skies give crews a full day of travel.');
+  }
+  if (droughtStage === 'warning') {
+    parts.push('Fields crack under the ongoing dry spell.');
+  } else if (droughtStage === 'watch') {
+    parts.push('Soil moisture is thinning across the ' + habitat + '.');
+  }
+  if (floodRisk === 'warning') {
+    parts.push('Ditches overflow and low alleys pool with water.');
+  } else if (floodRisk === 'watch') {
+    parts.push('Drainage crews keep an eye on runoff channels.');
+  }
+  return parts.join(' ');
+}
+
+function computeOutlook(
+  rng: () => number,
+  precipitation: PrecipitationProfile,
+  soil: HabitatSoilProfile,
+  season: CalendarSeason,
+  storm: boolean,
+  soilMoisture: number,
+  trend: WeatherTrend,
+  temperature: number,
+): WeatherOutlook {
+  const baseStormChance = precipitation.stormChance * (precipitation.chance + trend.wetSpellDays * 0.05);
+  const stormLikely = rng() < CLAMP(baseStormChance + (storm ? 0.2 : 0), 0, 0.95);
+  const droughtGap = CLAMP(soil.droughtThreshold - soilMoisture, -1, 1);
+  const drySpellLikely = rng() < CLAMP(0.15 + Math.max(0, droughtGap) * 0.8, 0, 0.95);
+  const floodLikely = rng() < CLAMP(Math.max(0, soilMoisture - soil.floodThreshold) * 1.2, 0, 0.9);
+  let expectedCondition: WeatherCondition = 'partly cloudy';
+  if (stormLikely) {
+    expectedCondition = temperature <= 0 ? 'snow' : 'storm';
+  } else if (drySpellLikely) {
+    expectedCondition = 'clear';
+  } else if (floodLikely) {
+    expectedCondition = 'rain';
+  }
+  const demandModifier = CLAMP(
+    (storm ? 0.15 : 0) +
+      (drySpellLikely ? 0.1 : 0) +
+      (floodLikely ? 0.1 : 0) +
+      (season === 'Autumn' ? 0.05 : 0),
+    -0.25,
+    0.4,
+  );
+  return { stormLikely, drySpellLikely, floodLikely, expectedCondition, demandModifier };
+}
+
+function updateSoil(
+  state: WeatherState,
+  soil: HabitatSoilProfile,
+  precipitationMm: number,
+  evaporationRate: number,
+  temperature: number,
+  isStorm: boolean,
+  currentDay: number,
+) {
+  if (precipitationMm > 0) {
+    const absorption = CLAMP((precipitationMm / 25) * soil.infiltration, 0, 1);
+    state.soilMoisture = CLAMP(
+      state.soilMoisture * soil.retention + absorption,
+      0,
+      1,
+    );
+    state.dryStreak = 0;
+    state.wetStreak += 1;
+    if (isStorm || precipitationMm > 12) {
+      state.lastStormDay = currentDay;
+    }
+  } else {
+    const heatFactor = temperature > 20 ? 1 + (temperature - 20) / 40 : 1;
+    state.soilMoisture = CLAMP(
+      state.soilMoisture * soil.retention - evaporationRate * heatFactor,
+      0,
+      1,
+    );
+    state.dryStreak += 1;
+    state.wetStreak = 0;
+  }
+}
+
+function computeHydrologyFlags(
+  state: WeatherState,
+  soil: HabitatSoilProfile,
+): { droughtStage: 'none' | 'watch' | 'warning'; floodRisk: 'none' | 'watch' | 'warning' } {
+  let droughtStage: 'none' | 'watch' | 'warning' = 'none';
+  let floodRisk: 'none' | 'watch' | 'warning' = 'none';
+
+  if (state.soilMoisture <= soil.droughtThreshold) {
+    droughtStage = state.dryStreak >= 4 ? 'warning' : 'watch';
+  }
+
+  if (state.soilMoisture >= soil.floodThreshold) {
+    floodRisk = state.wetStreak >= 3 ? 'warning' : 'watch';
+  }
+
+  return { droughtStage, floodRisk };
+}
+
+export class RegionalWeatherGenerator {
+  private readonly climates: Record<string, RegionClimateProfile>;
+  private readonly states = new Map<string, WeatherState>();
+  private readonly startDate: CalendarDate;
+
+  constructor(
+    profiles: RegionClimateProfile[] | Record<string, RegionClimateProfile>,
+    startDate?: CalendarDate,
+  ) {
+    if (Array.isArray(profiles)) {
+      this.climates = Object.fromEntries(profiles.map((profile) => [profile.key, profile]));
+    } else {
+      this.climates = { ...profiles };
+    }
+    this.startDate = startDate ? normalizeDate(startDate) : { year: 732, monthIndex: 0, day: 1 };
+  }
+
+  reset(regionKey?: string, habitat?: Habitat): void {
+    if (regionKey && habitat) {
+      this.states.delete(this.stateKey(regionKey, habitat));
+      return;
+    }
+    if (regionKey) {
+      Array.from(this.states.keys()).forEach((key) => {
+        if (key.startsWith(`${regionKey}:`)) {
+          this.states.delete(key);
+        }
+      });
+      return;
+    }
+    this.states.clear();
+  }
+
+  getDailyWeather(regionKey: string, habitat: Habitat, date: CalendarDate): WeatherReport {
+    const climate = this.climates[regionKey];
+    if (!climate) {
+      throw new Error(`Unknown climate region: ${regionKey}`);
+    }
+    const habitatClimate = climate.habitats[habitat];
+    if (!habitatClimate) {
+      throw new Error(`No climate profile for habitat ${habitat} in ${regionKey}`);
+    }
+
+    const key = this.stateKey(regionKey, habitat);
+    let state = this.states.get(key);
+    if (!state) {
+      state = createInitialState(habitatClimate.soil);
+      this.states.set(key, state);
+    }
+
+    const targetDate = normalizeDate(date);
+
+    if (!state.lastSimulated) {
+      state.lastSimulated = advanceDate(this.startDate, -1);
+      state.lastReport = null;
+    }
+
+    if (compareDates(targetDate, state.lastSimulated) < 0) {
+      state = createInitialState(habitatClimate.soil);
+      state.lastSimulated = advanceDate(this.startDate, -1);
+      state.lastReport = null;
+      this.states.set(key, state);
+    }
+
+    while (compareDates(state.lastSimulated, targetDate) < 0) {
+      const nextDate = advanceDate(state.lastSimulated, 1);
+      const report = this.simulateDay(regionKey, habitat, habitatClimate, state, nextDate);
+      state.lastSimulated = cloneDate(nextDate);
+      state.lastReport = report;
+    }
+
+    if (!state.lastReport) {
+      state.lastReport = this.simulateDay(regionKey, habitat, habitatClimate, state, targetDate);
+      state.lastSimulated = cloneDate(targetDate);
+    }
+
+    return state.lastReport;
+  }
+
+  private stateKey(regionKey: string, habitat: Habitat): string {
+    return `${regionKey}:${habitat}`;
+  }
+
+  private simulateDay(
+    regionKey: string,
+    habitat: Habitat,
+    climate: HabitatClimate,
+    state: WeatherState,
+    date: CalendarDate,
+  ): WeatherReport {
+    const season = getSeasonForDate(date);
+    const rng = createDeterministicRandom(`${regionKey}:${habitat}:${dateKey(date)}`);
+
+    const tempProfile = climate.temperature[season];
+    const baseTemp = tempProfile.min + (tempProfile.max - tempProfile.min) * rng();
+    const temperatureC = baseTemp + (rng() - 0.5) * tempProfile.variability;
+
+    const humidityBase = climate.humidity[season];
+    const humidity = CLAMP(humidityBase + (rng() - 0.5) * 10, 35, 100);
+
+    const precipProfile = climate.precipitation[season];
+    const precipRoll = rng();
+    let precipitationMm = 0;
+    let isStorm = false;
+    let hasDrizzle = false;
+    let foggy = false;
+
+    if (precipRoll < precipProfile.chance) {
+      const intensity = precipProfile.minMm + (precipProfile.maxMm - precipProfile.minMm) * rng();
+      precipitationMm = Math.max(0, intensity);
+      isStorm = rng() < precipProfile.stormChance;
+      if (!isStorm && precipProfile.drizzleChance) {
+        hasDrizzle = rng() < precipProfile.drizzleChance;
+      }
+    } else if (precipProfile.fogChance && rng() < precipProfile.fogChance) {
+      foggy = true;
+    }
+
+    const condition = pickCondition(temperatureC, precipitationMm, isStorm, hasDrizzle, foggy);
+
+    updateSoil(
+      state,
+      climate.soil,
+      precipitationMm,
+      climate.evaporation[season],
+      temperatureC,
+      isStorm,
+      dayOfYear(date),
+    );
+
+    const { droughtStage, floodRisk } = computeHydrologyFlags(state, climate.soil);
+
+    const trend: WeatherTrend = {
+      drySpellDays: state.dryStreak,
+      wetSpellDays: state.wetStreak,
+      lastStormDaysAgo:
+        state.lastStormDay != null ? dayOfYear(date) - state.lastStormDay : null,
+    };
+
+    const outlook = computeOutlook(
+      rng,
+      precipProfile,
+      climate.soil,
+      season,
+      isStorm,
+      state.soilMoisture,
+      trend,
+      temperatureC,
+    );
+
+    const narrative = buildNarrative(condition, habitat, droughtStage, floodRisk, isStorm);
+
+    return {
+      region: regionKey,
+      habitat,
+      date: cloneDate(date),
+      season,
+      temperatureC: Math.round(temperatureC * 10) / 10,
+      humidity: Math.round(humidity),
+      precipitationMm: Math.round(precipitationMm * 10) / 10,
+      condition,
+      soilMoisture: Math.round(state.soilMoisture * 100) / 100,
+      droughtStage,
+      floodRisk,
+      storm: isStorm,
+      trend,
+      outlook,
+      narrative,
+    };
+  }
+}
+
+const SPRING: TemperatureProfile = { min: 6, max: 14, variability: 4 };
+const SUMMER: TemperatureProfile = { min: 12, max: 22, variability: 5 };
+const AUTUMN: TemperatureProfile = { min: 8, max: 16, variability: 4 };
+const WINTER: TemperatureProfile = { min: 1, max: 9, variability: 5 };
+
+const FARMLAND_CLIMATE: HabitatClimate = {
+  temperature: {
+    Spring: SPRING,
+    Summer: { min: 14, max: 24, variability: 5 },
+    Autumn: AUTUMN,
+    Winter: { min: -1, max: 7, variability: 5 },
+  },
+  precipitation: {
+    Spring: { chance: 0.5, stormChance: 0.18, minMm: 2, maxMm: 18, drizzleChance: 0.2 },
+    Summer: { chance: 0.35, stormChance: 0.22, minMm: 1, maxMm: 20, drizzleChance: 0.1 },
+    Autumn: { chance: 0.55, stormChance: 0.25, minMm: 3, maxMm: 22, drizzleChance: 0.2 },
+    Winter: { chance: 0.45, stormChance: 0.2, minMm: 1, maxMm: 15, fogChance: 0.2 },
+  },
+  humidity: {
+    Spring: 74,
+    Summer: 70,
+    Autumn: 78,
+    Winter: 80,
+  },
+  evaporation: {
+    Spring: 0.02,
+    Summer: 0.035,
+    Autumn: 0.025,
+    Winter: 0.015,
+  },
+  soil: {
+    baseMoisture: 0.58,
+    infiltration: 0.7,
+    retention: 0.82,
+    droughtThreshold: 0.28,
+    floodThreshold: 0.82,
+  },
+};
+
+const COASTAL_CLIMATE: HabitatClimate = {
+  temperature: {
+    Spring: SPRING,
+    Summer: SUMMER,
+    Autumn: AUTUMN,
+    Winter: WINTER,
+  },
+  precipitation: {
+    Spring: { chance: 0.48, stormChance: 0.22, minMm: 2, maxMm: 20, fogChance: 0.18 },
+    Summer: { chance: 0.4, stormChance: 0.28, minMm: 1, maxMm: 24, drizzleChance: 0.12 },
+    Autumn: { chance: 0.6, stormChance: 0.3, minMm: 3, maxMm: 26, drizzleChance: 0.18 },
+    Winter: { chance: 0.5, stormChance: 0.24, minMm: 1, maxMm: 18, fogChance: 0.25 },
+  },
+  humidity: {
+    Spring: 82,
+    Summer: 78,
+    Autumn: 84,
+    Winter: 86,
+  },
+  evaporation: {
+    Spring: 0.018,
+    Summer: 0.03,
+    Autumn: 0.02,
+    Winter: 0.014,
+  },
+  soil: {
+    baseMoisture: 0.62,
+    infiltration: 0.55,
+    retention: 0.78,
+    droughtThreshold: 0.32,
+    floodThreshold: 0.8,
+  },
+};
+
+const URBAN_CLIMATE: HabitatClimate = {
+  temperature: {
+    Spring: SPRING,
+    Summer: { min: 14, max: 25, variability: 5 },
+    Autumn: AUTUMN,
+    Winter: { min: 2, max: 8, variability: 4 },
+  },
+  precipitation: {
+    Spring: { chance: 0.46, stormChance: 0.18, minMm: 1, maxMm: 16, fogChance: 0.15 },
+    Summer: { chance: 0.33, stormChance: 0.2, minMm: 1, maxMm: 18, drizzleChance: 0.12 },
+    Autumn: { chance: 0.5, stormChance: 0.24, minMm: 2, maxMm: 20, drizzleChance: 0.15 },
+    Winter: { chance: 0.42, stormChance: 0.18, minMm: 1, maxMm: 14, fogChance: 0.22 },
+  },
+  humidity: {
+    Spring: 72,
+    Summer: 68,
+    Autumn: 75,
+    Winter: 78,
+  },
+  evaporation: {
+    Spring: 0.018,
+    Summer: 0.03,
+    Autumn: 0.02,
+    Winter: 0.012,
+  },
+  soil: {
+    baseMoisture: 0.48,
+    infiltration: 0.42,
+    retention: 0.7,
+    droughtThreshold: 0.24,
+    floodThreshold: 0.72,
+  },
+};
+
+export const WAVES_BREAK_REGION_CLIMATE: RegionClimateProfile = {
+  key: 'waves_break',
+  label: "Wave's Break Littoral",
+  habitats: {
+    coastal: COASTAL_CLIMATE,
+    farmland: FARMLAND_CLIMATE,
+    urban: URBAN_CLIMATE,
+  },
+  prevailingWinds: 'Southerly sea breezes in spring, stiff western gales in autumn',
+  notes:
+    'Climate blends maritime spray with reclaimed lowlands; soil moisture swings govern city labor more than temperature extremes.',
+};
+
+export const DEFAULT_REGIONAL_CLIMATES: Record<string, RegionClimateProfile> = {
+  [WAVES_BREAK_REGION_CLIMATE.key]: WAVES_BREAK_REGION_CLIMATE,
+};
+
+export function createDefaultWeatherGenerator(startDate?: CalendarDate) {
+  return new RegionalWeatherGenerator(DEFAULT_REGIONAL_CLIMATES, startDate);
+}

--- a/tests/wavesBreakOwnership.test.ts
+++ b/tests/wavesBreakOwnership.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { LOCATIONS } from '../assets/data/locations.js';
+import { applyWavesBreakRegistry } from '../assets/data/waves_break_registry.js';
+
+applyWavesBreakRegistry(LOCATIONS);
+
+const wave = LOCATIONS["Wave's Break"];
+
+describe("Wave's Break registry", () => {
+  it('assigns ownership for every business', () => {
+    expect(wave.ownership?.businesses).toBeDefined();
+    const owners = wave.ownership?.businesses ?? {};
+    wave.businesses.forEach((business) => {
+      const detail = owners[business.name];
+      expect(detail, `Missing owner for business ${business.name}`).toBeDefined();
+      expect(detail?.owner).toBeTruthy();
+    });
+  });
+
+  it('assigns ownership for every building', () => {
+    expect(wave.ownership?.buildings).toBeDefined();
+    const owners = wave.ownership?.buildings ?? {};
+    wave.pointsOfInterest.buildings.forEach((building) => {
+      const detail = owners[building];
+      expect(detail, `Missing owner for building ${building}`).toBeDefined();
+      expect(detail?.owner).toBeTruthy();
+    });
+  });
+
+  it('routes Wave\'s Break quest postings through curated boards', () => {
+    const boardNames = Object.keys(wave.questBoards);
+    expect(boardNames.length).toBeGreaterThan(0);
+    expect(boardNames).toContain('North Gate Labor Postings');
+    expect(boardNames).toContain('South Gate Field Contracts');
+    expect(boardNames).toContain('Harborwatch Quay Ledger');
+    expect(boardNames).toContain('Adventurers\' Guild Contract Archive');
+    expect(boardNames.every((name) => !name.endsWith('Quest Board'))).toBe(true);
+
+    const businessNames = new Set(wave.businesses.map((b) => b.name));
+    const covered = new Set<string>();
+    Object.values(wave.questBoards).forEach((quests) => {
+      quests.forEach((quest) => {
+        if (quest.location && businessNames.has(quest.location)) {
+          covered.add(quest.location);
+        }
+      });
+    });
+    businessNames.forEach((name) => {
+      expect(covered.has(name), `Missing quest board coverage for ${name}`).toBe(true);
+    });
+  });
+});

--- a/tests/worldSystems.test.ts
+++ b/tests/worldSystems.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MONTHS,
+  DAYS_PER_MONTH,
+  DAYS_PER_YEAR,
+  TidefallCalendar,
+  advanceDate,
+  dateKey,
+  getSeasonForDate,
+} from '../assets/data/calendar.js';
+import {
+  createDefaultWeatherGenerator,
+  createDeterministicRandom,
+} from '../assets/data/weather.js';
+import { LOCATIONS } from '../assets/data/locations.js';
+import { applyWavesBreakRegistry } from '../assets/data/waves_break_registry.js';
+
+applyWavesBreakRegistry(LOCATIONS);
+
+describe('calendar system', () => {
+  it('tracks a 13 month, 28 day calendar year', () => {
+    expect(MONTHS.length).toBe(13);
+    expect(DAYS_PER_MONTH).toBe(28);
+    expect(DAYS_PER_YEAR).toBe(364);
+  });
+
+  it('advances dates across year boundaries', () => {
+    const calendar = new TidefallCalendar({ year: 732, monthIndex: 12, day: 27 });
+    calendar.advance(5);
+    expect(calendar.today()).toEqual({ year: 733, monthIndex: 0, day: 4 });
+    expect(getSeasonForDate(calendar.today())).toBe('Spring');
+  });
+});
+
+describe('weather generator', () => {
+  it('produces deterministic daily reports with hydrology trends', () => {
+    const generator = createDefaultWeatherGenerator({ year: 732, monthIndex: 0, day: 1 });
+    const reports: any[] = [];
+    let date = { year: 732, monthIndex: 0, day: 1 };
+    for (let i = 0; i < 40; i += 1) {
+      reports.push(generator.getDailyWeather('waves_break', 'farmland', date));
+      date = advanceDate(date, 1);
+    }
+    const droughtSeen = reports.some((report) => report.droughtStage !== 'none');
+    const floodSeen = reports.some((report) => report.floodRisk !== 'none');
+    expect(droughtSeen || floodSeen).toBe(true);
+    const repeat = generator.getDailyWeather('waves_break', 'farmland', { year: 732, monthIndex: 0, day: 10 });
+    expect(repeat).toEqual(reports[9]);
+  });
+});
+
+describe('quest visibility rules', () => {
+  const wave = LOCATIONS["Wave's Break"];
+  const farmlandBoard = wave.questBoards['North Gate Labor Postings'];
+  const kilnQuest = farmlandBoard.find((quest) => quest.title === "Kiln-Keeper's Call");
+  const stormQuest = farmlandBoard.find((quest) => quest.title === 'Harborface Rush Order');
+  const generator = createDefaultWeatherGenerator({ year: 732, monthIndex: 0, day: 1 });
+
+  it('keeps dry-season kiln work gated until conditions warrant', () => {
+    if (!kilnQuest?.visibility) throw new Error('Expected kiln quest visibility');
+    const binding = kilnQuest.visibilityBinding || { region: 'waves_break', habitat: 'farmland', business: kilnQuest.location };
+    const startDate = { year: 732, monthIndex: 0, day: 1 };
+    const startWeather = generator.getDailyWeather(binding.region, binding.habitat, startDate);
+    const startRng = createDeterministicRandom(
+      `${binding.region}:${binding.habitat}:${binding.business}:${dateKey(startDate)}:${kilnQuest.title}`,
+    );
+    const initialAvailability = kilnQuest.visibility({
+      date: startDate,
+      weather: startWeather,
+      random: startRng,
+      binding,
+      laborCondition: kilnQuest.laborCondition,
+      questTitle: kilnQuest.title,
+    });
+    let date = startDate;
+    let maxDemand = initialAvailability.demand;
+    for (let i = 0; i < 120; i += 1) {
+      const weather = generator.getDailyWeather(binding.region, binding.habitat, date);
+      const rng = createDeterministicRandom(
+        `${binding.region}:${binding.habitat}:${binding.business}:${dateKey(date)}:${kilnQuest.title}`,
+      );
+      const availability = kilnQuest.visibility({
+        date,
+        weather,
+        random: rng,
+        binding,
+        laborCondition: kilnQuest.laborCondition,
+        questTitle: kilnQuest.title,
+      });
+      if (availability.demand > maxDemand) {
+        maxDemand = availability.demand;
+      }
+      date = advanceDate(date, 1);
+    }
+    expect(maxDemand).toBeGreaterThan(initialAvailability.demand);
+  });
+
+  it('activates storm response quests only during surge conditions', () => {
+    if (!stormQuest?.visibility) throw new Error('Expected storm quest visibility');
+    const binding = stormQuest.visibilityBinding || { region: 'waves_break', habitat: 'farmland', business: stormQuest.location };
+    const calmDate = { year: 732, monthIndex: 0, day: 1 };
+    const calmWeather = generator.getDailyWeather(binding.region, binding.habitat, calmDate);
+    const calmRng = createDeterministicRandom(
+      `${binding.region}:${binding.habitat}:${binding.business}:${dateKey(calmDate)}:${stormQuest.title}`,
+    );
+    const calmAvailability = stormQuest.visibility({
+      date: calmDate,
+      weather: calmWeather,
+      random: calmRng,
+      binding,
+      laborCondition: stormQuest.laborCondition,
+      questTitle: stormQuest.title,
+    });
+    expect(calmAvailability.available).toBe(false);
+
+    let date = calmDate;
+    let seenStorm = false;
+    for (let i = 0; i < 90; i += 1) {
+      const weather = generator.getDailyWeather(binding.region, binding.habitat, date);
+      if (weather.storm || weather.floodRisk !== 'none') {
+        const rng = createDeterministicRandom(
+          `${binding.region}:${binding.habitat}:${binding.business}:${dateKey(date)}:${stormQuest.title}`,
+        );
+        const availability = stormQuest.visibility({
+          date,
+          weather,
+          random: rng,
+          binding,
+          laborCondition: stormQuest.laborCondition,
+          questTitle: stormQuest.title,
+        });
+        expect(availability.available).toBe(true);
+        seenStorm = true;
+        break;
+      }
+      date = advanceDate(date, 1);
+    }
+    expect(seenStorm).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- rename the Tidefall calendar months and constellations to varied seasonal fantasy motifs rather than sea-centric titles
- refresh each description to match the new lore-friendly constellation themes

## Testing
- npm run validate
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cacd25392c8325a5955b79df2219eb