### PR TITLE
Adjust top menu layout and recalc height after updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,10 +18,6 @@
   <button id="character-button" aria-label="Character" style="display:none;">
     <img id="character-icon" src="assets/images/icons/Character Menu Male.png" alt="Character">
   </button>
-  <div class="top-menu-info">
-    <span id="menu-date">Date: —</span>
-    <span id="menu-money">Funds: —</span>
-  </div>
   <div class="settings-group">
     <button id="settings-button" aria-label="Settings">
       <img src="assets/images/icons/Settings.png" alt="Settings">
@@ -37,6 +33,10 @@
         <img src="assets/images/icons/Plus.png" alt="Increase">
       </button>
     </div>
+  </div>
+  <div class="top-menu-info">
+    <span id="menu-date">Date: —</span>
+    <span id="menu-money">Funds: —</span>
   </div>
   </nav>
 

--- a/script.js
+++ b/script.js
@@ -469,6 +469,11 @@ function updateTopMenuIndicators() {
       : '—';
     menuMoneyLabel.textContent = `Funds: ${funds}`;
   }
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(() => updateMenuHeight());
+  } else {
+    updateMenuHeight();
+  }
 }
 
 function updateLayoutSize() {

--- a/style.css
+++ b/style.css
@@ -105,7 +105,6 @@ main {
   }
 
 .top-menu-info {
-  margin-left: auto;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -114,7 +113,8 @@ main {
   line-height: 1.1;
   font-weight: 600;
   color: var(--menu-color-dark);
-  padding: 0 0.5rem;
+  padding: 0 0.5rem 0 0.25rem;
+  margin-left: 0.25rem;
 }
 
 .top-menu-info span {
@@ -143,7 +143,7 @@ body.theme-dark .top-menu-info {
   gap: 0.0625rem;
   position: relative;
   align-items: center;
-  margin-left: 0.25rem;
+  margin-left: auto;
 }
 
 @media (orientation: portrait) {


### PR DESCRIPTION
## Summary
- reposition the top menu date/funds display so the settings controls stay visible
- tweak top menu spacing so the indicators sit to the right of the settings buttons without forcing them off-screen
- recalculate menu height after the indicators update to avoid layout issues during initial load

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc84fedd148325b0fda72bddec7967