### PR TITLE
Fix farm overview default text quoting

### DIFF
--- a/script.js
+++ b/script.js
@@ -4187,7 +4187,7 @@ const BUILDING_OVERVIEW_BLUEPRINTS = {
         "season:autumn": "Wagons brim with harvested grain and root bundles",
         "season:winter": "Root cellars stand stacked with preserved stores while fields lie fallow",
         default: () => {
-          const good = fragments.sampleGood || 'produce ready for the day's dispatch';
+          const good = fragments.sampleGood || "produce ready for the day's dispatch";
           return `Stacked crates of ${good} wait beside the packing shed`;
         },
       },


### PR DESCRIPTION
## Summary
- replace the farm overview fallback string with double quotes so the apostrophe in "day's" no longer breaks parsing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d36b4ad04883258350507827ffdf1c