### PR TITLE
Ensure map container is ready before UI renders

### DIFF
--- a/script.js
+++ b/script.js
@@ -608,6 +608,13 @@ const topMenu = document.querySelector('.top-menu');
 const app = document.getElementById('app');
 const menuDateLabel = document.getElementById('menu-date');
 const menuMoneyLabel = document.getElementById('menu-money');
+const mapContainer = document.createElement('div');
+mapContainer.id = 'map-container';
+mapContainer.style.display = 'none';
+if (app) {
+  app.appendChild(mapContainer);
+}
+let mapToggleButton = null;
 
 function updateTopMenuIndicators() {
   if (menuDateLabel) {
@@ -657,8 +664,8 @@ updateTopMenuIndicators();
 
 function setMainHTML(html) {
   if (main) main.innerHTML = html;
-  if (typeof mapContainer !== "undefined") mapContainer.style.display = "none";
-  if (typeof mapToggleButton !== "undefined" && mapToggleButton) {
+  if (mapContainer) mapContainer.style.display = 'none';
+  if (mapToggleButton) {
     mapToggleButton.classList.remove("map-toggle-floating");
     mapToggleButton = null;
   }
@@ -6642,10 +6649,6 @@ const menuButton = document.getElementById('menu-button');
 const characterButton = document.getElementById('character-button');
 const dropdownMenu = document.getElementById('dropdownMenu');
 const characterMenu = document.getElementById('characterMenu');
-const mapContainer = document.createElement('div');
-mapContainer.id = 'map-container';
-app.appendChild(mapContainer);
-let mapToggleButton = null;
 function toggleCityMap(btn) {
   if (!currentCharacter) return;
   if (mapContainer.style.display === 'flex') {


### PR DESCRIPTION
## Summary
- initialize the city map container alongside the other cached DOM nodes so early UI rendering doesn't hit a ReferenceError
- reset the map overlay via the shared container when swapping screens so the menu can load cleanly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf1d5197988325b1b7296b4ad1ab21