### PR TITLE
Integrate special effect glossary into combat status data

### DIFF
--- a/data/game/combat.ts
+++ b/data/game/combat.ts
@@ -73,6 +73,317 @@ export interface CombatOptions {
   rng?: () => number;
 }
 
+export type StatusEffectDiscipline =
+  | "damage"
+  | "control"
+  | "utility"
+  | "armorTrait"
+  | "accessoryTrait";
+
+export interface StatusEffectEntry {
+  name: string;
+  aliases?: string[];
+  summary: string;
+  delivery: string;
+  duration: string;
+  tacticalNotes: string;
+}
+
+export interface StatusEffectCategory {
+  id: string;
+  title: string;
+  discipline: StatusEffectDiscipline;
+  description: string;
+  entries: StatusEffectEntry[];
+}
+
+export const STATUS_EFFECT_GLOSSARY: StatusEffectCategory[] = [
+  {
+    id: "damage-types",
+    title: "Damage Types",
+    discipline: "damage",
+    description:
+      "Primary damage channels that describe how martial or elemental attacks interact with defenses and resistances.",
+    entries: [
+      {
+        name: "Slashing",
+        summary: "Shearing strikes that excel at cutting exposed targets.",
+        delivery: "Melee weapon arcs",
+        duration: "Instant",
+        tacticalNotes:
+          "Edge alignment and follow-through reward precise form, making slashing ideal against lightly armored foes or enemies already suffering defense breaks.",
+      },
+      {
+        name: "Piercing",
+        summary: "Focused thrusts that punch through armor gaps.",
+        delivery: "Melee thrust or thrown point",
+        duration: "Instant",
+        tacticalNotes:
+          "Reliable against plated opponents; accuracy and timing let the attacker bypass shields or interlocking mail by targeting seams and joints.",
+      },
+      {
+        name: "Blunt",
+        aliases: ["Breaker", "Sunder"],
+        summary: "Concussive blows that transfer force through armor.",
+        delivery: "Melee bludgeon",
+        duration: "Instant",
+        tacticalNotes:
+          "Excellent for shattering shields and staggering heavily armored enemies, often pairing with control effects that exploit the resulting imbalance.",
+      },
+      {
+        name: "Bleed",
+        aliases: ["Rend"],
+        summary: "Persistent wounds that drain vitality over time.",
+        delivery: "Melee precision cuts",
+        duration: "Timed 2–4 turns",
+        tacticalNotes:
+          "Stacks with other sustained pressure; best applied early in an encounter so follow-up attacks capitalize on the attrition.",
+      },
+      {
+        name: "Burn",
+        summary: "Lingering flames that continue to scorch the target area.",
+        delivery: "Area ignition or explosive burst",
+        duration: "Timed 2–3 turns",
+        tacticalNotes:
+          "Spreads pressure across clustered enemies, denies zones, and punishes foes who remain in chokepoints or tight formations.",
+      },
+    ],
+  },
+  {
+    id: "control-effects",
+    title: "Control Effects",
+    discipline: "control",
+    description:
+      "Disabling maneuvers that limit an opponent's options, movement, or access to gear for a tactical window.",
+    entries: [
+      {
+        name: "Hook",
+        aliases: ["Trip", "Disarm"],
+        summary: "Jolts the enemy off balance or strips their weapon.",
+        delivery: "Close-quarters grapple",
+        duration: "Instant to 1 turn",
+        tacticalNotes:
+          "Perfect opener for setting up allies; forcing a weapon drop or knockdown exposes gaps that coordinated parties can exploit immediately.",
+      },
+      {
+        name: "Stun",
+        aliases: ["Daze"],
+        summary: "Completely halts the target's next action.",
+        delivery: "Heavy melee impact",
+        duration: "1 turn",
+        tacticalNotes:
+          "Timing matters—use to interrupt casts or momentum attacks. Many elite foes resist chain stuns, so alternate with other disables.",
+      },
+      {
+        name: "Snare",
+        aliases: ["Entangle"],
+        summary: "Restricts movement with binding lines or growth.",
+        delivery: "Short-range control",
+        duration: "1–2 turns",
+        tacticalNotes:
+          "Buys time for ranged parties and prevents escapes. Works well when layered with terrain hazards that punish forced immobility.",
+      },
+      {
+        name: "Ignore-shield",
+        summary: "Bypasses active shield blocks and cover bonuses.",
+        delivery: "Focused melee strike",
+        duration: "Sustained while stance holds",
+        tacticalNotes:
+          "Adopted as a stance or weapon state; lets precision fighters stay lethal even against disciplined defenders relying on tower shields.",
+      },
+    ],
+  },
+  {
+    id: "utility-effects",
+    title: "Utility Effects",
+    discipline: "utility",
+    description:
+      "Supportive maneuvers and stances that expand battlefield options beyond raw damage or control.",
+    entries: [
+      {
+        name: "Parry",
+        summary: "Counters melee strikes with a riposte window.",
+        delivery: "Reactive melee guard",
+        duration: "Triggered response",
+        tacticalNotes:
+          "Successful parries open instant counterattacks. High skill builds can chain parry states to bait predictable opponents.",
+      },
+      {
+        name: "Return",
+        aliases: ["Return-cord"],
+        summary: "Ensures a thrown weapon snaps back to hand.",
+        delivery: "Short-range tether",
+        duration: "Instant",
+        tacticalNotes:
+          "Lets combatants cycle ranged gambits without dropping their primary weapon—great for boomerangs, axes, or harpoons.",
+      },
+      {
+        name: "Cleave",
+        summary: "Sweeps through multiple adjacent foes.",
+        delivery: "Melee arc",
+        duration: "Instant",
+        tacticalNotes:
+          "Maintains pressure on clustered enemies and chips away at minions while focusing a main target.",
+      },
+      {
+        name: "Mounted",
+        aliases: ["Cavalry"],
+        summary: "Harnesses the momentum and height of a mount.",
+        delivery: "Melee reach from mount",
+        duration: "Sustained",
+        tacticalNotes:
+          "Adds charge damage, mobility, and battlefield dominance. Requires space and mount training to avoid penalties in tight quarters.",
+      },
+      {
+        name: "Duelist",
+        aliases: ["Pairing"],
+        summary: "Excels in single combat or paired weapon play.",
+        delivery: "Focused stance",
+        duration: "Sustained",
+        tacticalNotes:
+          "Rewards isolating opponents. Bonuses often scale with limiting adjacent foes, encouraging positioning plays and flanking allies.",
+      },
+      {
+        name: "Phalanx",
+        summary: "Bolsters allies fighting in formation.",
+        delivery: "Group reach",
+        duration: "Sustained",
+        tacticalNotes:
+          "Increases stability, guard coverage, and combined damage when ranks stay locked shoulder-to-shoulder.",
+      },
+    ],
+  },
+  {
+    id: "armor-traits",
+    title: "Armor & Clothing Traits",
+    discipline: "armorTrait",
+    description:
+      "Persistent properties granted by armor sets, uniforms, or crafted garments.",
+    entries: [
+      {
+        name: "Light Armor",
+        aliases: ["Medium Armor", "Heavy Armor", "Max-Protect"],
+        summary: "Defines the weight-to-defense curve of armor tiers.",
+        delivery: "Equipped attire",
+        duration: "Sustained",
+        tacticalNotes:
+          "Light favors agility and stealth, medium balances coverage with mobility, heavy prioritizes soak at stamina cost, and max-protect builds near-impenetrable bulwarks for siege scenarios.",
+      },
+      {
+        name: "Flexible",
+        aliases: ["Articulated", "Hidden-Plates"],
+        summary: "Maintains mobility while keeping key vitals protected.",
+        delivery: "Crafted joint work",
+        duration: "Sustained",
+        tacticalNotes:
+          "Segmented lamellae, chain underlays, or hidden plating let wearers dodge, climb, and disguise protection without losing defensive ratings.",
+      },
+      {
+        name: "Weatherproofing",
+        aliases: ["Warm", "Cooling"],
+        summary: "Buffers the wearer against harsh climates.",
+        delivery: "Environmental lining",
+        duration: "Sustained",
+        tacticalNotes:
+          "Layered cloaks, insulated furs, or heat-dispersing mesh prevent fatigue from extreme cold or heat, enabling long operations outdoors.",
+      },
+      {
+        name: "Prestige Tailoring",
+        aliases: ["Intimidate", "Noble", "Fashion"],
+        summary: "Projects status, authority, or cultural messaging.",
+        delivery: "Social presence",
+        duration: "Sustained",
+        tacticalNotes:
+          "Ideal for court intrigue and diplomacy; grants social leverage, morale bumps, or crowd control through sheer presentation.",
+      },
+      {
+        name: "Blessed Ward",
+        aliases: ["Radiant", "Ward", "Mystic"],
+        summary: "Infuses garments with protective magic.",
+        delivery: "Self/party aura",
+        duration: "Sustained",
+        tacticalNotes:
+          "Reduces curse potency, repels hexes, and can anchor ritual protections for the whole party when keyed to shared crests.",
+      },
+    ],
+  },
+  {
+    id: "accessory-traits",
+    title: "Accessories & Trinkets",
+    discipline: "accessoryTrait",
+    description:
+      "Charms, kits, and insignia that convey passive bonuses or narrative authority.",
+    entries: [
+      {
+        name: "Luck Charm",
+        aliases: ["Omen", "Fortune"],
+        summary: "Nudges probability in the wearer's favor.",
+        delivery: "Global passive",
+        duration: "Sustained",
+        tacticalNotes:
+          "Boosts crit chance, loot quality, or random event tables—best equipped by leaders who influence party-wide rolls.",
+      },
+      {
+        name: "Focus Token",
+        aliases: ["Arcane", "Scholar"],
+        summary: "Stabilizes concentration for spellwork and lore checks.",
+        delivery: "Self focus",
+        duration: "Sustained",
+        tacticalNotes:
+          "Offers bonus mana regen, spell accuracy, or knowledge recall, keeping casters sharp during extended delves.",
+      },
+      {
+        name: "Utility Rig",
+        aliases: ["Carry", "Kit"],
+        summary: "Adds tool slots and load-bearing options.",
+        delivery: "Equipment harness",
+        duration: "Sustained",
+        tacticalNotes:
+          "Increases inventory limits, quick-access tools, and mission-specific modules like climbing gear or alchemy pouches.",
+      },
+      {
+        name: "Authority Badge",
+        aliases: ["Signal"],
+        summary: "Signals rank and grants command recognition.",
+        delivery: "Social presence",
+        duration: "Sustained",
+        tacticalNotes:
+          "Unlocks restricted areas, compels obedience from trained troops, and smooths negotiations with allied factions.",
+      },
+    ],
+  },
+];
+
+export interface StatusEffectLookupResult {
+  categoryId: string;
+  categoryTitle: string;
+  entry: StatusEffectEntry;
+}
+
+export const STATUS_EFFECT_LOOKUP: Record<string, StatusEffectLookupResult> = (() => {
+  const index: Record<string, StatusEffectLookupResult> = {};
+  for (const category of STATUS_EFFECT_GLOSSARY) {
+    for (const entry of category.entries) {
+      const value: StatusEffectLookupResult = {
+        categoryId: category.id,
+        categoryTitle: category.title,
+        entry,
+      };
+      index[entry.name.toLowerCase()] = value;
+      for (const alias of entry.aliases ?? []) {
+        index[alias.toLowerCase()] = value;
+      }
+    }
+  }
+  return index;
+})();
+
+export function getStatusEffect(name: string): StatusEffectLookupResult | null {
+  return STATUS_EFFECT_LOOKUP[name.toLowerCase()] ?? null;
+}
+
+export const getSpecialEffect = getStatusEffect;
+
 export const MELEE_FORMULA = {
   description:
     "Upgraded melee model with crits, resist typing, AP, on-hit effects, sunder/disarm/sever hooks, and armor crit-defense.",
@@ -134,6 +445,7 @@ export const ON_HIT_DEFAULTS = {
     tickSec: 2,
     scalesWith: "finalDamage",
     tags: ["damage", "over-time", "physical"],
+    glossaryKey: "bleed",
   },
   sunder: {
     description: "Reduces the target's armor and defense values per stack.",
@@ -141,6 +453,7 @@ export const ON_HIT_DEFAULTS = {
     durationSec: 12,
     maxStacks: 5,
     tags: ["debuff", "armor"],
+    glossaryKey: "sunder",
   },
   disarm: {
     description: "Forces the target to lose grip on their weapon, reducing their offensive options temporarily.",
@@ -148,6 +461,7 @@ export const ON_HIT_DEFAULTS = {
     durationSec: 4,
     cdSec: 8,
     tags: ["control", "crowd"],
+    glossaryKey: "disarm",
   },
   sever: {
     description: "Inflicts a grievous wound with a chance to maim or cripple the target.",
@@ -160,6 +474,7 @@ export const ON_HIT_DEFAULTS = {
     range: "Contact",
     durationSec: 2,
     tags: ["control", "crowd"],
+    glossaryKey: "daze",
   },
   rend: {
     description: "Tears through armor and flesh, causing bleed-like damage and reducing defenses.",
@@ -168,12 +483,14 @@ export const ON_HIT_DEFAULTS = {
     tickSec: 2,
     scalesWith: "finalDamage",
     tags: ["damage", "over-time", "armor"],
+    glossaryKey: "rend",
   },
   entangle: {
     description: "Restricts the target's movement, lowering evasion and making repositioning difficult.",
     range: "Reach",
     durationSec: 6,
     tags: ["control", "crowd"],
+    glossaryKey: "entangle",
   },
   lunarBrand: {
     description: "Brands the target in pale light, increasing the damage they take from follow-up attacks.",


### PR DESCRIPTION
## Summary
- merge the regenerated special effect glossary into `data/game/combat.ts` as part of the status effect catalog and expose a shared lookup helper
- link existing on-hit defaults to the glossary entries so weapon configs can reference the shared descriptions
- remove the standalone special effects data/documentation and clean the README reference now that the glossary lives with the combat status data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccb530cd7c8325b681baf04b2cc540