### PR TITLE
Align top menu resource bar connectors

### DIFF
--- a/style.css
+++ b/style.css
@@ -211,19 +211,6 @@ main {
   min-width: 7.25rem;
 }
 
-.top-resource-bar::before {
-  content: "";
-  position: absolute;
-  top: -0.85rem;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 0.22rem;
-  height: 0.7rem;
-  border-radius: 0.25rem;
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.05));
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
-}
-
 .top-resource-label {
   font-size: 0.72rem;
   font-weight: 700;
@@ -238,8 +225,21 @@ main {
   height: 0.55rem;
   border-radius: 999px;
   background: linear-gradient(180deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.05));
-  overflow: hidden;
+  overflow: visible;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.16);
+}
+
+.top-resource-track::before {
+  content: "";
+  position: absolute;
+  bottom: calc(100% + 0.15rem);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0.22rem;
+  height: 0.7rem;
+  border-radius: 0.25rem;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.05));
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
 .top-resource-fill {
@@ -453,7 +453,7 @@ body.theme-dark .top-resource-bar {
   color: var(--menu-color-light);
 }
 
-body.theme-dark .top-resource-bar::before {
+body.theme-dark .top-resource-track::before {
   background: linear-gradient(to bottom, rgba(200, 210, 240, 0.45), rgba(120, 140, 180, 0.2));
   box-shadow: 0 2px 5px rgba(4, 6, 14, 0.45);
 }
@@ -471,7 +471,7 @@ body.theme-sepia .top-resource-bar {
   color: #5a4028;
 }
 
-body.theme-sepia .top-resource-bar::before {
+body.theme-sepia .top-resource-track::before {
   background: linear-gradient(to bottom, rgba(140, 110, 70, 0.32), rgba(140, 110, 70, 0.08));
 }
 


### PR DESCRIPTION
## Summary
- move the resource connector pseudo-element onto the progress track so each divider centers over its bar
- adjust offsets and theme overrides to keep the connectors aligned in dark and sepia themes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df117ed7108325bce33b10bd95ad52