### PR TITLE
Fix district map icons and consolidate Little Terns quest board

### DIFF
--- a/data/game/waves_break_registry.js
+++ b/data/game/waves_break_registry.js
@@ -393,28 +393,28 @@ const UPPER_WARD_BOARD_PLAN = {
     },
 };
 const LITTLE_TERNS_BOARD_PLAN = {
-    "Guild of Smiths Forge Gate": {
-        location: "Guild of Smiths",
+  "Guild of Smiths Forge Gate": {
+        location: "Little Terns District Board",
         businesses: ["Guild of Smiths"],
     },
     "Timberwave Yard Posting": {
-        location: "Timberwave Carpenters' Guild",
+        location: "Little Terns District Board",
         businesses: ["Timberwave Carpenters' Guild"],
     },
     "Carvers' Hall Chisel Board": {
-        location: "Carvers' and Fletchers' Hall",
+        location: "Little Terns District Board",
         businesses: ["Carvers' and Fletchers' Hall"],
     },
     "Gilded Needle Facade Placards": {
-        location: "The Gilded Needle Clothiers",
+        location: "Little Terns District Board",
         businesses: ["The Gilded Needle Clothiers"],
     },
     "Brine & Bark Headhouse": {
-        location: "Brine & Bark Tannery",
+        location: "Little Terns District Board",
         businesses: ["Brine & Bark Tannery"],
     },
     "Seawind Loft Rail": {
-        location: "Seawind Sailmakers' Hall",
+        location: "Little Terns District Board",
         businesses: ["Seawind Sailmakers' Hall"],
     },
 };

--- a/data/game/waves_break_registry.ts
+++ b/data/game/waves_break_registry.ts
@@ -478,27 +478,27 @@ const UPPER_WARD_BOARD_PLAN: BoardPlan = {
 
 const LITTLE_TERNS_BOARD_PLAN: BoardPlan = {
   "Guild of Smiths Forge Gate": {
-    location: "Guild of Smiths",
+    location: "Little Terns District Board",
     businesses: ["Guild of Smiths"],
   },
   "Timberwave Yard Posting": {
-    location: "Timberwave Carpenters' Guild",
+    location: "Little Terns District Board",
     businesses: ["Timberwave Carpenters' Guild"],
   },
   "Carvers' Hall Chisel Board": {
-    location: "Carvers' and Fletchers' Hall",
+    location: "Little Terns District Board",
     businesses: ["Carvers' and Fletchers' Hall"],
   },
   "Gilded Needle Facade Placards": {
-    location: "The Gilded Needle Clothiers",
+    location: "Little Terns District Board",
     businesses: ["The Gilded Needle Clothiers"],
   },
   "Brine & Bark Headhouse": {
-    location: "Brine & Bark Tannery",
+    location: "Little Terns District Board",
     businesses: ["Brine & Bark Tannery"],
   },
   "Seawind Loft Rail": {
-    location: "Seawind Sailmakers' Hall",
+    location: "Little Terns District Board",
     businesses: ["Seawind Sailmakers' Hall"],
   },
 };

--- a/script.js
+++ b/script.js
@@ -3340,21 +3340,21 @@ function showNavigation() {
         const isLandscape = window.innerWidth > window.innerHeight;
         const iconRem = isLandscape ? 10 : 4.5;
         const size = iconRem * fontSize;
-        const nodes = allNames.map(name => {
+        const visibleNames = allNames.filter(name => accessible.has(name));
+        const nodes = visibleNames.map(name => {
           const coords = layout.positions[name] || [0, 0];
           const [row, col] = coords;
-          const disabled = !accessible.has(name);
           const extraClass = name === pos.district ? 'current-district' : '';
           return `<div class="district-node" style="left:${col * size}px;top:${row * size}px;">${createNavItem({
             type: 'district',
             target: name,
             name,
             icon: getDistrictIcon(pos.city, name),
-            disabled,
             extraClass,
           })}</div>`;
         });
         const lines = (layout.connections || [])
+          .filter(([a, b]) => accessible.has(a) && accessible.has(b))
           .map(([a, b]) => {
             const [r1, c1] = layout.positions[a] || [0, 0];
             const [r2, c2] = layout.positions[b] || [0, 0];
@@ -5740,11 +5740,13 @@ function showQuestBoardDetails(boardIdentifier, options = {}) {
     };
     if (activeSections.length) {
       html += '<div class="questboard-subareas">';
-      activeSections.forEach(section => {
+      const autoOpenAll = activeSections.length === 1;
+      activeSections.forEach((section, index) => {
         const summaryLabel = sanitizeText(section.name || displayName);
         const countLabel = `<span class="quest-count">${section.entries.length}</span>`;
         const listHTML = section.entries.map(renderQuestItem).join('');
-        html += `<details class="questboard-subarea" open><summary>${summaryLabel}${countLabel}</summary><ul class="quest-board-list">${listHTML}</ul></details>`;
+        const openAttr = autoOpenAll || index === 0 ? ' open' : '';
+        html += `<details class="questboard-subarea"${openAttr}><summary>${summaryLabel}${countLabel}</summary><ul class="quest-board-list">${listHTML}</ul></details>`;
       });
       html += '</div>';
     } else {


### PR DESCRIPTION
## Summary
- limit the city map overlay to render icons and connection lines only for the currently reachable districts
- default quest board sections to collapsible panels with only the first area opened initially
- group all Little Terns contracts under a single district board entry by sharing the same location binding in the data set

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cffebc78948325ad8157f8d01408bf