### PR TITLE
Add Merchants' Wharf quest board and scene updates

### DIFF
--- a/data/game/locations.ts
+++ b/data/game/locations.ts
@@ -3617,6 +3617,109 @@ const WAVES_BREAK_PORT_BUSINESSES: BusinessProfile[] = [
     ],
   },
   {
+    name: "Merchants' Wharf",
+    category: "logistics",
+    scale: {
+      tier: 'strategic',
+      label: "Bulk Cargo Wharf (Strategic)",
+      rationale:
+        "Limited berths demand nonstop crane crews to keep merchant hulls turning with the tide.",
+      output:
+        "Berth rotations, cargo tallies, and wagon dispatches feeding inland trade routes.",
+    },
+    production: {
+      goods: ["bulk cargo transfers", "berth schedules", "overland dispatch slips"],
+      notes:
+        "Timber cranes, capstan winches, and wagon queues move grain, ore, and textiles ashore before the tide shifts again.",
+    },
+    workforce: {
+      description:
+        "Stevedore gangs, crane captains, tally clerks, and wagon marshals labor in tight rotations along the quay.",
+      normal: [
+        unskilled(54, "dock laborers, sling teams, wagon loaders"),
+        skilled(20, "crane captains, tally clerks, rigging supervisors"),
+        specialist(5, "dockmasters coordinating berths and manifests"),
+      ],
+    },
+    laborConditions: [
+      {
+        trigger: "Storm-delayed flotillas",
+        season: "Any storm season emergency",
+        description:
+          "Backlogged hulls arrive on the same tide; extra shifts must clear cargo before the harbormaster closes the lane.",
+        staffing: [
+          unskilled(30, "night crane gangs and rope tenders"),
+          skilled(8, "relief tally clerks and riggers"),
+          specialist(2, "assistant dockmasters to juggle berth rotations"),
+        ],
+      },
+      {
+        trigger: "Harvest convoy surge",
+        season: "Late summer through early autumn",
+        description:
+          "Grain barges and timber caravans crowd the piers, demanding overflow crews to keep wagons rolling inland.",
+        staffing: [
+          unskilled(24, "sunrise wagon loaders and sack carriers"),
+          skilled(6, "scale inspectors certifying cargo weight"),
+        ],
+      },
+    ],
+    quests: [
+      createQuest(
+        "Sunrise Cargo Rotation",
+        "Dockmaster Alis needs reliable muscle to clear holds before the tide turns.",
+        {
+          location: "Merchants' Wharf",
+          requirements: [
+            "Athletics 18+ or Strength 16+ to haul sling loads without slowing",
+            "Guild Rank: Dockhand Crew Laborer or Adventurers' Guild Bronze",
+            "Bronze token stamped with 1 star accepted; stamp resets when promoted.",
+          ],
+          conditions: [
+            "Sunrise-to-sunset shift moving bulk cargo from holds to waiting wagons",
+            "Obey crane captains' calls and report tally discrepancies immediately",
+          ],
+          timeline: "Single-day contract (sunrise rotation)",
+          risks: [
+            "Swinging pallets and runaway wagons",
+            "Fines for damaged cargo or missed tide",
+          ],
+          reward: "2 sp 6 cp plus hot meal chit at the quay kitchens",
+          postingStyle: "Dockmaster's Bill",
+          issuer: "Factor Alis Merrow",
+          guildRankRequirement: "Adventurers' Guild Bronze",
+          reputationRequirement: "Bronze token stamped with 1 star for dock service",
+        },
+      ),
+      createQuest(
+        "Evening Crane Watch",
+        "The Merrow Syndicate requires sharp oversight as dusk shipments berth under crowded quotas.",
+        {
+          location: "Merchants' Wharf",
+          requirements: [
+            "Perception 20+ or Navigator's Tools proficiency 18+ to spot unsafe rigging",
+            "Guild Rank: Harbor Guard Corporal or Adventurers' Guild Silver",
+            "Silver token stamped with 1 star; stamp clears upon promotion.",
+          ],
+          conditions: [
+            "Supervise crane teams through sunset arrivals and log incidents with Harborwatch",
+            "File berth turnover reports before the curfew bell",
+          ],
+          timeline: "Two-evening oversight during storm backlog",
+          risks: [
+            "Cable snaps over crowded decks",
+            "Dockmaster fines if cargo schedules slip",
+          ],
+          reward: "12 sp plus berth priority chit for a chartered vessel",
+          postingStyle: "Syndicate Crane Order",
+          issuer: "Merrow Syndicate Berth Office",
+          guildRankRequirement: "Adventurers' Guild Silver",
+          reputationRequirement: "Silver token stamped with 1 star for harbor oversight",
+        },
+      ),
+    ],
+  },
+  {
     name: "Saltworks",
     category: "processing",
     scale: {

--- a/data/game/waves_break_registry.ts
+++ b/data/game/waves_break_registry.ts
@@ -339,6 +339,7 @@ const PORT_BUSINESSES = [
   "Harborwatch Trading House",
   "Stormkeel Shipwrights",
   "Harbor Guard Naval Yard",
+  "Merchants' Wharf",
   "Saltworks",
   "Fishmongers' Row",
   "The Ropewalk",
@@ -443,6 +444,10 @@ const PORT_BOARD_PLAN: BoardPlan = {
   "Naval Yard Muster Wall": {
     location: "Harbor Guard Naval Yard",
     businesses: ["Harbor Guard Naval Yard"],
+  },
+  "Merchants' Wharf Cargo Roster": {
+    location: "Merchants' Wharf",
+    businesses: ["Merchants' Wharf"],
   },
   "Saltworks Evaporation Gate": {
     location: "Saltworks",
@@ -805,6 +810,11 @@ const WAVES_BREAK_BUSINESS_OWNERS: OwnershipMap = {
     stewards: ["Captain Yorsen of the Harbor Guard"],
     notes: "Fleet tenders answer to the harbor admiralty office.",
   },
+  "Merchants' Wharf": {
+    owner: "Merrow Syndicate",
+    stewards: ["Factor Alis Merrow"],
+    notes: "Merrow berth officers marshal crane captains and cargo bosses to keep the quay turning.",
+  },
   "Saltworks": {
     owner: "Saltmaster Family Cooperative",
     stewards: ["Saltmaster Rinna"],
@@ -992,7 +1002,7 @@ const WAVES_BREAK_BUILDING_OWNERS: OwnershipMap = {
   "Merchants' Wharf": {
     owner: "Merrow Syndicate",
     stewards: ["Factor Alis Merrow"],
-    notes: "Syndicate factors rotate berths for merchant caravels.",
+    notes: "Syndicate factors rotate berths and crane crews to keep bulk cargo moving between tide windows.",
   },
   "Fisherman's Pier": {
     owner: "Hookfin Netters",

--- a/script.js
+++ b/script.js
@@ -2564,6 +2564,32 @@ function buildingWeatherPhrase(weather, habitat, buildingName) {
   return `amid shifting weather over ${place.toLowerCase()}`;
 }
 
+function merchantsWharfWeatherSentence(weather) {
+  if (!weather) {
+    return 'Stevedores keep the berths turning regardless of the day.';
+  }
+  const condition = (weather.condition || '').toLowerCase();
+  if (condition.includes('storm')) {
+    return "Spray lashes every gang as gale gusts whip across the quay.";
+  }
+  if (condition.includes('rain') || condition.includes('drizzle')) {
+    return "Laborers move with redoubled efforts under the heavy rain's onslaught.";
+  }
+  if (condition.includes('fog')) {
+    return 'Bell signals and shouted counts cut through the fog to keep the cargo flowing.';
+  }
+  if (condition.includes('snow') || condition.includes('sleet')) {
+    return 'Slick planks and frozen lines slow every step, but the crews lash each pallet tight.';
+  }
+  if (condition.includes('clear')) {
+    return 'Sunlight gleams on wet ropes while the pace never falters beneath the clear sky.';
+  }
+  if (condition.includes('cloud')) {
+    return 'Cool overcast skies keep the crews marching in a relentless rhythm.';
+  }
+  return 'Crews adjust on the fly, keeping cargo moving despite the shifting conditions.';
+}
+
 function buildingActivityPhrase(workers, profile, buildingName) {
   if (!workers) {
     return `Only caretakers keep ${buildingName} idling today.`;
@@ -2605,11 +2631,18 @@ function buildingSceneParagraphs(context) {
   if (building?.description) paragraphs.push(building.description);
   const displayName = building?.name || buildingName;
   if (displayName) {
-    const weatherPhrase = buildingWeatherPhrase(weather, habitat, displayName);
-    const intro = timeLabel
-      ? `${displayName} works through the ${timeLabel.toLowerCase()}, ${weatherPhrase}.`
-      : `${displayName} hums ${weatherPhrase}.`;
-    paragraphs.push(intro);
+    if (displayName === "Merchants' Wharf") {
+      const base =
+        'Laborers and merchants line the docks from sunrise to sunset as lines of cargo make their way on and off of ships.';
+      const weatherSentence = merchantsWharfWeatherSentence(weather);
+      paragraphs.push(`${base} ${weatherSentence}`);
+    } else {
+      const weatherPhrase = buildingWeatherPhrase(weather, habitat, displayName);
+      const intro = timeLabel
+        ? `${displayName} works through the ${timeLabel.toLowerCase()}, ${weatherPhrase}.`
+        : `${displayName} hums ${weatherPhrase}.`;
+      paragraphs.push(intro);
+    }
   }
   const activity = buildingActivityPhrase(workers, businessProfile, displayName || 'the site');
   if (activity) paragraphs.push(activity);


### PR DESCRIPTION
## Summary
- add a detailed Merchants' Wharf business profile with workforce, labor conditions, and new cargo-focused quests
- register the wharf with Wave's Break ownership data and create a dedicated Merchants' Wharf Cargo Roster quest board in the port plan
- customize the Merchants' Wharf building scene to describe day-long cargo work followed by weather-specific flavour text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d03204dae48325ac5d65244358be02