### PR TITLE
Fix browser load errors by adding JS proficiency modules

### DIFF
--- a/data/game/animal_handling_proficiency.js
+++ b/data/game/animal_handling_proficiency.js
@@ -1,0 +1,52 @@
+import { gainProficiency, F_repeat } from "./proficiency_base.js";
+const CONTEXT_FACTOR = {
+    routine: 0.6,
+    training: 0.75,
+    emergency: 1.0,
+};
+function levelFactor(characterLevel, taskDifficulty) {
+    const diff = Math.abs(taskDifficulty - characterLevel);
+    return 1 / (1 + diff / 2);
+}
+export function gainAnimalHandling(character, animalKey, opts = {}) {
+    var _a, _b, _c, _d, _e;
+    const { difficulty = (_a = character.level) !== null && _a !== void 0 ? _a : 1, success = true, context = 'routine', } = opts;
+    if (!character.animalHandling)
+        character.animalHandling = {};
+    if (!character._animalHandlingRepeat)
+        character._animalHandlingRepeat = {};
+    const current = (_b = character.animalHandling[animalKey]) !== null && _b !== void 0 ? _b : 0;
+    const level = (_c = character.level) !== null && _c !== void 0 ? _c : 1;
+    const repeatCount = (_d = character._animalHandlingRepeat[animalKey]) !== null && _d !== void 0 ? _d : 0;
+    const F_repeat_factor = F_repeat(repeatCount);
+    const F_context = (_e = CONTEXT_FACTOR[context]) !== null && _e !== void 0 ? _e : CONTEXT_FACTOR.routine;
+    const F_level = levelFactor(level, difficulty);
+    const updated = gainProficiency({
+        P: current,
+        L: level,
+        A0: 1,
+        A: 0,
+        r: 1,
+        F_context,
+        F_level,
+        F_repeat: F_repeat_factor,
+        success,
+    });
+    character.animalHandling[animalKey] = updated;
+    if (success) {
+        if (character._animalHandlingLast === animalKey) {
+            character._animalHandlingRepeat[animalKey] = repeatCount + 1;
+        }
+        else {
+            character._animalHandlingRepeat[animalKey] = 1;
+        }
+        character._animalHandlingLast = animalKey;
+    }
+    else {
+        character._animalHandlingRepeat[animalKey] = repeatCount;
+    }
+    return updated;
+}
+export function handleAnimal(character, animalKey, opts = {}) {
+    return gainAnimalHandling(character, animalKey, opts);
+}

--- a/data/game/armor_proficiency.js
+++ b/data/game/armor_proficiency.js
@@ -1,0 +1,115 @@
+// armor_proficiency.ts — armor proficiency progression using evasion as reference
+import { proficiencyCap } from "./proficiency_base.js";
+/** Round to 2 decimals */
+const r2 = (x) => Math.round(x * 100) / 100;
+export const LIGHT_ARMOR_CFG = {
+    g0: 0.04,
+    levelFloorEqual: 0.2,
+    levelSlope: 0.15,
+    levelCap: 1.0,
+    attrBase: 0.7,
+    attrSlope: 0.01,
+    attrMax: 1.3,
+    maxGain: 0.5,
+    tauLow: 0.015,
+    tauHigh: 0.05,
+    pSmallMin: 0.1,
+    rng: () => Math.random(),
+};
+export const MEDIUM_ARMOR_CFG = Object.assign({}, LIGHT_ARMOR_CFG);
+export const HEAVY_ARMOR_CFG = Object.assign({}, LIGHT_ARMOR_CFG);
+function levelFactor(actorL, enemyL, cfg) {
+    const d = enemyL - actorL;
+    if (d < 0)
+        return 0; // no gain vs weaker foes
+    if (d === 0)
+        return cfg.levelFloorEqual;
+    const f = cfg.levelFloorEqual + cfg.levelSlope * d;
+    return Math.min(cfg.levelCap, f);
+}
+function attrFactor(STR, DEX, AGI, cfg) {
+    const avg = (STR + DEX + AGI) / 3;
+    const f = cfg.attrBase + cfg.attrSlope * avg;
+    return Math.min(cfg.attrMax, Math.max(cfg.attrBase, f));
+}
+function gainArmorProficiency(input, cfg) {
+    const { P, cap, actorLevel, enemyLevel, STR, DEX, AGI, pieces, totalPieces, hasChest } = input;
+    // Equipment requirement: majority of worn pieces including the chest/body
+    if (!hasChest || pieces <= totalPieces / 2)
+        return r2(P);
+    const F_level = levelFactor(actorLevel, enemyLevel, cfg);
+    if (F_level <= 0)
+        return r2(P);
+    const F_attr = attrFactor(STR, DEX, AGI, cfg);
+    const raw = cfg.g0 * F_level * F_attr;
+    const Δ = Math.min(cfg.maxGain, raw, Math.max(0, cap - P));
+    if (Δ <= 0)
+        return r2(P);
+    let gain = 0;
+    if (Δ >= cfg.tauHigh) {
+        gain = Δ;
+    }
+    else {
+        let p;
+        if (Δ <= cfg.tauLow) {
+            p = cfg.pSmallMin;
+        }
+        else {
+            const t = (Δ - cfg.tauLow) / (cfg.tauHigh - cfg.tauLow);
+            p = cfg.pSmallMin + t * (1 - cfg.pSmallMin);
+        }
+        if (cfg.rng() < p)
+            gain = Δ;
+    }
+    const nextP = Math.min(cap, P + gain);
+    return r2(nextP);
+}
+/** Compute next light armor proficiency (2 decimals).
+ * Should be invoked once per defeated enemy while wearing light armor.
+ */
+export function gainLightArmorProficiency(input, cfg = LIGHT_ARMOR_CFG) {
+    return gainArmorProficiency(input, cfg);
+}
+/** Medium armor proficiency progression */
+export function gainMediumArmorProficiency(input, cfg = MEDIUM_ARMOR_CFG) {
+    return gainArmorProficiency(input, cfg);
+}
+/** Heavy armor proficiency progression */
+export function gainHeavyArmorProficiency(input, cfg = HEAVY_ARMOR_CFG) {
+    return gainArmorProficiency(input, cfg);
+}
+const ARMOR_CFG_MAP = {
+    lightArmor: LIGHT_ARMOR_CFG,
+    mediumArmor: MEDIUM_ARMOR_CFG,
+    heavyArmor: HEAVY_ARMOR_CFG,
+};
+function applyArmorProficiencyGain(character, key, params) {
+    var _a, _b, _c, _d, _e, _f;
+    if (!character)
+        return 0;
+    const { enemyLevel, pieces, totalPieces, hasChest, cap, cfg } = params;
+    const attrs = ((_a = character.attributes) === null || _a === void 0 ? void 0 : _a.current) || {};
+    const next = gainArmorProficiency({
+        P: character[key] || 0,
+        cap: cap !== null && cap !== void 0 ? cap : proficiencyCap((_b = character.level) !== null && _b !== void 0 ? _b : 1),
+        actorLevel: (_c = character.level) !== null && _c !== void 0 ? _c : 1,
+        enemyLevel,
+        STR: (_d = attrs.STR) !== null && _d !== void 0 ? _d : 0,
+        DEX: (_e = attrs.DEX) !== null && _e !== void 0 ? _e : 0,
+        AGI: (_f = attrs.AGI) !== null && _f !== void 0 ? _f : 0,
+        pieces,
+        totalPieces,
+        hasChest,
+    }, cfg || ARMOR_CFG_MAP[key]);
+    character[key] = next;
+    return next;
+}
+export function applyLightArmorProficiencyGain(character, params) {
+    return applyArmorProficiencyGain(character, 'lightArmor', params);
+}
+export function applyMediumArmorProficiencyGain(character, params) {
+    return applyArmorProficiencyGain(character, 'mediumArmor', params);
+}
+export function applyHeavyArmorProficiencyGain(character, params) {
+    return applyArmorProficiencyGain(character, 'heavyArmor', params);
+}

