### PR TITLE
Refine Warehouse Row narration and stabilize top menu layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -646,8 +646,9 @@ function updateTopMenuIndicators() {
 
 function updateLayoutSize() {
   if (!app) return;
-  const vw = window.innerWidth;
-  const vh = window.innerHeight;
+  const viewport = window.visualViewport;
+  const vw = viewport?.width || window.innerWidth;
+  const vh = viewport?.height || window.innerHeight;
   const scale = parseFloat(
     getComputedStyle(document.documentElement).getPropertyValue('--ui-scale')
   ) || 1;
@@ -670,6 +671,10 @@ function handleResize() {
   normalizeProficiencyNameWidths();
 }
 window.addEventListener('resize', handleResize);
+if (window.visualViewport) {
+  window.visualViewport.addEventListener('resize', handleResize);
+  window.visualViewport.addEventListener('scroll', handleResize);
+}
 handleResize();
 updateTopMenuIndicators();
 
@@ -2795,6 +2800,9 @@ function buildingOperationDetail(buildingName) {
   if (name.includes('wharf') || name.includes('dock') || name.includes('pier') || name.includes('quay')) {
     return 'cargo flowing along the wharf';
   }
+  if (name.includes('warehouse')) {
+    return 'manifests checked and cargo sealed along the warehouse row';
+  }
   if (name.includes('yard')) {
     return 'the yard drilled and ready';
   }
@@ -2862,6 +2870,14 @@ function buildingExtraSceneOverride(buildingName, rng) {
       scenes: [
         'Capstan crews chant as they warp a grain barge beneath the waiting cranes.',
         'Ledger-runners weave between crate stacks, relaying berth assignments to sweating dock bosses.',
+      ],
+    },
+    {
+      pattern: /warehouse/,
+      scenes: [
+        'Porters hoist crates while tally clerks flick abacuses beneath the hanging lamps.',
+        'Inspectors unseal cargo before scribes ink fresh manifests for the bonded stores.',
+        'Cart teams reverse in tight formation as dockhands stack marked freight for delivery.',
       ],
     },
     {

--- a/style.css
+++ b/style.css
@@ -19,6 +19,7 @@
   --settings-panel-gap: 0.0625rem;
   --settings-panel-width: calc(3 * var(--menu-button-size) + 2 * var(--settings-panel-gap));
   --settings-panel-buffer: 0.5rem;
+  --top-menu-padding-right: 0.75rem;
 }
 
 html {
@@ -56,7 +57,7 @@ main {
   display: flex;
   flex-direction: row;
   gap: var(--settings-panel-gap);
-  padding: 0 0.5rem;
+  padding: 0 var(--top-menu-padding-right) 0 0.5rem;
   height: var(--menu-button-size);
   align-items: center;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
@@ -194,7 +195,8 @@ body.theme-dark .top-menu-info {
   }
 
   .top-menu {
-    padding: 0 0.5rem;
+    padding-left: 0.5rem;
+    padding-right: var(--top-menu-padding-right);
     flex-wrap: wrap;
     row-gap: 0.25rem;
   }


### PR DESCRIPTION
## Summary
- add warehouse-specific operation text and extra scene details so Warehouse Row no longer repeats generic narration
- use visual viewport metrics for layout scaling and listen for viewport events to keep the menu within view
- increase the top menu's right padding so the date and funds indicators stay on-screen

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0ce23faf48325a14b21cd8728851b