### PR TITLE
Fix UI loading by restoring smithy dependencies

### DIFF
--- a/data/game/crafting_proficiency.js
+++ b/data/game/crafting_proficiency.js
@@ -1,0 +1,28 @@
+import { F_repeat, W_unlock_window, POST_UNLOCK_CHOKE_K } from "./proficiency_base.js";
+
+const r2 = (x) => Math.round(x * 100) / 100;
+
+export const CRAFT_CFG = {
+  g0: 0.5,
+  repeat: F_repeat,
+  unlockWindow: W_unlock_window,
+  postUnlockChokeK: POST_UNLOCK_CHOKE_K,
+};
+
+export function gainCraftProficiency(input, cfg = CRAFT_CFG) {
+  const { P, cap, recipeUnlock, N_same, success } = input;
+  if (!success) return r2(P);
+
+  const diff = P - recipeUnlock;
+  let F_unlock;
+  if (diff < 0) {
+    F_unlock = 1 + (-diff) / cfg.unlockWindow;
+  } else {
+    F_unlock = 1 / (1 + diff / cfg.postUnlockChokeK);
+  }
+
+  const F_rep = cfg.repeat(N_same);
+  const raw = cfg.g0 * F_rep * F_unlock;
+  const gain = Math.min(raw, Math.max(0, cap - P));
+  return r2(P + gain);
+}

--- a/data/game/shop.js
+++ b/data/game/shop.js
@@ -611,6 +611,48 @@ function producePlan(context) {
   return { sells: normalized, buys, resale: false };
 }
 
+function forgePlan(context) {
+  const wealthQualities =
+    context.wealth === "wealthy"
+      ? ["Luxury", "Arcane"]
+      : context.wealth === "comfortable"
+        ? ["Common", "Fine"]
+        : ["Common"];
+  const sells = [
+    {
+      key: "Metals",
+      label: context.scale === "large" ? "Ingots & Stock" : "Smelted Metals",
+      limit: { small: 2, medium: 4, large: 6 },
+      preferBulk: context.scale !== "small",
+      preferBasics: context.wealth !== "wealthy"
+    },
+    {
+      key: "Weapons",
+      label: context.wealth === "wealthy" ? "Commissioned Weapons" : "Forged Weapons",
+      limit: { small: 3, medium: 5, large: 8 },
+      quality: wealthQualities,
+      allowQualityFallback: true,
+      sort: context.wealth === "wealthy" ? "desc" : null
+    },
+    {
+      key: "Armor",
+      label: context.wealth === "wealthy" ? "Plate & Mail" : "Forged Armor",
+      limit: { small: 2, medium: 4, large: 6 },
+      quality: wealthQualities,
+      allowQualityFallback: true,
+      sort: context.wealth === "wealthy" ? "desc" : null
+    },
+    {
+      key: "Tools",
+      label: "Smithing Tools",
+      limit: { small: 1, medium: 2, large: 3 },
+      preferBasics: true
+    }
+  ].map(section => finalizeSection(section, context));
+  const buys = ["Metals", "Weapons", "Armor", "Tools"];
+  return { sells, buys, resale: false };
+}
+
 function tailorPlan(context) {
   const wealthQualities = context.wealth === "wealthy" ? ["Luxury", "Arcane"] : context.wealth === "comfortable" ? ["Common", "Fine"] : ["Common"];
   const sells = [


### PR DESCRIPTION
## Summary
- add a JavaScript build for `crafting_proficiency` so craft tracking modules load in the browser
- define a smithy `forgePlan` inventory rule to replace the missing reference in the shop planner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caf47ba72083259012437155b4bf42