--- a/data/game/dance_proficiency.js
+++ b/data/game/dance_proficiency.js
@@ -1,0 +1,147 @@
+// dance_proficiency.ts — proficiency gains for Dances (TS/JS compatible)
+const r2 = (x) => Math.round(x * 100) / 100;
+export const DANCE_CFG = {
+    g0: 0.075,
+    contextWeight: { practice: 0.25, spar: 0.75, battle: 1.0 },
+    levelFloorEqual: 0.30,
+    levelSlope: 0.11,
+    levelCap: 1.0,
+    secNorm: 4, // every ~4s of real maintained dancing ≈ one learning unit
+    uptimeK: 0.6, // diminishing returns exponent on uptime factor
+    crowdK: 0.08, crowdMax: 1.30,
+    pressureK: 0.10, pressureMax: 1.35,
+    minRepeatFactor: 0.45,
+    varietyMaxBonus: 0.25, varietyWindow: 10, varietyTargetDistinct: 4,
+    postUnlockChoke: 0.35, unlockWindow: 8.0,
+    capSoftenerK: 0.9,
+    outcomeWeight: { success: 1.0, partial: 0.35, fail: 0.0 },
+    stopBonus: 0.12, // small extra nudge when the dancer ends a sequence cleanly
+    tauLow: 0.018, tauHigh: 0.055, pSmallMin: 0.12,
+    rng: () => Math.random(),
+};
+/* ========================= Internal helpers ========================= */
+function levelFactor(actorL, enemyL, cfg) {
+    const d = enemyL - actorL;
+    if (d < -1)
+        return 0.05; // trivial content
+    if (d <= 0)
+        return cfg.levelFloorEqual;
+    return Math.min(cfg.levelCap, cfg.levelFloorEqual + cfg.levelSlope * d);
+}
+function repeatFactor(N_same, cfg) {
+    if (N_same <= 0)
+        return 1;
+    const f = 1 / (1 + Math.log(1 + N_same));
+    return Math.max(cfg.minRepeatFactor, f);
+}
+function varietyFactor(ids, cfg) {
+    if (!(ids === null || ids === void 0 ? void 0 : ids.length))
+        return 1;
+    const slice = ids.slice(-cfg.varietyWindow);
+    const distinct = new Set(slice).size;
+    const t = Math.min(1, distinct / cfg.varietyTargetDistinct);
+    return 1 + cfg.varietyMaxBonus * t;
+}
+function thresholdChoke(P, thresholds, cfg) {
+    for (const t of thresholds)
+        if (P >= t && P <= t + cfg.unlockWindow)
+            return cfg.postUnlockChoke;
+    return 1.0;
+}
+function capGapFactor(P, cap, cfg) {
+    if (cap <= 0)
+        return 0;
+    const gap = Math.max(0, cap - P);
+    return Math.pow(gap / cap, cfg.capSoftenerK);
+}
+function crowdFactor(nAllies, cfg) {
+    return Math.min(cfg.crowdMax, 1 + cfg.crowdK * Math.max(0, nAllies - 1));
+}
+function pressureFactor(nEnemies, cfg) {
+    return Math.min(cfg.pressureMax, 1 + cfg.pressureK * Math.max(0, nEnemies - 0));
+}
+/** Convert uptime seconds into a normalized factor with diminishing returns. */
+function uptimeFactor(maintainedSec, cfg) {
+    if (maintainedSec <= 0)
+        return 1; // instant pulse dances still give a tiny signal
+    const units = maintainedSec / cfg.secNorm; // how many “ticks” worth of practice
+    return Math.pow(units, cfg.uptimeK); // diminishing returns for very long holds
+}
+/* ========================= Main progression ========================= */
+/** Compute next Dance proficiency (2 decimals).
+ *  Call this:
+ *   - once per active “tick” while the dancer maintains (e.g., every 3–5s), OR
+ *   - once when they stop (isStopEvent=true) to apply a small consolidation bonus.
+ */
+export function gainDanceProficiency(input, cfg = DANCE_CFG) {
+    const { P, cap, actorLevel, enemyLevelAvg, context, outcome, maintainedSec, isStopEvent, N_same, recentDanceIds, alliesAffected, enemiesPressuring, thresholds } = input;
+    // Basic eligibility & outcome
+    const W_ctx = cfg.contextWeight[context];
+    if (W_ctx <= 0 || outcome === "fail")
+        return r2(P);
+    // Build multipliers
+    const F_level = levelFactor(actorLevel, enemyLevelAvg, cfg);
+    const F_repeat = repeatFactor(N_same, cfg);
+    const F_variety = varietyFactor(recentDanceIds, cfg);
+    const F_unlock = thresholdChoke(P, thresholds, cfg);
+    const F_cap = capGapFactor(P, cap, cfg);
+    const F_crowd = crowdFactor(alliesAffected, cfg);
+    const F_pressure = pressureFactor(enemiesPressuring, cfg);
+    const F_uptime = uptimeFactor(maintainedSec, cfg);
+    const W_outcome = cfg.outcomeWeight[outcome];
+    // Raw deterministic delta (pre-gate)
+    let raw = cfg.g0
+        * W_ctx
+        * F_level
+        * F_repeat
+        * F_variety
+        * F_unlock
+        * F_cap
+        * F_crowd
+        * F_pressure
+        * F_uptime
+        * W_outcome;
+    // End-of-dance consolidation (very small nudge)
+    if (isStopEvent)
+        raw *= (1 + cfg.stopBonus);
+    const Δ = Math.min(raw, Math.max(0, cap - P));
+    if (Δ <= 0)
+        return r2(P);
+    // Strict chance gate — keeps progression slow & eventful
+    let pGain;
+    if (Δ >= cfg.tauHigh)
+        pGain = 1.0;
+    else if (Δ <= cfg.tauLow)
+        pGain = cfg.pSmallMin;
+    else {
+        const t = (Δ - cfg.tauLow) / (cfg.tauHigh - cfg.tauLow);
+        pGain = cfg.pSmallMin + (1 - cfg.pSmallMin) * t;
+    }
+    return (cfg.rng() < pGain) ? r2(P + Δ) : r2(P);
+}
+/* ========================= Example usage =========================
+import { gainDanceProficiency } from "./dance_proficiency";
+
+// Maintain a dance for ~6s during battle vs slightly higher-level enemies:
+let P = 24.17, cap = 54;
+P = gainDanceProficiency({
+  P, cap,
+  actorLevel: 12, enemyLevelAvg: 13,
+  context: "battle", outcome: "success",
+  maintainedSec: 6, isStopEvent: false,
+  N_same: 1, recentDanceIds: ["BUFF_DN:02","CTRL_DN:03"],
+  alliesAffected: 4, enemiesPressuring: 2,
+  thresholds: [10,20,30,40,50,60,70,80,90,100]
+});
+
+// When the dancer stops, call once more with a stop-event:
+P = gainDanceProficiency({
+  P, cap,
+  actorLevel: 12, enemyLevelAvg: 13,
+  context: "battle", outcome: "success",
+  maintainedSec: 0, isStopEvent: true,
+  N_same: 1, recentDanceIds: ["BUFF_DN:02","CTRL_DN:03"],
+  alliesAffected: 4, enemiesPressuring: 2,
+  thresholds: [10,20,30,40,50,60,70,80,90,100]
+});
+------------------------------------------------------------------- */

