### PR TITLE
Add interactive quest storylines and logging

### DIFF
--- a/style.css
+++ b/style.css
@@ -1720,6 +1720,123 @@ body.theme-dark .top-menu button {
   border: 1px solid rgba(178, 34, 34, 0.4);
 }
 
+.quest-storyline {
+  padding: 1rem 1.25rem;
+  background: rgba(248, 248, 248, 0.85);
+  border-radius: 0.75rem;
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.quest-storyline-header h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.quest-storyline-subtitle {
+  margin: 0.15rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(51, 51, 51, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.quest-storyline-body {
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.quest-storyline-body p {
+  margin: 0.5rem 0;
+}
+
+.quest-storyline-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.quest-storyline-actions button {
+  padding: 0.55rem 1.2rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(51, 51, 51, 0.25);
+  background: white;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.quest-storyline-actions button:hover {
+  border-color: rgba(46, 139, 87, 0.55);
+  color: rgba(46, 139, 87, 0.95);
+}
+
+.quest-storyline-outcome {
+  display: inline-block;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.5rem;
+}
+
+.quest-storyline-outcome-success {
+  background: rgba(46, 139, 87, 0.18);
+  color: rgba(25, 83, 52, 0.95);
+  border: 1px solid rgba(46, 139, 87, 0.35);
+}
+
+.quest-storyline-outcome-failed {
+  background: rgba(178, 34, 34, 0.18);
+  color: rgba(120, 25, 25, 0.95);
+  border: 1px solid rgba(178, 34, 34, 0.35);
+}
+
+.quest-storyline-outcome-declined {
+  background: rgba(70, 130, 180, 0.18);
+  color: rgba(45, 82, 110, 0.95);
+  border: 1px solid rgba(70, 130, 180, 0.35);
+}
+
+body.theme-dark .quest-storyline {
+  background: rgba(20, 24, 32, 0.9);
+  box-shadow: 0 0.75rem 1.75rem rgba(0, 0, 0, 0.5);
+}
+
+body.theme-dark .quest-storyline-subtitle {
+  color: rgba(220, 220, 220, 0.65);
+}
+
+body.theme-dark .quest-storyline-actions button {
+  background: rgba(32, 36, 46, 0.95);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: rgba(235, 235, 235, 0.9);
+}
+
+body.theme-dark .quest-storyline-actions button:hover {
+  border-color: rgba(135, 206, 250, 0.6);
+  color: rgba(200, 230, 255, 0.95);
+}
+
+body.theme-dark .quest-storyline-outcome-success {
+  background: rgba(30, 80, 60, 0.35);
+  border-color: rgba(60, 140, 110, 0.55);
+}
+
+body.theme-dark .quest-storyline-outcome-failed {
+  background: rgba(120, 30, 30, 0.35);
+  border-color: rgba(160, 60, 60, 0.6);
+}
+
+body.theme-dark .quest-storyline-outcome-declined {
+  background: rgba(50, 90, 130, 0.35);
+  border-color: rgba(90, 140, 190, 0.55);
+}
+
 .backstory-block {
   margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary
- implement a quest storyline flow that guides players through travel, check-ins, decision making, time advancement, rewards, and quest history logging once a contract is accepted
- ensure quest acceptance spawns storylines, tracks time of day, and records quest outcomes for the active character
- add styling for the quest storyline presentation in both light and dark themes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccdaf1c83883259651330ebc73c14f