### PR TITLE
Refine quest board spacing and quest narratives

### DIFF
--- a/data/game/locations.ts
+++ b/data/game/locations.ts
@@ -2031,9 +2031,9 @@ const WAVES_BREAK_FARMLAND_BUSINESSES: BusinessProfile[] = [
     quests: [
       createQuest(
         "North Gate Roster",
-        "Captain Brisa calls for gate-grinders and a veteran guard to keep the portcullis ready through caravan week.",
+        "Captain Brisa spreads a grease-striped roster atop the North Gate winch dais, seeking grinders to oil the counterweight chains and a veteran to pace the torch-lit portcullis drums through caravan week.",
         {
-          location: "North Gate",
+          location: "North Gate winch dais and toll ledgers",
           requirements: [
             "Wave's Break Guard rank: Gatehand or Adventurers' Guild Bronze",
             "Strength to work portcullis winches for extended periods",
@@ -2058,9 +2058,9 @@ const WAVES_BREAK_FARMLAND_BUSINESSES: BusinessProfile[] = [
       ),
       createQuest(
         "Portcullis Siege Drill",
-        "Intelligence of raiders triggers a siege drill—experienced guards must man the murder holes and test the gate.",
+        "Raid whispers send gongs ringing along the parapet—the winch towers need archers at the murder holes, engineers tending tar cauldrons, and shield guards bracing the gatehouse doors for a midnight siege drill.",
         {
-          location: "North Gate",
+          location: "North Gate battlements and murder-hole galleries",
           requirements: [
             "Guard rank: Sergeant or Adventurers' Guild Brass",
             "Martial Weapon proficiency 35+ with polearm or crossbow",
@@ -2638,9 +2638,9 @@ const WAVES_BREAK_FARMLAND_BUSINESSES: BusinessProfile[] = [
     quests: [
       createQuest(
         "South Gate Writ",
-        "Captain Relwen seeks gate marshals and a sergeant to regulate outbound wagons bound for the fields.",
+        "Captain Relwen nails a sun-faded writ beneath the South Gate canopy, calling for queue marshals to chalk wagon numbers, steady torch-bearers amid spice carts, and a steady sergeant to stamp toll ledgers before the harvest caravans roll out.",
         {
-          location: "South Gate",
+          location: "South Gate marshal's canopy and outbound queue lanes",
           requirements: [
             "Wave's Break Guard rank: Gatehand or Adventurers' Guild Bronze",
             "Perception 24+ to spot contraband",
@@ -2664,9 +2664,9 @@ const WAVES_BREAK_FARMLAND_BUSINESSES: BusinessProfile[] = [
       ),
       createQuest(
         "Outbound Patrol Escort",
-        "Bandit rumors demand a vetted escort team to lead supply wagons to the outer watchposts.",
+        "Gatewatch runners need a seasoned escort to marshal salt-caked supply wagons, haul storm tarps, and carry brass signal horns from the South Gate muster yard to the Brackenshore and Coast Road watchposts as bandit whispers flare.",
         {
-          location: "South Gate",
+          location: "South Gate muster yard and coastal road watchposts",
           requirements: [
             "Guard rank: Sergeant or Adventurers' Guild Brass",
             "Martial Weapon proficiency 30+ or Battle Magic (Circle 1)",
@@ -5937,9 +5937,9 @@ const WAVES_BREAK_LOWER_GARDENS_BUSINESSES: BusinessProfile[] = [
     quests: [
       createQuest(
         "Caravan Loader Levy",
-        "Gate sergeants hire loaders to ready caravans before the midday sun.",
+        "Sergeant Hullen waves crews toward the South Gate loading yard, pressing bale hooks, crate sledges, and fresh tarpaulins into ready hands so wagons are stacked before the noon bells scorch the cobbles.",
         {
-          location: "South Gate Market",
+          location: "South Gate Market loading yards and tack sheds",
           requirements: [
             "Strength and stamina",
             "Guild Rank: Caravan Laborer or Adventurers' Guild Bronze",
@@ -5963,9 +5963,9 @@ const WAVES_BREAK_LOWER_GARDENS_BUSINESSES: BusinessProfile[] = [
       ),
       createQuest(
         "Manifest Inspection Patrol",
-        "Smuggling rumors demand discreet inspectors to walk the line and verify manifests at dusk.",
+        "With contraband whispers rising, Hullen needs quiet inspectors walking the dusk-lit caravan queue, lanterns angled over brass-sealed manifests and spice-stained crates to spot false seals before the wagons roll.",
         {
-          location: "South Gate Market",
+          location: "South Gate Market caravan queue and ledger tents",
           requirements: [
             "Investigation 20+",
             "Guild Rank: Gate Inspector or Adventurers' Guild Silver",

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
       </button>
     </div>
   </div>
+  <div class="settings-buffer" aria-hidden="true"></div>
   <div class="top-menu-info">
     <span id="menu-date">Date: —</span>
     <span id="menu-money">Funds: —</span>

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@
   --foreground: #333333;
   /* Menu button colors default to the light theme */
   --menu-color-dark: #333333;
-    --menu-color-light: #d3d3d3;
+  --menu-color-light: #d3d3d3;
   --range-color: #555555;
   --capped-color: #2e8b57;
   --new-char-bg: #333333;
@@ -16,6 +16,9 @@
   --stamina-color: #00ff00;
   --menu-button-size: 2.625rem;
   --menu-height: var(--menu-button-size);
+  --settings-panel-gap: 0.0625rem;
+  --settings-panel-width: calc(3 * var(--menu-button-size) + 2 * var(--settings-panel-gap));
+  --settings-panel-buffer: 0.5rem;
 }
 
 html {
@@ -52,7 +55,7 @@ main {
   background: var(--background);
   display: flex;
   flex-direction: row;
-  gap: 0.0625rem;
+  gap: var(--settings-panel-gap);
   padding: 0 0.5rem;
   height: var(--menu-button-size);
   align-items: center;
@@ -114,7 +117,7 @@ main {
   font-weight: 600;
   color: var(--menu-color-dark);
   padding: 0 0.5rem 0 0.75rem;
-  margin-left: auto;
+  margin-left: var(--settings-panel-gap);
 }
 
 .top-menu-info span {
@@ -140,9 +143,15 @@ body.theme-dark .top-menu-info {
 
 .settings-group {
   display: flex;
-  gap: 0.0625rem;
+  gap: var(--settings-panel-gap);
   position: relative;
   align-items: center;
+}
+
+.settings-buffer {
+  flex: 0 0 calc(var(--settings-panel-width) + var(--settings-panel-buffer));
+  min-width: calc(var(--settings-panel-width) + var(--settings-panel-buffer));
+  height: 100%;
 }
 
 @media (orientation: portrait) {
@@ -157,7 +166,7 @@ body.theme-dark .top-menu-info {
 
 #settings-panel {
   display: flex;
-  gap: 0.0625rem;
+  gap: var(--settings-panel-gap);
   overflow: hidden;
   position: absolute;
   pointer-events: none;
@@ -1628,6 +1637,16 @@ body.theme-dark .top-menu button {
 .questboard-detail .quest-weather {
   margin: 0.5rem 0 0.75rem;
   font-size: 0.9rem;
+}
+
+.questboard-detail .quest-sources {
+  margin: 0.25rem 0 0.75rem;
+  font-size: 0.85rem;
+  color: rgba(51, 51, 51, 0.75);
+}
+
+.questboard-detail .quest-sources strong {
+  color: rgba(51, 51, 51, 0.95);
 }
 
 .questboard-detail .quest-empty {


### PR DESCRIPTION
## Summary
- reserve consistent top-bar spacing for the expanding settings panel and add quest board icons to district buttons for clarity
- surface quest board posting sources and per-quest posting details while summarising board task locations
- enrich North and South Gate quest descriptions with location-aware narrative details and updated task locales

## Testing
- npm run validate
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd6f2b6d888325b8867ea1c3da82ed