### PR TITLE
Fix top menu info overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -131,7 +131,11 @@ main {
   align-items: center;
   justify-content: flex-end;
   gap: 0.35rem;
-  white-space: nowrap;
+  max-width: 100%;
+  flex-wrap: wrap;
+  white-space: normal;
+  text-align: right;
+  overflow-wrap: anywhere;
 }
 
 .top-menu-info .currency {
@@ -139,6 +143,8 @@ main {
   align-items: center;
   justify-content: flex-end;
   gap: 0.35rem;
+  flex-wrap: wrap;
+  max-width: 100%;
 }
 
 .top-menu-info .coin {


### PR DESCRIPTION
## Summary
- allow the date and funds indicators to wrap within the top menu so they stay on-screen
- enable the currency display to wrap coin icons while keeping right-aligned styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d006e9d5048325a657afab204410b4