### PR TITLE
Improve top menu date and funds display

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
   </div>
   <div class="settings-buffer" aria-hidden="true"></div>
   <div class="top-menu-info">
-    <span id="menu-date">Date: —</span>
-    <span id="menu-money">Funds: —</span>
+    <span id="menu-date" class="top-menu-item" aria-label="Current date" title="Current date">—</span>
+    <span id="menu-money" class="top-menu-item" aria-label="Available funds" title="Available funds">—</span>
   </div>
   </nav>
 

--- a/script.js
+++ b/script.js
@@ -618,13 +618,24 @@ let mapToggleButton = null;
 
 function updateTopMenuIndicators() {
   if (menuDateLabel) {
-    menuDateLabel.textContent = `Date: ${worldCalendar.formatCurrentDate()}`;
+    const currentDate = worldCalendar.formatCurrentDate();
+    menuDateLabel.textContent = currentDate;
+    menuDateLabel.setAttribute('title', `Date: ${currentDate}`);
+    menuDateLabel.setAttribute('aria-label', `Current date: ${currentDate}`);
   }
   if (menuMoneyLabel) {
-    const funds = currentCharacter
-      ? formatCurrency(currentCharacter.money || createEmptyCurrency())
-      : '—';
-    menuMoneyLabel.textContent = `Funds: ${funds}`;
+    if (currentCharacter) {
+      const money = currentCharacter.money || createEmptyCurrency();
+      const totalCopper = convertCurrency(toIron(money), 'coldIron', 'copper');
+      const fundsText = formatCurrency(money);
+      menuMoneyLabel.innerHTML = cpToCoins(totalCopper, true, true);
+      menuMoneyLabel.setAttribute('title', `Funds: ${fundsText}`);
+      menuMoneyLabel.setAttribute('aria-label', `Available funds: ${fundsText}`);
+    } else {
+      menuMoneyLabel.textContent = '—';
+      menuMoneyLabel.setAttribute('title', 'Available funds');
+      menuMoneyLabel.setAttribute('aria-label', 'Available funds: unavailable');
+    }
   }
   if (typeof requestAnimationFrame === 'function') {
     requestAnimationFrame(() => updateMenuHeight());

--- a/style.css
+++ b/style.css
@@ -111,19 +111,37 @@ main {
 
 .top-menu-info {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.125rem;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
   font-size: calc(var(--menu-button-size) * 0.32);
-  line-height: 1.1;
+  line-height: 1;
   font-weight: 600;
   color: var(--menu-color-dark);
   padding: 0 0.5rem 0 0.75rem;
-  margin-left: var(--settings-panel-gap);
+  margin-left: auto;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
-.top-menu-info span {
+.top-menu-info .top-menu-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   white-space: nowrap;
+}
+
+.top-menu-info .currency {
+  gap: 0.35rem;
+}
+
+.top-menu-info .coin {
+  gap: 0.2rem;
+}
+
+.top-menu-info .coin-icon {
+  height: calc(var(--menu-button-size) * 0.32);
+  width: auto;
 }
 
   body.theme-dark #menu-button {
@@ -179,6 +197,8 @@ body.theme-dark .top-menu-info {
     margin-left: 0;
     padding: 0.25rem 0 0;
     align-items: flex-start;
+    justify-content: flex-start;
+    flex-wrap: wrap;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the date and funds indicators within the top menu using dedicated info items
- restyle the top menu info area for horizontal layout and coin icon presentation
- render the current date and character funds without labels while swapping coin text for icons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf441210908325bd83c197b3a83cdb