### PR TITLE
Fix environment interaction string quoting

### DIFF
--- a/data/game/environment_interactions.js
+++ b/data/game/environment_interactions.js
@@ -667,7 +667,7 @@ const ENVIRONMENT_NODES = [
           {
             weight: 1,
             scene: 'A rip current tugs unexpectedly at your legs.',
-            outcome: 'You fight free, losing a little time but gaining respect for the sea's pull.',
+            outcome: "You fight free, losing a little time but gaining respect for the sea's pull.",
             extraTimeHours: 0.2,
           },
         ],


### PR DESCRIPTION
## Summary
- replace an improperly quoted Tidebreak Riverbank outcome string so the browser can parse environment_interactions.js again

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68deee66a564832599426c8f5752b1b8