--- a/data/game/instrument_songs.js
+++ b/data/game/instrument_songs.js
@@ -1,0 +1,235 @@
+// instrument_songs.ts — Full songbook + scaling + progression (TS/JS)
+/** clamp helper */
+const clamp01 = (x) => Math.max(0, Math.min(1, x));
+/** round to 2 decimals */
+const r2 = (x) => Math.round(x * 100) / 100;
+/** attribute-based variance multiplier */
+export const VARIANCE_ALPHA = 0.02;
+/** Duration scaling rule (standardized across all songs):
+ *  duration = base * (1 + (P - unlock) / 100)
+ *  always at least baseDurationSec
+ */
+export function computeSongDurationSec(song, P) {
+    const growth = 1 + Math.max(0, (P - song.unlock)) / 100;
+    return Math.floor(song.baseDurationSec * growth);
+}
+/** Magnitude interpolation from unlock -> 100; capped if provided.
+ *  For percentage effects, 'scale.m0'/'scale.m100' are % points (e.g., 5 means +5%).
+ */
+export function computeSongMagnitude(song, P) {
+    if (song.kind === "ultimate") {
+        // Ultimate: +1% ALL STATS per 10 proficiency (rounded properly)
+        return Math.round(P / 10); // returns % points
+    }
+    const t = clamp01((P - song.unlock) / (100 - song.unlock || 1));
+    const raw = song.scale.m0 + (song.scale.m100 - song.scale.m0) * t;
+    return song.scale.cap != null ? Math.min(raw, song.scale.cap) : raw;
+}
+/* ========================= Core Songbook ========================= */
+/** Base 20 control/debuff/DoT & buff/regen; elemental & ultimate appended below */
+const CONTROL_DEBUFF_DOT_BASE = [
+    { name: "Dissonant Chord", category: "control", kind: "debuff", target: "ST", side: "enemy", unlock: 10, baseDurationSec: 20, scale: { m0: -10, m100: -18, unit: "pct" }, tags: ["ATK_DOWN"] },
+    { name: "Crippling Melody", category: "control", kind: "debuff", target: "ST", side: "enemy", unlock: 15, baseDurationSec: 20, scale: { m0: -10, m100: -20, unit: "pct" }, tags: ["MOVE_SPEED_DOWN"] },
+    { name: "Withering Tone", category: "control", kind: "dot", target: "ST", side: "enemy", unlock: 20, baseDurationSec: 20, scale: { m0: 2, m100: 4, unit: "pct" }, tags: ["HP_DOT", "per5s"] }, // % Max HP per 5s
+    { name: "Enfeebling Dirge", category: "control", kind: "debuff", target: "AoE", side: "enemy", unlock: 25, baseDurationSec: 20, scale: { m0: -8, m100: -16, unit: "pct" }, tags: ["DEF_DOWN"] },
+    { name: "Discordant Anthem", category: "control", kind: "debuff", target: "AoE", side: "enemy", unlock: 30, baseDurationSec: 20, scale: { m0: +10, m100: +18, unit: "pct" }, tags: ["DMG_TAKEN_UP"] },
+    { name: "Maddening Hum", category: "control", kind: "control", target: "ST", side: "enemy", unlock: 40, baseDurationSec: 15, scale: { m0: 0, m100: 0 }, tags: ["Confuse"] },
+    { name: "Soul-Draining Verse", category: "control", kind: "dot", target: "ST", side: "enemy", unlock: 50, baseDurationSec: 20, scale: { m0: 2, m100: 4, unit: "pct" }, tags: ["MP_DOT", "per5s"] }, // % Max MP per 5s
+    { name: "Lethargy Hymn", category: "control", kind: "debuff", target: "AoE", side: "enemy", unlock: 60, baseDurationSec: 20, scale: { m0: -10, m100: -20, unit: "pct" }, tags: ["STAM_REGEN_DOWN"] },
+    { name: "Silence of Strings", category: "control", kind: "control", target: "ST", side: "enemy", unlock: 70, baseDurationSec: 10, scale: { m0: 0, m100: 0 }, tags: ["Silence"] },
+    { name: "Curse of Discord", category: "control", kind: "debuff", target: "AoE", side: "enemy", unlock: 80, baseDurationSec: 20, scale: { m0: -10, m100: -20, unit: "pct" }, tags: ["ALL_STATS_DOWN"] },
+];
+const BUFF_REGEN_BASE = [
+    { name: "Courageous March", category: "buff", kind: "buff", target: "AoE", side: "ally", unlock: 10, baseDurationSec: 20, scale: { m0: +5, m100: +10, unit: "pct" }, tags: ["ATK_UP"] },
+    { name: "Swift Step", category: "buff", kind: "buff", target: "AoE", side: "ally", unlock: 15, baseDurationSec: 20, scale: { m0: +5, m100: +10, unit: "pct" }, tags: ["MOVE_SPEED_UP"] },
+    { name: "Hymn of Vitality", category: "buff", kind: "regen", target: "AoE", side: "ally", unlock: 20, baseDurationSec: 20, scale: { m0: +2, m100: +5, unit: "pct" }, tags: ["HP_REGEN", "per5s"] }, // % Max HP / 5s
+    { name: "Harmonious Shield", category: "buff", kind: "buff", target: "AoE", side: "ally", unlock: 25, baseDurationSec: 20, scale: { m0: +8, m100: +16, unit: "pct" }, tags: ["DEF_UP"] },
+    { name: "Anthem of Unity", category: "buff", kind: "buff", target: "AoE", side: "ally", unlock: 30, baseDurationSec: 20, scale: { m0: -10, m100: -20, unit: "pct" }, tags: ["DMG_TAKEN_DOWN"] },
+    { name: "Refreshing Aria", category: "buff", kind: "regen", target: "AoE", side: "ally", unlock: 40, baseDurationSec: 20, scale: { m0: +2, m100: +5, unit: "pct" }, tags: ["MP_REGEN", "per5s"] }, // % Max MP / 5s
+    { name: "Enduring Rhythm", category: "buff", kind: "regen", target: "AoE", side: "ally", unlock: 50, baseDurationSec: 20, scale: { m0: +2, m100: +5, unit: "pct" }, tags: ["STAM_REGEN", "per5s"] }, // % Max STA / 5s
+    { name: "Inspiring Chorus", category: "buff", kind: "buff", target: "AoE", side: "ally", unlock: 60, baseDurationSec: 20, scale: { m0: +5, m100: +10, unit: "pct" }, tags: ["ALL_STATS_UP"] },
+    { name: "Resilient Ballad", category: "buff", kind: "buff", target: "AoE", side: "ally", unlock: 70, baseDurationSec: 20, scale: { m0: +15, m100: +25, unit: "pct" }, tags: ["CONTROL_RESIST_UP"] },
+    { name: "Guardian’s Song", category: "buff", kind: "buff", target: "AoE", side: "ally", unlock: 80, baseDurationSec: 20, scale: { m0: +10, m100: +18, unit: "pct" }, tags: ["HP_SHIELD_PCTMAX"] },
+];
+/** Elemental songs @33 (resist allies) and @66 (weakness enemies) */
+const ELEMENTS = ["Stone", "Water", "Wind", "Fire", "Ice", "Lightning", "Dark", "Light"];
+const ELEMENTAL_BASE = [
+    // Resist @33
+    ...ELEMENTS.map(el => ({
+        name: {
+            Stone: "Stoneguard Tune", Water: "Flowing Harmony", Wind: "Tempest Chant", Fire: "Ember Hymn",
+            Ice: "Frostsong", Lightning: "Storm Resonance", Dark: "Shadow Lament", Light: "Radiant Canticle"
+        }[el],
+        category: "elemental", kind: "resist", element: el,
+        target: "AoE", side: "ally", unlock: 33, baseDurationSec: 20,
+        scale: { m0: +15, m100: +25, unit: "pct" }, tags: ["ELEMENT_RESIST_UP"]
+    })),
+    // Weakness @66
+    ...ELEMENTS.map(el => ({
+        name: {
+            Stone: "Shattering Note", Water: "Drowning Dirge", Wind: "Cutting Gale Song", Fire: "Scorching Refrain",
+            Ice: "Piercing Chill", Lightning: "Overload Symphony", Dark: "Umbral Chant", Light: "Blinding Hymn"
+        }[el],
+        category: "elemental", kind: "weakness", element: el,
+        target: "AoE", side: "enemy", unlock: 66, baseDurationSec: 20,
+        scale: { m0: -15, m100: -25, unit: "pct" }, tags: ["ELEMENT_RESIST_DOWN"]
+    })),
+];
+/** Ultimate @100 */
+const ULTIMATE = {
+    name: "Eternal Overture", category: "ultimate", kind: "ultimate",
+    target: "AoE", side: "ally", unlock: 100, baseDurationSec: 20,
+    scale: { m0: 0, m100: 0, unit: "pct" }, tags: ["ALL_STATS_UP_PARTY"]
+};
+/** Build SONGS with stable IDs */
+function makeId(prefix, idx) { return `${prefix}:${idx.toString().padStart(2, "0")}`; }
+export const INSTRUMENT_SONGS = [
+    ...CONTROL_DEBUFF_DOT_BASE.map((s, i) => (Object.assign({ id: makeId("CTRL", i + 1) }, s))),
+    ...BUFF_REGEN_BASE.map((s, i) => (Object.assign({ id: makeId("BUFF", i + 1) }, s))),
+    ...ELEMENTAL_BASE.map((s, i) => (Object.assign({ id: makeId("ELEM", i + 1) }, s))),
+    Object.assign({ id: "ULT:01" }, ULTIMATE)
+];
+const TAG_TO_MOD = {
+    ATK_UP: "ATK_PCT",
+    ATK_DOWN: "ATK_PCT",
+    MOVE_SPEED_UP: "MOVE_SPEED_PCT",
+    MOVE_SPEED_DOWN: "MOVE_SPEED_PCT",
+    DEF_UP: "DEF_PCT",
+    DEF_DOWN: "DEF_PCT",
+    DMG_TAKEN_UP: "DMG_TAKEN_PCT",
+    DMG_TAKEN_DOWN: "DMG_TAKEN_PCT",
+    ALL_STATS_UP: "ALL_STATS_PCT",
+    ALL_STATS_DOWN: "ALL_STATS_PCT",
+    CONTROL_RESIST_UP: "CONTROL_RESIST_PCT",
+    HP_SHIELD_PCTMAX: "HP_SHIELD_PCTMAX"
+};
+/** Resolve a song at proficiency P and attribute value into numbers your engine can apply */
+export function resolveSongEffect(song, P, attrVal = 10) {
+    var _a, _b, _c, _d, _e, _f;
+    const durationSec = computeSongDurationSec(song, P);
+    const baseMag = computeSongMagnitude(song, P);
+    const magnitude = r2(baseMag * (1 + VARIANCE_ALPHA * (attrVal - 10)));
+    const effect = {
+        kind: song.kind,
+        durationModel: "post-stop",
+        element: song.element,
+        tags: song.tags
+    };
+    let per5sPct;
+    if (song.kind === "regen" || ((_a = song.tags) === null || _a === void 0 ? void 0 : _a.includes("HP_REGEN")) || ((_b = song.tags) === null || _b === void 0 ? void 0 : _b.includes("MP_REGEN")) || ((_c = song.tags) === null || _c === void 0 ? void 0 : _c.includes("STAM_REGEN"))) {
+        per5sPct = magnitude;
+        effect.percent = Math.abs(magnitude);
+    }
+    else if (song.kind === "dot" || ((_d = song.tags) === null || _d === void 0 ? void 0 : _d.includes("HP_DOT")) || ((_e = song.tags) === null || _e === void 0 ? void 0 : _e.includes("MP_DOT"))) {
+        per5sPct = magnitude;
+        effect.percent = Math.abs(magnitude);
+    }
+    else if (song.kind === "resist" || song.kind === "weakness") {
+        effect.percent = Math.abs(magnitude);
+    }
+    else if (song.kind === "ultimate") {
+        effect.modifiers = { ALL_STATS_PCT: magnitude };
+    }
+    else if (song.kind === "buff" || song.kind === "debuff") {
+        const tag = (_f = song.tags) === null || _f === void 0 ? void 0 : _f[0];
+        if (tag) {
+            const key = TAG_TO_MOD[tag] || tag;
+            effect.modifiers = { [key]: magnitude };
+        }
+    }
+    return { durationSec, magnitude, per5sPct, effect };
+}
+export const INSTRUMENT_CFG = {
+    g0: 0.065, // base gain unit (lower than active spells; you’re buffing from safety)
+    contextWeight: { practice: 0.20, spar: 0.65, battle: 1.0 },
+    // Level factor: equal-level gives some gains; higher-level improves quickly; lower-level yields almost none
+    levelFloorEqual: 0.35, levelSlope: 0.12, levelCap: 1.0,
+    // Crowd factor (more targets affected gives more “learning signal”)
+    crowdK: 0.08, crowdMax: 1.30, // factor = 1 + min(crowdMax-1, crowdK*(targets-1))
+    // Repetition & variety
+    minRepeatFactor: 0.45,
+    varietyMaxBonus: 0.25, varietyWindow: 10, varietyTargetDistinct: 4,
+    // Unlock choke & cap taper
+    postUnlockChoke: 0.35, unlockWindow: 8.0,
+    capSoftenerK: 0.9,
+    // Outcome weights
+    outcomeWeight: { success: 1.0, partial: 0.25, fail: 0.0 },
+    // Chance gating (to keep it slow past mid tiers)
+    tauLow: 0.020, tauHigh: 0.060, pSmallMin: 0.12,
+    rng: () => Math.random()
+};
+function levelFactor(actorL, enemyL, cfg = INSTRUMENT_CFG) {
+    const d = enemyL - actorL;
+    if (d < -1)
+        return 0.05; // nearly nothing if content is much lower
+    if (d <= 0)
+        return cfg.levelFloorEqual; // equal or slightly lower
+    return Math.min(cfg.levelCap, cfg.levelFloorEqual + cfg.levelSlope * d);
+}
+function repeatFactor(N_same, cfg = INSTRUMENT_CFG) {
+    if (N_same <= 0)
+        return 1;
+    const f = 1 / (1 + Math.log(1 + N_same));
+    return Math.max(cfg.minRepeatFactor, f);
+}
+function varietyFactor(ids, cfg = INSTRUMENT_CFG) {
+    if (!ids || !ids.length)
+        return 1;
+    const slice = ids.slice(-cfg.varietyWindow);
+    const distinct = new Set(slice).size;
+    const t = Math.min(1, distinct / cfg.varietyTargetDistinct);
+    return 1 + cfg.varietyMaxBonus * t;
+}
+function thresholdChoke(P, thresholds, cfg = INSTRUMENT_CFG) {
+    for (const t of thresholds)
+        if (P >= t && P <= t + cfg.unlockWindow)
+            return cfg.postUnlockChoke;
+    return 1.0;
+}
+function capGapFactor(P, cap, cfg = INSTRUMENT_CFG) {
+    const gap = Math.max(0, cap - P);
+    if (cap <= 0)
+        return 0;
+    return Math.pow(gap / cap, cfg.capSoftenerK);
+}
+function crowdFactor(n, cfg = INSTRUMENT_CFG) {
+    return Math.min(cfg.crowdMax, 1 + cfg.crowdK * Math.max(0, n - 1));
+}
+/** Main: compute next proficiency (2-dec) */
+export function gainInstrumentProficiency(input, cfg = INSTRUMENT_CFG) {
+    const { P, cap, actorLevel, enemyLevelAvg, context, outcome, N_same, recentSongIds, thresholds, targetsAffected } = input;
+    // Must be at least practice; battle/spar carry more weight automatically
+    const W_ctx = cfg.contextWeight[context];
+    if (W_ctx <= 0 || outcome === "fail")
+        return r2(P);
+    const F_level = levelFactor(actorLevel, enemyLevelAvg, cfg);
+    const F_repeat = repeatFactor(N_same, cfg);
+    const F_variety = varietyFactor(recentSongIds, cfg);
+    const F_unlock = thresholdChoke(P, thresholds, cfg);
+    const F_cap = capGapFactor(P, cap, cfg);
+    const F_crowd = crowdFactor(targetsAffected, cfg);
+    const W_outcome = cfg.outcomeWeight[outcome];
+    const raw = cfg.g0 * W_ctx * F_level * F_repeat * F_variety * F_unlock * F_cap * F_crowd * W_outcome;
+    const Δ = Math.min(raw, Math.max(0, cap - P));
+    if (Δ <= 0)
+        return r2(P);
+    // Chance gate
+    let pGain;
+    if (Δ >= cfg.tauHigh)
+        pGain = 1.0;
+    else if (Δ <= cfg.tauLow)
+        pGain = cfg.pSmallMin;
+    else {
+        const t = (Δ - cfg.tauLow) / (cfg.tauHigh - cfg.tauLow);
+        pGain = cfg.pSmallMin + (1 - cfg.pSmallMin) * t;
+    }
+    return (cfg.rng() < pGain) ? r2(P + Δ) : r2(P);
+}
+/* ===================== Convenience lookups ===================== */
+/** Get all songs unlocked at or below proficiency P */
+export function songsAvailableAt(P) {
+    return INSTRUMENT_SONGS.filter(s => P >= s.unlock);
+}
+/** Filter helpers */
+export const songsByKind = (k) => INSTRUMENT_SONGS.filter(s => s.kind === k);
+export const songsByElement = (el) => INSTRUMENT_SONGS.filter(s => s.element === el);

