### PR TITLE
Fix district navigation display and adjust portrait menu layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -3372,22 +3372,7 @@ function showNavigation() {
         ];
       }
       const neighborButtons = districtLinks.map(makeButton);
-      if (!hasMultipleDistricts) {
-        return neighborButtons;
-      }
-      const neighborNames = new Set(districtLinks.map(d => d.target || d.name));
-      const additional = allNames
-        .filter(name => name !== pos.district && !neighborNames.has(name))
-        .map(name =>
-          createNavItem({
-            type: 'district',
-            target: name,
-            name,
-            prompt: 'Travel to',
-            icon: getDistrictIcon(pos.city, name),
-          })
-        );
-      return [...neighborButtons, ...additional];
+      return neighborButtons;
     };
 
     const mapToggle = hasMultipleDistricts

--- a/style.css
+++ b/style.css
@@ -200,16 +200,17 @@ body.theme-dark .top-menu-info {
   }
 
   .top-menu-info {
-    order: 10;
-    flex: 1 0 100%;
-    margin-left: 0;
-    padding: 0.25rem 0 0;
-    align-items: flex-start;
-    text-align: left;
+    order: 0;
+    flex: 1 1 auto;
+    margin-left: auto;
+    padding: 0;
+    align-items: flex-end;
+    text-align: right;
+    min-width: 0;
   }
 
   .top-menu-info .top-menu-item {
-    justify-content: flex-start;
+    justify-content: flex-end;
   }
 }
 


### PR DESCRIPTION
## Summary
- restrict the district navigation list to only show connected districts
- keep the date and funds indicators within the top menu in portrait orientation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0033f8fe08325a999a43d7b933cf3