### PR TITLE
Require fishing rods for fishing actions

### DIFF
--- a/data/game/environment_interactions.js
+++ b/data/game/environment_interactions.js
@@ -578,7 +578,7 @@ const ENVIRONMENT_NODES = [
         attributes: ['WIS', 'DEX'],
         tool: {
           kind: 'fishing',
-          message: 'You need a fishing rod, hand line, or net to work the surf effectively.',
+          message: 'You need a fishing rod or pole to work the surf effectively; without one you scour the shallows by hand.',
         },
         handGatherable: {
           chance: 0.35,
@@ -586,7 +586,7 @@ const ENVIRONMENT_NODES = [
           faunaRegions: ['coastal', 'aquatic'],
           taxonGroups: ['mollusk', 'other'],
           sizeClasses: ['tiny', 'small'],
-          narrative: 'You can still pry shellfish from tidepools with bare hands, though it is slow work.',
+          narrative: 'Lacking a rod, you wade the shallows to pry shellfish and tideline creatures loose by hand.',
         },
         seasonModifiers: { Winter: -0.05, Autumn: 0.05 },
         timeModifiers: { dawn: 0.1, dusk: 0.1, night: -0.15 },
@@ -883,7 +883,7 @@ const ENVIRONMENT_NODES = [
         attributes: ['WIS', 'DEX'],
         tool: {
           kind: 'fishing',
-          message: 'A rod, hand line, or net is needed to fish the river properly.',
+          message: 'Bring a fishing rod or pole if you want to cast here; otherwise you settle for working the shallows by hand.',
         },
         handGatherable: {
           chance: 0.4,
@@ -891,7 +891,7 @@ const ENVIRONMENT_NODES = [
           faunaRegions: ['aquatic'],
           taxonGroups: ['mollusk', 'other'],
           sizeClasses: ['tiny', 'small'],
-          narrative: 'Bare hands can still pry mussels and crayfish from the slick banks.',
+          narrative: 'Without a rod you comb the shallows, coaxing mussels and crayfish from the slick banks by hand.',
         },
         seasonModifiers: { Winter: -0.1, Autumn: 0.05 },
         timeModifiers: { dawn: 0.08, dusk: 0.08, night: -0.2 },
@@ -981,7 +981,7 @@ const ENVIRONMENT_NODES = [
         attributes: ['WIS', 'DEX'],
         tool: {
           kind: 'fishing',
-          message: 'A light rod, snare line, or net is needed to fish the creek efficiently.',
+          message: 'A fishing rod or pole is required to set lines here; otherwise you resort to hand gathering in the shallows.',
         },
         handGatherable: {
           chance: 0.45,
@@ -989,7 +989,7 @@ const ENVIRONMENT_NODES = [
           faunaRegions: ['aquatic'],
           taxonGroups: ['mollusk', 'other'],
           sizeClasses: ['tiny', 'small'],
-          narrative: 'You can scoop crayfish and freshwater mussels by hand from shaded pools.',
+          narrative: 'Lacking a rod you kneel in the shallows, scooping crayfish and freshwater mussels by hand.',
         },
         seasonModifiers: { Winter: -0.12, Autumn: 0.04 },
         timeModifiers: { dawn: 0.06, dusk: 0.08, night: -0.18 },

--- a/script.js
+++ b/script.js
@@ -3295,7 +3295,6 @@ const ENVIRONMENT_TOOL_KEYWORDS = {
   fishing: [
     /fish/i,
     /net/i,
-    /rod/i,
     /line/i,
     /hook/i,
     /tackle/i,
@@ -3338,6 +3337,30 @@ const ENVIRONMENT_MELEE_WEAPONS = [
   /polearm/i,
 ];
 
+const FISHING_ROD_OR_POLE_PATTERNS = [/\brods?\b/i, /\bpoles?\b/i];
+const FISHING_ROD_CONTEXT_PATTERNS = [
+  /fish/i,
+  /angl/i,
+  /reel/i,
+  /cast/i,
+  /bait/i,
+  /hook/i,
+  /lure/i,
+  /fly/i,
+  /troll/i,
+  /surf/i,
+  /river/i,
+  /lake/i,
+  /ocean/i,
+  /sea/i,
+  /shore/i,
+  /tidal/i,
+  /shallows?/i,
+  /current/i,
+  /net/i,
+  /line/i,
+];
+
 const HUNT_DIFFICULTY_BY_SIZE = {
   tiny: 1,
   small: 2,
@@ -3367,11 +3390,26 @@ function gatherCharacterItemNames(character) {
   return names;
 }
 
+function hasFishingRodOrPole(names) {
+  return names.some(name => {
+    if (!name) return false;
+    const text = String(name);
+    if (!FISHING_ROD_OR_POLE_PATTERNS.some(pattern => pattern.test(text))) {
+      return false;
+    }
+    return FISHING_ROD_CONTEXT_PATTERNS.some(pattern => pattern.test(text));
+  });
+}
+
 function hasToolRequirement(requirement, character) {
   if (!requirement) return { ok: true, matched: false };
+  const names = gatherCharacterItemNames(character);
+  if (requirement.kind === 'fishing') {
+    const matchedRodOrPole = hasFishingRodOrPole(names);
+    return { ok: matchedRodOrPole, matched: matchedRodOrPole };
+  }
   const patterns = ENVIRONMENT_TOOL_KEYWORDS[requirement.kind] || [];
   if (!patterns.length) return { ok: true, matched: false };
-  const names = gatherCharacterItemNames(character);
   const matched = names.some(name => patterns.some(pattern => pattern.test(name)));
   return { ok: matched, matched };
 }


### PR DESCRIPTION
## Summary
- ensure fishing tool checks specifically look for rods or poles and fall back to hand gathering when absent
- refresh fishing action messaging to describe hand-gathering shallows when no rod or pole is present

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68def151b1488325bf1570a6207a45bd