--- a/data/game/proficiencies.js
+++ b/data/game/proficiencies.js
@@ -3,13 +3,13 @@ import { gainCraftProficiency } from "./crafting_proficiency.js";
 import { performCraft, trainingCraft, resetCraftTracking, } from "./craft_skill_tracker.js";
 import { gainSwimming, gainSailing, gainRiding, performOutdoorActivity } from "./outdoor_skills.js";
 import { gainHuntingProficiency, performHunt } from "./hunting_proficiency.js";
-import { gainInstrumentProficiency } from "./instrument_songs.ts";
-import { gainDanceProficiency } from "./dance_proficiency.ts";
-import { gainSingingProficiency } from "./singing_proficiency.ts";
-import { gainAnimalHandling } from "./animal_handling_proficiency.ts";
-import { gainSwordProficiency, gainGreatswordProficiency, gainAxeProficiency, gainGreataxeProficiency, gainSpearProficiency, gainDaggerProficiency, gainMaceProficiency, gainBowProficiency, gainCrossbowProficiency, gainStaffProficiency, gainShieldProficiency, gainWandProficiency, gainUnarmedProficiency, } from "./weapon_proficiency.ts";
-import { applyLightArmorProficiencyGain, applyMediumArmorProficiencyGain, applyHeavyArmorProficiencyGain, } from "./armor_proficiency.ts";
-import { gainReactiveProficiency } from "./reactive_proficiency.ts";
+import { gainInstrumentProficiency } from "./instrument_songs.js";
+import { gainDanceProficiency } from "./dance_proficiency.js";
+import { gainSingingProficiency } from "./singing_proficiency.js";
+import { gainAnimalHandling } from "./animal_handling_proficiency.js";
+import { gainSwordProficiency, gainGreatswordProficiency, gainAxeProficiency, gainGreataxeProficiency, gainSpearProficiency, gainDaggerProficiency, gainMaceProficiency, gainBowProficiency, gainCrossbowProficiency, gainStaffProficiency, gainShieldProficiency, gainWandProficiency, gainUnarmedProficiency, } from "./weapon_proficiency.js";
+import { applyLightArmorProficiencyGain, applyMediumArmorProficiencyGain, applyHeavyArmorProficiencyGain, } from "./armor_proficiency.js";
+import { gainReactiveProficiency } from "./reactive_proficiency.js";
 import { gainElementProficiency } from "./spell_proficiency.js";
 const OUTDOOR_GAINERS = {
     swimming: gainSwimming,

--- a/data/game/reactive_proficiency.js
+++ b/data/game/reactive_proficiency.js
@@ -1,0 +1,148 @@
+// reactive_proficiency.ts — Evasion, Parry, Block progression (hardest to master)
+/** Proficiency is tracked to 2 decimals. */
+const r2 = (x) => Math.round(x * 100) / 100;
+/** Tunables: deliberately stingy; adjust carefully. */
+export const REACTIVE_CFG = {
+    // Base scalar: MUCH lower than active skills
+    g0: 0.035, // base gain unit per qualifying event (tiny)
+    // In-activity requirements
+    requireCombatOrSpar: true,
+    requireRealWeapons: true,
+    // Level disparity factor (equal-level = rare & small)
+    // If Δ = enemyL - actorL:
+    // Δ < 0 -> 0 gain; Δ = 0 -> small (F=0.15); Δ >= 5 -> F ≈ 1.0
+    levelSlope: 0.17,
+    levelFloorEqual: 0.15, // at Δ=0
+    levelCap: 1.0,
+    // Event weighting (how informative each reactive event is)
+    // Evasion is hardest/highest info, then Parry, then Block
+    eventWeight: {
+        evasion: 1.00,
+        parry: 0.85,
+        block: 0.75,
+    },
+    // Outcome multipliers
+    // Very small partial learning; fails usually teach nothing
+    outcomeWeight: {
+        success: 1.00,
+        partial: 0.20,
+        fail: 0.00,
+    },
+    // Repetition decay (anti-farm): 1 / (1 + ln(1 + N_same))
+    // N_same = recent consecutive same-kind uses (e.g., blocks)
+    minRepeatFactor: 0.35,
+    // Variety bonus for mixing reactions (evasion+parry+block in window)
+    varietyMaxBonus: 0.20, // up to +20%
+    varietyWindow: 12, // last N reactive events
+    varietyTargetDistinct: 3,
+    // Distance to next threshold (unlock/tier) taper:
+    // as you cross a threshold, gains choke quickly
+    postUnlockChoke: 0.25, // multiply when below newly unlocked tier (discourage farming old tier)
+    unlockWindow: 6.0, // points after a threshold where choke applies to lower tiers
+    // Cap-gap factor: shrink when close to cap
+    capSoftenerK: 0.75, // factor in ((Cap - P)/Cap)^K
+    // Chance gate — very strict to make these slowest to master
+    // We convert the deterministic delta into a chance to tick; tiny deltas are often 0.
+    tauLow: 0.010, // ≤ 0.010 -> very small; rare
+    tauHigh: 0.045, // ≥ 0.045 -> reliable
+    pSmallMin: 0.08, // floor for tiny gains
+    // Partial-on-fail (VERY rare)
+    pPartialOnFail: 0.05,
+    // RNG: inject for determinism in tests
+    rng: () => Math.random(),
+};
+/** Utility: compute level factor respecting "hardest to master" and equal-level rarity. */
+function levelFactor(actorL, enemyL, cfg = REACTIVE_CFG) {
+    const d = enemyL - actorL;
+    if (d < 0)
+        return 0; // no gain vs weaker foes
+    if (d === 0)
+        return cfg.levelFloorEqual;
+    const f = cfg.levelFloorEqual + cfg.levelSlope * d;
+    return Math.min(cfg.levelCap, f);
+}
+/** Anti-farm repetition decay. */
+function repeatFactor(N_same, cfg = REACTIVE_CFG) {
+    if (N_same <= 0)
+        return 1;
+    const f = 1 / (1 + Math.log(1 + N_same));
+    return Math.max(cfg.minRepeatFactor, f);
+}
+/** Variety factor: reward mixing different reactions within a small window. */
+function varietyFactor(recentKinds, cfg = REACTIVE_CFG) {
+    if (!recentKinds || recentKinds.length === 0)
+        return 1;
+    const N = cfg.varietyWindow;
+    const slice = recentKinds.slice(-N);
+    const distinct = new Set(slice).size;
+    const t = Math.min(1, distinct / cfg.varietyTargetDistinct);
+    return 1 + cfg.varietyMaxBonus * t;
+}
+/** Post-unlock choke: if you are just past a threshold, choke gains from lower-tier habits. */
+function thresholdChoke(P, thresholds, cfg = REACTIVE_CFG) {
+    // If within unlockWindow above ANY threshold, apply choke (we assume the event is "lower-tierish")
+    // This is a heuristic for "stop farming easy stuff after a tier-up".
+    for (const t of thresholds) {
+        if (P >= t && P <= t + cfg.unlockWindow) {
+            return cfg.postUnlockChoke;
+        }
+    }
+    return 1.0;
+}
+/** Cap-gap factor: ((cap - P)/cap)^K */
+function capGapFactor(P, cap, cfg = REACTIVE_CFG) {
+    if (cap <= 0)
+        return 0;
+    const gap = Math.max(0, cap - P);
+    return Math.pow(gap / cap, cfg.capSoftenerK);
+}
+/** Core function: compute next proficiency for Evasion/Parry/Block (2-dec). */
+export function gainReactiveProficiency(input, cfg = REACTIVE_CFG) {
+    let { kind, outcome, P, cap, actorLevel, enemyLevel, inCombat, isSpar, realWeapons, N_same, recentKinds, thresholds } = input;
+    // Hard gating: only in combat or spar, and with real weapons, vs equal+ level
+    if (cfg.requireCombatOrSpar && !(inCombat || isSpar))
+        return r2(P);
+    if (cfg.requireRealWeapons && !realWeapons)
+        return r2(P);
+    if (enemyLevel < actorLevel)
+        return r2(P);
+    // If outcome is fail, still allow a tiny "partial" roll
+    if (outcome === "fail") {
+        if (cfg.rng() < cfg.pPartialOnFail) {
+            outcome = "partial";
+        }
+        else {
+            return r2(P); // no gain
+        }
+    }
+    const W_event = cfg.eventWeight[kind];
+    const F_level = levelFactor(actorLevel, enemyLevel, cfg);
+    const F_repeat = repeatFactor(N_same, cfg);
+    const F_variety = varietyFactor(recentKinds, cfg);
+    const F_unlock = thresholdChoke(P, thresholds, cfg);
+    const F_cap = capGapFactor(P, cap, cfg);
+    const W_outcome = cfg.outcomeWeight[outcome];
+    const raw = cfg.g0 * W_event * F_level * F_repeat * F_variety * F_unlock * F_cap * W_outcome;
+    // Strict chance gate to make these the slowest to master
+    const Δ = Math.min(raw, Math.max(0, cap - P)); // can't exceed cap
+    if (Δ <= 0)
+        return r2(P);
+    let gain = 0;
+    if (Δ >= cfg.tauHigh) {
+        gain = Δ;
+    }
+    else {
+        let p;
+        if (Δ <= cfg.tauLow) {
+            p = cfg.pSmallMin;
+        }
+        else {
+            const t = (Δ - cfg.tauLow) / (cfg.tauHigh - cfg.tauLow);
+            p = cfg.pSmallMin + t * (1 - cfg.pSmallMin);
+        }
+        if (cfg.rng() < p)
+            gain = Δ;
+    }
+    const nextP = Math.min(cap, P + gain);
+    return r2(nextP);
+}

--- a/data/game/singing_proficiency.js
+++ b/data/game/singing_proficiency.js
@@ -1,0 +1,156 @@
+// singing_proficiency.ts — proficiency gains for Singing (TS/JS compatible)
+const r2 = (x) => Math.round(x * 100) / 100;
+export const SINGING_CFG = {
+    g0: 0.072, // base gain per normalized tick (stingy)
+    contextWeight: { practice: 0.28, spar: 0.72, battle: 1.0 },
+    levelFloorEqual: 0.32,
+    levelSlope: 0.11,
+    levelCap: 1.0,
+    secNorm: 4, // ~4s sustained ≈ one learning unit
+    uptimeK: 0.6, // diminishing returns
+    crowdK: 0.08, crowdMax: 1.30,
+    pressureK: 0.09, pressureMax: 1.30,
+    acousticK: 0.10, ensembleK: 0.12,
+    acousticMax: 1.15, ensembleMax: 1.18,
+    minRepeatFactor: 0.45,
+    varietyMaxBonus: 0.25, varietyWindow: 10, varietyTargetDistinct: 4,
+    postUnlockChoke: 0.35, unlockWindow: 8.0,
+    capSoftenerK: 0.9,
+    outcomeWeight: { success: 1.0, partial: 0.30, fail: 0.0 },
+    stopBonus: 0.12,
+    tauLow: 0.018, tauHigh: 0.055, pSmallMin: 0.12,
+    rng: () => Math.random(),
+};
+/* ========================= Internal helpers ========================= */
+function levelFactor(actorL, enemyL, cfg) {
+    const d = enemyL - actorL;
+    if (d < -1)
+        return 0.05; // trivial content gives almost nothing
+    if (d <= 0)
+        return cfg.levelFloorEqual; // equal/slightly lower
+    return Math.min(cfg.levelCap, cfg.levelFloorEqual + cfg.levelSlope * d);
+}
+function repeatFactor(N_same, cfg) {
+    if (N_same <= 0)
+        return 1;
+    const f = 1 / (1 + Math.log(1 + N_same));
+    return Math.max(cfg.minRepeatFactor, f);
+}
+function varietyFactor(ids, cfg) {
+    if (!(ids === null || ids === void 0 ? void 0 : ids.length))
+        return 1;
+    const slice = ids.slice(-cfg.varietyWindow);
+    const distinct = new Set(slice).size;
+    const t = Math.min(1, distinct / cfg.varietyTargetDistinct);
+    return 1 + cfg.varietyMaxBonus * t;
+}
+function thresholdChoke(P, thresholds, cfg) {
+    for (const t of thresholds)
+        if (P >= t && P <= t + cfg.unlockWindow)
+            return cfg.postUnlockChoke;
+    return 1.0;
+}
+function capGapFactor(P, cap, cfg) {
+    const gap = Math.max(0, cap - P);
+    if (cap <= 0)
+        return 0;
+    return Math.pow(gap / cap, cfg.capSoftenerK);
+}
+function crowdFactor(nAllies, cfg) {
+    return Math.min(cfg.crowdMax, 1 + cfg.crowdK * Math.max(0, nAllies - 1));
+}
+function pressureFactor(nEnemies, cfg) {
+    return Math.min(cfg.pressureMax, 1 + cfg.pressureK * Math.max(0, nEnemies));
+}
+function uptimeFactor(maintainedSec, cfg) {
+    if (maintainedSec <= 0)
+        return 1; // instant pulse songs still give tiny signal
+    const units = maintainedSec / cfg.secNorm; // normalized “ticks”
+    return Math.pow(units, cfg.uptimeK); // diminishing returns on very long sustain
+}
+function acousticFactor(q = 0, cfg) {
+    const f = 1 + cfg.acousticK * Math.max(0, Math.min(1, q));
+    return Math.min(cfg.acousticMax, f);
+}
+function ensembleFactor(s = 0, cfg) {
+    const f = 1 + cfg.ensembleK * Math.max(0, Math.min(1, s));
+    return Math.min(cfg.ensembleMax, f);
+}
+/* ========================= Main progression ========================= */
+/** Compute next Singing proficiency (2 decimals).
+ * Call per maintained “tick” (e.g., every 3–5s) and once more with isStopEvent=true when stopping.
+ */
+export function gainSingingProficiency(input, cfg = SINGING_CFG) {
+    const { P, cap, actorLevel, enemyLevelAvg, context, outcome, maintainedSec, isStopEvent, N_same, recentSongIds, alliesAffected, enemiesPressuring, thresholds, acousticQuality = 0, ensembleSynergy = 0 } = input;
+    const W_ctx = cfg.contextWeight[context];
+    if (W_ctx <= 0 || outcome === "fail")
+        return r2(P);
+    const F_level = levelFactor(actorLevel, enemyLevelAvg, cfg);
+    const F_repeat = repeatFactor(N_same, cfg);
+    const F_variety = varietyFactor(recentSongIds, cfg);
+    const F_unlock = thresholdChoke(P, thresholds, cfg);
+    const F_cap = capGapFactor(P, cap, cfg);
+    const F_crowd = crowdFactor(alliesAffected, cfg);
+    const F_pressure = pressureFactor(enemiesPressuring, cfg);
+    const F_uptime = uptimeFactor(maintainedSec, cfg);
+    const F_acoustic = acousticFactor(acousticQuality, cfg);
+    const F_ensemble = ensembleFactor(ensembleSynergy, cfg);
+    const W_outcome = cfg.outcomeWeight[outcome];
+    let raw = cfg.g0
+        * W_ctx
+        * F_level
+        * F_repeat
+        * F_variety
+        * F_unlock
+        * F_cap
+        * F_crowd
+        * F_pressure
+        * F_uptime
+        * F_acoustic
+        * F_ensemble
+        * W_outcome;
+    if (isStopEvent)
+        raw *= (1 + cfg.stopBonus);
+    const Δ = Math.min(raw, Math.max(0, cap - P));
+    if (Δ <= 0)
+        return r2(P);
+    // Chance gate (keeps mastery slow and eventful)
+    let pGain;
+    if (Δ >= cfg.tauHigh)
+        pGain = 1.0;
+    else if (Δ <= cfg.tauLow)
+        pGain = cfg.pSmallMin;
+    else {
+        const t = (Δ - cfg.tauLow) / (cfg.tauHigh - cfg.tauLow);
+        pGain = cfg.pSmallMin + (1 - cfg.pSmallMin) * t;
+    }
+    return (cfg.rng() < pGain) ? r2(P + Δ) : r2(P);
+}
+/* ========================= Example usage =========================
+import { gainSingingProficiency } from "./singing_proficiency";
+
+// Maintain a chorus for ~5s during battle vs slightly higher-level enemies:
+let P = 37.42, cap = 68;
+P = gainSingingProficiency({
+  P, cap,
+  actorLevel: 20, enemyLevelAvg: 21,
+  context: "battle", outcome: "success",
+  maintainedSec: 5, isStopEvent: false,
+  N_same: 2, recentSongIds: ["SING_BUFF:02","SING_CTRL:03","SING_BUFF:08"],
+  alliesAffected: 5, enemiesPressuring: 2,
+  acousticQuality: 0.7, ensembleSynergy: 0.5,
+  thresholds: [10,20,30,40,50,60,70,80,90,100]
+});
+
+// On stop, apply small consolidation:
+P = gainSingingProficiency({
+  P, cap,
+  actorLevel: 20, enemyLevelAvg: 21,
+  context: "battle", outcome: "success",
+  maintainedSec: 0, isStopEvent: true,
+  N_same: 0, recentSongIds: ["SING_BUFF:02","SING_CTRL:03","SING_BUFF:08"],
+  alliesAffected: 5, enemiesPressuring: 2,
+  acousticQuality: 0.7, ensembleSynergy: 0.5,
+  thresholds: [10,20,30,40,50,60,70,80,90,100]
+});
+------------------------------------------------------------------- */

--- a/data/game/weapon_proficiency.js
+++ b/data/game/weapon_proficiency.js
@@ -1,0 +1,45 @@
+// weapon_proficiency.ts — generic weapon proficiency progression
+import { gainProficiency, proficiencyCap, PROF_MILESTONES } from "./proficiency_base.js";
+/**
+ * Increase a member's weapon proficiency.
+ *
+ * The member must have a `proficiencies` map following the {@link ProfBlock}
+ * shape from {@link party.ts}. If the block for the given kind does not
+ * exist it will be initialised with default cap and thresholds.
+ */
+export function gainWeaponProficiency(member, kind, opts = {}) {
+    const { success = true } = opts;
+    if (!member.proficiencies[kind]) {
+        member.proficiencies[kind] = {
+            value: 0,
+            cap: proficiencyCap(member.level),
+            thresholds: [...PROF_MILESTONES],
+        };
+    }
+    const block = member.proficiencies[kind];
+    // refresh cap for current level
+    block.cap = proficiencyCap(member.level);
+    block.value = gainProficiency({
+        P: block.value,
+        L: member.level,
+        A0: 1,
+        A: 0,
+        r: 1,
+        success,
+    });
+    return block.value;
+}
+// Convenience wrappers for specific weapons
+export const gainSwordProficiency = (m, opts) => gainWeaponProficiency(m, "Weapon_Sword", opts);
+export const gainGreatswordProficiency = (m, opts) => gainWeaponProficiency(m, "Weapon_Greatsword", opts);
+export const gainAxeProficiency = (m, opts) => gainWeaponProficiency(m, "Weapon_Axe", opts);
+export const gainGreataxeProficiency = (m, opts) => gainWeaponProficiency(m, "Weapon_Greataxe", opts);
+export const gainSpearProficiency = (m, opts) => gainWeaponProficiency(m, "Weapon_Spear", opts);
+export const gainDaggerProficiency = (m, opts) => gainWeaponProficiency(m, "Weapon_Dagger", opts);
+export const gainMaceProficiency = (m, opts) => gainWeaponProficiency(m, "Weapon_Mace", opts);
+export const gainBowProficiency = (m, opts) => gainWeaponProficiency(m, "Weapon_Bow", opts);
+export const gainCrossbowProficiency = (m, opts) => gainWeaponProficiency(m, "Weapon_Crossbow", opts);
+export const gainStaffProficiency = (m, opts) => gainWeaponProficiency(m, "Weapon_Staff", opts);
+export const gainShieldProficiency = (m, opts) => gainWeaponProficiency(m, "Weapon_Shield", opts);
+export const gainWandProficiency = (m, opts) => gainWeaponProficiency(m, "Weapon_Wand", opts);
+export const gainUnarmedProficiency = (m, opts) => gainWeaponProficiency(m, "Weapon_Unarmed", opts);


### PR DESCRIPTION
## Summary
- add JavaScript builds for the proficiency modules so the browser no longer attempts to load TypeScript files as modules
- update the main proficiency registry to import the new .js modules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cce7cafe948325b57124617ad0e89a