### PR TITLE
Adjust top menu layout spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -113,8 +113,8 @@ main {
   line-height: 1.1;
   font-weight: 600;
   color: var(--menu-color-dark);
-  padding: 0 0.5rem 0 0.25rem;
-  margin-left: 0.25rem;
+  padding: 0 0.5rem 0 0.75rem;
+  margin-left: auto;
 }
 
 .top-menu-info span {
@@ -143,7 +143,6 @@ body.theme-dark .top-menu-info {
   gap: 0.0625rem;
   position: relative;
   align-items: center;
-  margin-left: auto;
 }
 
 @media (orientation: portrait) {


### PR DESCRIPTION
## Summary
- group the top navigation buttons on the left by removing the auto margin from the settings cluster
- let the date/funds display sit on the right with flexible spacing by applying auto margin and updated padding

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ccdd70c068832590d432251ac2a8da