### PR TITLE
Add arcane, desert court, and merchant equipment sets

### DIFF
--- a/data/game/equipment.d.ts
+++ b/data/game/equipment.d.ts
@@ -7,6 +7,7 @@ export type WeaponSlot =
 
 export type ArmorSlot =
   | "head"
+  | "face"
   | "neck"
   | "body"
   | "shoulders"
@@ -23,6 +24,8 @@ export type TrinketSlot =
   | "neck"
   | "lRing"
   | "rRing"
+  | "brooch"
+  | "belt"
   | "pouch";
 
 export type DamageType = "BLUNT" | "SLASH" | "PIERCE";
@@ -83,6 +86,8 @@ export interface ArmorCatalogItem {
   critDefense?: number;
   slots: string[];
   setMemberships?: string[];
+  effects?: string[];
+  bonuses?: Record<string, number>;
 }
 
 export interface ArmorSet {
@@ -109,6 +114,8 @@ export interface TrinketCatalogItem {
   suggestedPriceCp: number;
   netProfitCp: number;
   slots: string[];
+  effects?: string[];
+  bonuses?: Record<string, number>;
 }
 
 export interface TrinketCatalog {

--- a/data/game/equipment.js
+++ b/data/game/equipment.js
@@ -8,6 +8,7 @@ export const WEAPON_SLOTS = [
 
 export const ARMOR_SLOTS = [
   "head",
+  "face",
   "neck",
   "body",
   "shoulders",
@@ -25,6 +26,8 @@ export const TRINKET_SLOTS = [
   "neck",
   "lRing",
   "rRing",
+  "brooch",
+  "belt",
   "pouch"
 ];
 
@@ -45,6 +48,7 @@ export const CODEX_SCHEMA = {
     armorClasses: ["Light", "Medium", "Heavy"],
     slotsArmor: [
       "head",
+      "face",
       "neck",
       "body",
       "shoulders",
@@ -56,7 +60,7 @@ export const CODEX_SCHEMA = {
       "feet"
     ],
     slotsWeapons: ["mainHand", "offHand", "ranged", "instrument", "ammo"],
-    slotsTrinkets: ["lEar", "rEar", "neck", "lRing", "rRing", "pouch"],
+    slotsTrinkets: ["lEar", "rEar", "neck", "lRing", "rRing", "brooch", "belt", "pouch"],
     quality: ["Standard", "Fine", "Masterwork"],
     regions: [
       "High Kingdoms",
@@ -1935,6 +1939,256 @@ export const ARMOR_CATALOG = {
       critDefense: 2,
       slots: ["feet"],
       setMemberships: ["aset:courtly-royal"]
+    },
+    {
+      id: "arm:witchs-widebrim-head",
+      categoryKey: "armor",
+      internalName: "witchs-widebrim",
+      displayName: "Witch’s Widebrim (Head)",
+      baseItem: "Witch’s Widebrim",
+      variant: "Runesewn brim",
+      qualityTier: "Arcane",
+      primaryConsumer: "Arcanist",
+      unit: "each",
+      marketValueCp: 5200,
+      displayPrice: "2g 12si",
+      suggestedPriceCp: 5200,
+      materialCostCp: null,
+      laborCostCp: null,
+      overheadCp: 520,
+      netProfitCp: 4680,
+      dutyPct: 0,
+      regions: ["High Villages"],
+      defense: 14,
+      strReq: 0,
+      weightClass: "Light",
+      resists: { BLUNT: 4, SLASH: 6, PIERCE: 5 },
+      critDefense: 3,
+      slots: ["head"],
+      setMemberships: ["aset:arcane-attire"],
+      effects: [
+        "Bolsters arcane channeling",
+        "Draws down moonlight to restore spent mana"
+      ],
+      bonuses: { spellFocusPct: 4, manaRegenPct: 3, nightSightBonusPct: 10 }
+    },
+    {
+      id: "arm:sky-dancer-boots-feet",
+      categoryKey: "armor",
+      internalName: "sky-dancer-boots",
+      displayName: "Sky Dancer Boots (Feet)",
+      baseItem: "Sky Dancer Boots",
+      variant: "Featherlight soles",
+      qualityTier: "Arcane",
+      primaryConsumer: "Arcanist",
+      unit: "pair",
+      marketValueCp: 4800,
+      displayPrice: "2g 8si",
+      suggestedPriceCp: 4800,
+      materialCostCp: null,
+      laborCostCp: null,
+      overheadCp: 480,
+      netProfitCp: 4320,
+      dutyPct: 0,
+      regions: ["High Villages"],
+      defense: 12,
+      strReq: 0,
+      weightClass: "Light",
+      resists: { BLUNT: 3, SLASH: 4, PIERCE: 4 },
+      slots: ["feet"],
+      setMemberships: ["aset:arcane-attire"],
+      effects: [
+        "Featherstep enchantments cushion leaps",
+        "Winds assist dodges while airborne"
+      ],
+      bonuses: { moveSpeedPct: 6, evadePct: 4, fallDamageReductionPct: 25 }
+    },
+    {
+      id: "arm:silken-turban-head",
+      categoryKey: "armor",
+      internalName: "silken-turban",
+      displayName: "Silken Turban (Head)",
+      baseItem: "Silken Turban",
+      variant: "Desert court weave",
+      qualityTier: "Luxury",
+      primaryConsumer: "Envoy",
+      unit: "each",
+      marketValueCp: 3100,
+      displayPrice: "1g 11si",
+      suggestedPriceCp: 3100,
+      materialCostCp: null,
+      laborCostCp: null,
+      overheadCp: 310,
+      netProfitCp: 2790,
+      dutyPct: 0,
+      regions: ["Southern Kingdoms"],
+      defense: 16,
+      strReq: 0,
+      weightClass: "Light",
+      resists: { BLUNT: 3, SLASH: 6, PIERCE: 4 },
+      critDefense: 2,
+      slots: ["head"],
+      setMemberships: ["aset:desert-court"],
+      effects: [
+        "Veils the wearer from desert sun",
+        "Keeps sand devils from the eyes"
+      ],
+      bonuses: { heatResistPct: 20, perceptionBonusPct: 4 }
+    },
+    {
+      id: "arm:mistveil-cape-back",
+      categoryKey: "armor",
+      internalName: "mistveil-cape",
+      displayName: "Mistveil Cape (Back)",
+      baseItem: "Mistveil Cape",
+      variant: "Layered gauze",
+      qualityTier: "Luxury",
+      primaryConsumer: "Envoy",
+      unit: "each",
+      marketValueCp: 3600,
+      displayPrice: "1g 16si",
+      suggestedPriceCp: 3600,
+      materialCostCp: null,
+      laborCostCp: null,
+      overheadCp: 360,
+      netProfitCp: 3240,
+      dutyPct: 0,
+      regions: ["Southern Kingdoms"],
+      defense: 18,
+      strReq: 0,
+      weightClass: "Light",
+      resists: { BLUNT: 4, SLASH: 7, PIERCE: 3 },
+      slots: ["back"],
+      setMemberships: ["aset:desert-court"],
+      effects: [
+        "Billows mirage-light to break an archer’s aim",
+        "Sheds dust and grit with a shake"
+      ],
+      bonuses: { heatResistPct: 10, stealthBonusPct: 6, evadePct: 2 }
+    },
+    {
+      id: "arm:sandskimmer-goggles-face",
+      categoryKey: "armor",
+      internalName: "sandskimmer-goggles",
+      displayName: "Sandskimmer Goggles (Face)",
+      baseItem: "Sandskimmer Goggles",
+      variant: "Sunstone lenses",
+      qualityTier: "Luxury",
+      primaryConsumer: "Envoy",
+      unit: "each",
+      marketValueCp: 2400,
+      displayPrice: "1g 4si",
+      suggestedPriceCp: 2400,
+      materialCostCp: null,
+      laborCostCp: null,
+      overheadCp: 240,
+      netProfitCp: 2160,
+      dutyPct: 0,
+      regions: ["Southern Kingdoms"],
+      defense: 8,
+      strReq: 0,
+      weightClass: "Light",
+      resists: { BLUNT: 2, SLASH: 3, PIERCE: 5 },
+      slots: ["face"],
+      setMemberships: ["aset:desert-court"],
+      effects: [
+        "Filters grit and glare when storms rise",
+        "Focuses distant silhouettes along the dunes"
+      ],
+      bonuses: { sandstormVisionPct: 40, rangedAccuracyPct: 3 }
+    },
+    {
+      id: "arm:guildmaster-vest-body",
+      categoryKey: "armor",
+      internalName: "guildmaster-vest",
+      displayName: "Guildmaster Vest (Body)",
+      baseItem: "Guildmaster Vest",
+      variant: "Ledger-lined",
+      qualityTier: "Fine",
+      primaryConsumer: "Merchant",
+      unit: "each",
+      marketValueCp: 2800,
+      displayPrice: "1g 8si",
+      suggestedPriceCp: 2800,
+      materialCostCp: null,
+      laborCostCp: null,
+      overheadCp: 280,
+      netProfitCp: 2520,
+      dutyPct: 0,
+      regions: ["High Kingdoms"],
+      defense: 28,
+      strReq: 0,
+      weightClass: "Light",
+      resists: { BLUNT: 6, SLASH: 12, PIERCE: 8 },
+      slots: ["body"],
+      setMemberships: ["aset:merchant-guild"],
+      effects: [
+        "Hidden pockets balance ledger weight",
+        "Copper-thread wards against sudden blades"
+      ],
+      bonuses: { presenceBonusPct: 6, negotiationBonusPct: 8 }
+    },
+    {
+      id: "arm:guntram-warbelt-waist",
+      categoryKey: "armor",
+      internalName: "guntram-warbelt",
+      displayName: "Guntram Warbelt (Waist)",
+      baseItem: "Guntram Warbelt",
+      variant: "Layered cuirboulli",
+      qualityTier: "Fine",
+      primaryConsumer: "Merchant Guard",
+      unit: "each",
+      marketValueCp: 2100,
+      displayPrice: "1g 1si",
+      suggestedPriceCp: 2100,
+      materialCostCp: null,
+      laborCostCp: null,
+      overheadCp: 210,
+      netProfitCp: 1890,
+      dutyPct: 0,
+      regions: ["High Kingdoms"],
+      defense: 14,
+      strReq: 1,
+      weightClass: "Medium",
+      resists: { BLUNT: 4, SLASH: 5, PIERCE: 4 },
+      slots: ["waist"],
+      setMemberships: ["aset:merchant-guild"],
+      effects: [
+        "Distributes satchel loads across the hips",
+        "Brace plates guard against knives in the crowd"
+      ],
+      bonuses: { carryCapacityPct: 12, staminaRegenPct: 2 }
+    },
+    {
+      id: "arm:messenger-satchel-back",
+      categoryKey: "armor",
+      internalName: "messenger-satchel",
+      displayName: "Messenger Satchel (Back)",
+      baseItem: "Messenger Satchel",
+      variant: "Waxed couriers’ leather",
+      qualityTier: "Fine",
+      primaryConsumer: "Merchant",
+      unit: "each",
+      marketValueCp: 1950,
+      displayPrice: "19si 50cp",
+      suggestedPriceCp: 1950,
+      materialCostCp: null,
+      laborCostCp: null,
+      overheadCp: 195,
+      netProfitCp: 1755,
+      dutyPct: 0,
+      regions: ["High Kingdoms"],
+      defense: 10,
+      strReq: 0,
+      weightClass: "Light",
+      resists: { BLUNT: 3, SLASH: 4, PIERCE: 3 },
+      slots: ["back"],
+      setMemberships: ["aset:merchant-guild"],
+      effects: [
+        "Courier compartments keep missives dry",
+        "Harness lets packs drop free for a quick draw"
+      ],
+      bonuses: { inventorySlotsBonus: 4, travelSpeedPct: 4 }
     }
   ],
   sets: [
@@ -2223,6 +2477,61 @@ export const ARMOR_CATALOG = {
         threatReductionPct: 6,
         critDamageReductionPct: 4
       }
+    },
+    {
+      id: "aset:arcane-attire",
+      displayName: "Arcane Attire Set",
+      components: [
+        "arm:witchs-widebrim-head",
+        "arm:sky-dancer-boots-feet",
+        "trn:lucky-raven-pin",
+        "trn:serpents-eye",
+        "trn:moonsilver-band"
+      ],
+      class: "Light",
+      setBonuses: {
+        spellFocusPct: 8,
+        manaRegenPct: 6,
+        EVADE_PCT: 4,
+        critChancePct: 3
+      }
+    },
+    {
+      id: "aset:desert-court",
+      displayName: "Desert Court Set",
+      components: [
+        "arm:silken-turban-head",
+        "arm:mistveil-cape-back",
+        "arm:sandskimmer-goggles-face",
+        "trn:river-pearl-chain"
+      ],
+      class: "Light",
+      setBonuses: {
+        heatResistPct: 20,
+        EVADE_PCT: 3,
+        DMG_TAKEN_PCT: -2,
+        perceptionBonusPct: 6,
+        travelSpeedPct: 4
+      }
+    },
+    {
+      id: "aset:merchant-guild",
+      displayName: "Merchant Guild Set",
+      components: [
+        "arm:guildmaster-vest-body",
+        "arm:guntram-warbelt-waist",
+        "arm:messenger-satchel-back",
+        "trn:herbalist-belt",
+        "trn:physic-kit-pouch"
+      ],
+      class: "Light",
+      setBonuses: {
+        negotiationBonusPct: 12,
+        tradePriceBonusPct: 10,
+        carryCapacityPct: 15,
+        DMG_TAKEN_PCT: -1,
+        staminaRegenPct: 2
+      }
     }
   ]
 };
@@ -2316,6 +2625,102 @@ export const TRINKET_CATALOG = {
       suggestedPriceCp: 1357,
       netProfitCp: 203.544,
       slots: ["neck"]
+    },
+    {
+      id: "trn:lucky-raven-pin",
+      displayName: "Lucky Raven Pin",
+      variant: "Feathered obsidian",
+      qualityTier: "Arcane",
+      marketValueCp: 3600,
+      displayPrice: "1g 16si",
+      suggestedPriceCp: 3600,
+      netProfitCp: 3240,
+      slots: ["brooch"],
+      effects: [
+        "Feather-charms coax fortune in the wearer’s favor",
+        "Softens falls as the pin’s feathers flare"
+      ],
+      bonuses: { luckBonusPct: 5, missileEvadePct: 5, critChancePct: 3 }
+    },
+    {
+      id: "trn:serpents-eye",
+      displayName: "Serpent’s Eye",
+      variant: "Verdant crystal",
+      qualityTier: "Arcane",
+      marketValueCp: 4200,
+      displayPrice: "2g 2si",
+      suggestedPriceCp: 4200,
+      netProfitCp: 3780,
+      slots: ["neck"],
+      effects: [
+        "Glass gem sees heat shimmer and hidden venom",
+        "Attunes spell chants with sibilant harmony"
+      ],
+      bonuses: { spellFocusPct: 3, perceptionBonusPct: 6, poisonResistPct: 15 }
+    },
+    {
+      id: "trn:moonsilver-band",
+      displayName: "Moonsilver Band",
+      variant: "Runed circlet",
+      qualityTier: "Arcane",
+      marketValueCp: 4000,
+      displayPrice: "2g",
+      suggestedPriceCp: 4000,
+      netProfitCp: 3600,
+      slots: ["lRing", "rRing"],
+      effects: [
+        "Pale glyphs sip moonlight for reserves",
+        "Stills shaking hands when weaving wards"
+      ],
+      bonuses: { manaRegenPct: 4, wardStrengthPct: 3 }
+    },
+    {
+      id: "trn:river-pearl-chain",
+      displayName: "River Pearl Chain",
+      variant: "Court tassel",
+      qualityTier: "Luxury",
+      marketValueCp: 2500,
+      displayPrice: "1g 5si",
+      suggestedPriceCp: 2500,
+      netProfitCp: 2250,
+      slots: ["neck"],
+      effects: [
+        "Cool pearls ease parched throats in the dunes",
+        "Polished shell charms favor courtly words"
+      ],
+      bonuses: { diplomacyBonusPct: 6, heatResistPct: 8 }
+    },
+    {
+      id: "trn:herbalist-belt",
+      displayName: "Herbalist Belt",
+      variant: "Glass vials",
+      qualityTier: "Fine",
+      marketValueCp: 1800,
+      displayPrice: "18si",
+      suggestedPriceCp: 1800,
+      netProfitCp: 1620,
+      slots: ["belt"],
+      effects: [
+        "Holds fresh-cut sprigs at even weight",
+        "Colour-coded straps quick-sort reagents"
+      ],
+      bonuses: { alchemyBonusPct: 8, potionBrewSpeedPct: 10 }
+    },
+    {
+      id: "trn:physic-kit-pouch",
+      displayName: "Physic Kit Pouch",
+      variant: "Fold-out organizer",
+      qualityTier: "Fine",
+      marketValueCp: 1600,
+      displayPrice: "16si",
+      suggestedPriceCp: 1600,
+      netProfitCp: 1440,
+      slots: ["pouch"],
+      effects: [
+        "Keeps tinctures braced against jostling",
+        "Labelled tabs cut response time in crises"
+      ],
+      bonuses: { medicineBonusPct: 10, emergencyResponsePct: 12 }
     }
   ]
 };
@@ -2331,6 +2736,7 @@ export function createEmptyEquipment() {
     },
     armor: {
       head: null,
+      face: null,
       neck: null,
       body: null,
       shoulders: null,
@@ -2347,6 +2753,8 @@ export function createEmptyEquipment() {
       neck: null,
       lRing: null,
       rRing: null,
+      brooch: null,
+      belt: null,
       pouch: null
     }
   };

--- a/script.js
+++ b/script.js
@@ -3690,6 +3690,7 @@ const SLOT_ICONS = {
   instrument: '<svg viewBox="0 0 24 24"><path d="M6 3c4 9 10 12 10 19H6Z"/><path d="M6 7h8"/><path d="M6 11h9"/><path d="M6 15h8"/><path d="M6 19h6"/></svg>',
   ammo: '<svg viewBox="0 0 24 24"><path d="M3 12h14"/><polyline points="3 9 6 12 3 15"/><polyline points="17 7 23 12 17 17"/></svg>',
   head: '<svg viewBox="0 0 24 24"><path d="M2 10l4-2 3 3 3-6 3 6 3-3 4 2v8H2z"/></svg>',
+  face: '<svg viewBox="0 0 24 24"><circle cx="12" cy="9" r="4"/><path d="M4 20c1.2-3.2 4.6-5 8-5s6.8 1.8 8 5"/><path d="M7 9h10"/></svg>',
   body: '<svg viewBox="0 0 24 24"><path d="M20.38 3.46 16 2a4 4 0 0 1-8 0L3.62 3.46a2 2 0 0 0-1.34 2.23l.58 3.47a1 1 0 0 0 .99.84H6v10c0 1.1.9 2 2 2h8a2 2 0 0 0 2-2V10h2.15a1 1 0 0 0 .99-.84l.58-3.47a2 2 0 0 0-1.34-2.23z" /></svg>',
   shoulders: '<svg viewBox="0 0 24 24"><path d="M4 9a8 8 0 0 1 16 0v9l-6 4-1-5h-2l-1 5-6-4z"/></svg>',
   back: '<svg viewBox="0 0 24 24"><path d="M12 2c3 1 5 4 5 8v12l-5-3-5 3V10c0-4 2-7 5-8z"/></svg>',
@@ -3701,6 +3702,8 @@ const SLOT_ICONS = {
   lEar: '<svg viewBox="0 0 24 24"><g transform="scale(-1,1) translate(-24,0)"><path d="M6 8.5a6.5 6.5 0 1 1 13 0c0 6-6 6-6 10a3.5 3.5 0 1 1-7 0"/><path d="M15 8.5a2.5 2.5 0 0 0-5 0v1a2 2 0 1 1 0 4"/></g></svg>',
   neck: '<svg viewBox="0 0 24 24"><path d="M4 5a8 8 0 0 0 16 0"/><circle cx="12" cy="13" r="2"/><path d="M12 15v4"/></svg>',
   lRing: '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="5" /></svg>',
+  brooch: '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 8V4"/><path d="M12 16v4"/></svg>',
+  belt: '<svg viewBox="0 0 24 24"><rect x="3" y="10" width="18" height="4" rx="1"/><rect x="10" y="9" width="4" height="6" rx="0.5"/><path d="M3 12h4"/><path d="M17 12h4"/></svg>',
   pouch: '<svg viewBox="0 0 24 24"><path d="M4 7h16v10a5 5 0 0 1-5 5H9a5 5 0 0 1-5-5z"/><path d="M4 7l8-4 8 4"/><rect x="9" y="11" width="6" height="3"/><path d="M12 11v3"/></svg>'
 };
 SLOT_ICONS.rEar = '<svg viewBox="0 0 24 24"><path d="M6 8.5a6.5 6.5 0 1 1 13 0c0 6-6 6-6 10a3.5 3.5 0 1 1-7 0"/><path d="M15 8.5a2.5 2.5 0 0 0-5 0v1a2 2 0 1 1 0 4"/></svg>';
@@ -3710,10 +3713,14 @@ function formatSlotName(slot) {
   const names = {
     mainHand: 'Main Hand',
     offHand: 'Off Hand',
+    face: 'Face',
     lEar: 'Left Ear',
     rEar: 'Right Ear',
     lRing: 'Left Ring',
-    rRing: 'Right Ring'
+    rRing: 'Right Ring',
+    brooch: 'Brooch',
+    belt: 'Belt',
+    pouch: 'Pouch'
   };
   return (
     names[slot] ||


### PR DESCRIPTION
## Summary
- add new equipment slots, armor pieces, and trinkets for the Arcane Attire, Desert Court, and Merchant Guild collections with full combat stats and pricing
- extend catalog typings and data to record item effects/bonuses and define the new armor set bonuses
- update the UI slot icons so the new face, brooch, and belt trinket placements display correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc9d2e9b6883259eacd0bee1d5d567