### PR TITLE
Add stamina intensity system and top menu resource bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ The UI sanitizes partially specified saves and Codex entries through helpers suc
 
 `docs/economy_catalog.md` documents the CSV importer fields in depth, `docs/hex_grid.md` captures the hex coordinate workflow, and the `tests/` folder illustrates the invariants we expect across data sets. Browsing those files before large edits will save time chasing validation or test failures.
 
+### Stamina intensity system and menu indicators
+
+Outdoor actions now drain or replenish stamina according to intensity and recovery factors defined in `script.js`. Conventional recovery tapers off once a character has been awake for more than 24 hours unless aided by unconventional means, so plan long expeditions around magical support or crafted elixirs. The top navigation menu renders hanging HP, MP, stamina, and XP bars with hover tooltips that reflect these realtime changes, keeping vital statistics visible while exploring.
+
 ## Structure
 
 - `index.html` – entry point for the game UI

--- a/data/game/core.js
+++ b/data/game/core.js
@@ -94,6 +94,7 @@ export const characterTemplate = {
   mp: 0,
   maxStamina: 0,
   stamina: 0,
+  hoursAwake: 0,
   attackPower: 0,
   rangedPower: 0,
   spellPower: 0,

--- a/index.html
+++ b/index.html
@@ -54,6 +54,24 @@
       <span id="menu-weather-icon" class="time-icon weather-icon tooltip-anchor" role="img" aria-label="Weather">—</span>
     </div>
   </div>
+  <div class="top-menu-resource-bars" role="group" aria-label="Character resources" hidden>
+    <div class="top-resource-bar hp tooltip-anchor" data-resource="hp" role="progressbar" aria-label="Hit points" aria-valuemin="0" aria-valuenow="0" aria-valuemax="0" data-tooltip="">
+      <span class="top-resource-label">HP</span>
+      <div class="top-resource-track"><div class="top-resource-fill"></div></div>
+    </div>
+    <div class="top-resource-bar mp tooltip-anchor" data-resource="mp" role="progressbar" aria-label="Mana" aria-valuemin="0" aria-valuenow="0" aria-valuemax="0" data-tooltip="">
+      <span class="top-resource-label">MP</span>
+      <div class="top-resource-track"><div class="top-resource-fill"></div></div>
+    </div>
+    <div class="top-resource-bar stamina tooltip-anchor" data-resource="stamina" role="progressbar" aria-label="Stamina" aria-valuemin="0" aria-valuenow="0" aria-valuemax="0" data-tooltip="">
+      <span class="top-resource-label">ST</span>
+      <div class="top-resource-track"><div class="top-resource-fill"></div></div>
+    </div>
+    <div class="top-resource-bar xp tooltip-anchor" data-resource="xp" role="progressbar" aria-label="Experience" aria-valuemin="0" aria-valuenow="0" aria-valuemax="0" data-tooltip="">
+      <span class="top-resource-label">XP</span>
+      <div class="top-resource-track"><div class="top-resource-fill"></div></div>
+    </div>
+  </div>
   </nav>
 
 <div id="dropdownMenu">

--- a/style.css
+++ b/style.css
@@ -14,6 +14,8 @@
   --hp-color: #ff0000;
   --mp-color: #0000ff;
   --stamina-color: #00ff00;
+  --xp-color: #c07cff;
+  --top-menu-resource-drop: 2.5rem;
   --menu-button-size: 2.625rem;
   --menu-height: var(--menu-button-size);
   --settings-panel-gap: 0.0625rem;
@@ -69,10 +71,14 @@ main {
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 0 0 0 0.5rem;
+  padding: 0 var(--top-menu-padding-right) 0.5rem 0.5rem;
   height: var(--menu-button-size);
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   z-index: 300;
+}
+
+.top-menu.top-menu--resources-visible {
+  padding-bottom: var(--top-menu-resource-drop);
 }
 
   .top-menu button {
@@ -128,6 +134,103 @@ main {
   flex: 1 1 0;
   min-width: 0;
 }
+
+.top-menu-resource-bars {
+  position: absolute;
+  left: 50%;
+  bottom: calc(-1 * (var(--top-menu-resource-drop) - 0.65rem));
+  transform: translateX(-50%);
+  display: flex;
+  align-items: flex-start;
+  gap: 0.8rem;
+  padding: 0.55rem 0.9rem;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 1.75rem;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  backdrop-filter: blur(6px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 250;
+}
+
+.top-menu-resource-bars[hidden] {
+  opacity: 0;
+  transform: translate(-50%, 0.75rem);
+  pointer-events: none;
+}
+
+.top-resource-bar {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.98);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
+  color: var(--menu-color-dark);
+  min-width: 7.25rem;
+}
+
+.top-resource-bar::before {
+  content: "";
+  position: absolute;
+  top: -0.85rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0.22rem;
+  height: 0.7rem;
+  border-radius: 0.25rem;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.05));
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+.top-resource-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.top-resource-track {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 4.75rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.05));
+  overflow: hidden;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.16);
+}
+
+.top-resource-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 0%;
+  border-radius: inherit;
+  background: var(--menu-color-dark);
+  transition: width 0.35s ease;
+}
+
+.top-resource-bar.hp .top-resource-fill {
+  background: linear-gradient(90deg, rgba(255, 120, 120, 0.95), var(--hp-color));
+}
+
+.top-resource-bar.mp .top-resource-fill {
+  background: linear-gradient(90deg, rgba(140, 160, 255, 0.95), var(--mp-color));
+}
+
+.top-resource-bar.stamina .top-resource-fill {
+  background: linear-gradient(90deg, rgba(140, 255, 170, 0.9), var(--stamina-color));
+}
+
+.top-resource-bar.xp .top-resource-fill {
+  background: linear-gradient(90deg, rgba(215, 180, 255, 0.9), var(--xp-color));
+}
+
 
 .top-menu-center {
   display: flex;
@@ -298,6 +401,58 @@ body.theme-dark .time-display .time-icon {
 body.theme-dark .top-menu-center,
 body.theme-dark .time-display {
   color: var(--menu-color-light);
+}
+
+body.theme-dark .top-menu-resource-bars {
+  background: rgba(28, 32, 44, 0.92);
+  border-color: rgba(240, 244, 255, 0.12);
+  box-shadow: 0 14px 28px rgba(6, 10, 20, 0.45);
+}
+
+body.theme-dark .top-resource-bar {
+  background: rgba(40, 46, 62, 0.96);
+  border-color: rgba(240, 244, 255, 0.14);
+  box-shadow: 0 10px 20px rgba(6, 10, 22, 0.4);
+  color: var(--menu-color-light);
+}
+
+body.theme-dark .top-resource-bar::before {
+  background: linear-gradient(to bottom, rgba(200, 210, 240, 0.45), rgba(120, 140, 180, 0.2));
+  box-shadow: 0 2px 5px rgba(4, 6, 14, 0.45);
+}
+
+body.theme-dark .top-resource-track {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.04));
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35);
+}
+
+body.theme-dark .top-resource-label {
+  color: var(--menu-color-light);
+}
+
+body.theme-sepia .top-menu-resource-bars {
+  background: rgba(255, 245, 230, 0.94);
+  border-color: rgba(140, 110, 70, 0.2);
+  box-shadow: 0 12px 24px rgba(120, 90, 60, 0.28);
+}
+
+body.theme-sepia .top-resource-bar {
+  background: rgba(255, 250, 240, 0.96);
+  border-color: rgba(140, 110, 70, 0.22);
+  color: #5a4028;
+}
+
+body.theme-sepia .top-resource-bar::before {
+  background: linear-gradient(to bottom, rgba(140, 110, 70, 0.32), rgba(140, 110, 70, 0.08));
+}
+
+body.theme-sepia .top-resource-track {
+  background: linear-gradient(180deg, rgba(140, 110, 70, 0.18), rgba(140, 110, 70, 0.08));
+  box-shadow: inset 0 1px 2px rgba(120, 90, 60, 0.25);
+}
+
+body.theme-sepia .top-resource-label {
+  color: #5a4028;
 }
 
 .top-menu button:hover,
@@ -1223,9 +1378,25 @@ body.theme-dark .info-icon {
 .location-log-entry .environment-context,
 .location-log-entry .environment-roll,
 .location-log-entry .environment-skill,
+.location-log-entry .environment-stamina,
 .location-log-entry .location-log-meta {
   font-size: 0.9em;
   opacity: 0.85;
+}
+
+.location-log-entry .environment-stamina {
+  font-weight: 600;
+  color: #2f6f3f;
+  display: flex;
+  align-items: center;
+}
+
+body.theme-dark .location-log-entry .environment-stamina {
+  color: #7fdf9a;
+}
+
+body.theme-sepia .location-log-entry .environment-stamina {
+  color: #3a6a3a;
 }
 
 .location-log-entry .environment-requirement {


### PR DESCRIPTION
## Summary
- implement stamina intensity/recovery profiles for environment actions with diminishing conventional recovery after 24 hours awake
- add rest handling, hours-awake tracking, and stamina tooltips in the environment log
- surface hanging HP/MP/Stamina/XP bars in the top menu and hide redundant labels beneath bespoke action icons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68def94637f88325a614e393957bfdf3