### PR TITLE
Make character status chip open character menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,6 @@
       <button id="back-button" aria-label="Back" style="display:none;">
         <img src="assets/images/icons/Back Arrow.png" alt="Back">
       </button>
-      <button id="character-button" aria-label="Character" style="display:none;">
-        <img id="character-icon" src="assets/images/icons/Character Menu Male.png" alt="Character">
-      </button>
       <div class="settings-group">
         <button id="settings-button" aria-label="Settings">
           <img src="assets/images/icons/Settings.png" alt="Settings">
@@ -52,10 +49,13 @@
     </div>
   </div>
   <div class="top-menu-status" aria-live="polite">
-    <div class="top-menu-character">
-      <span id="menu-character-name" class="top-menu-item" aria-label="Active character" title="Active character">—</span>
+    <button id="character-button" class="top-menu-character" aria-label="Open character menu" title="Open character menu" style="display:none;">
+      <span class="top-menu-character-header">
+        <img id="character-icon" src="assets/images/icons/Character Menu Male.png" alt="" aria-hidden="true">
+        <span id="menu-character-name" class="top-menu-item" aria-label="Active character" title="Active character">—</span>
+      </span>
       <span id="menu-money" class="top-menu-item currency" aria-label="Available funds" title="Available funds">—</span>
-    </div>
+    </button>
     <div class="top-menu-resource-bars" role="group" aria-label="Character resources" hidden>
       <div class="top-resource-bar hp tooltip-anchor" data-resource="hp" role="progressbar" aria-label="Hit points" aria-valuemin="0" aria-valuenow="0" aria-valuemax="0" data-tooltip="">
         <span class="top-resource-label">HP</span>

--- a/style.css
+++ b/style.css
@@ -96,7 +96,7 @@ main {
   padding-bottom: 0;
 }
 
-  .top-menu button {
+  .top-menu-actions button {
     width: var(--menu-button-size);
     height: var(--menu-button-size);
     padding: calc(var(--menu-button-size) * 0.12);
@@ -121,16 +121,16 @@ main {
     cursor: pointer;
   }
 
-  .top-menu button svg,
-  .top-menu button img {
+  .top-menu-actions button svg,
+  .top-menu-actions button img {
     width: 100%;
     height: 100%;
     display: block;
   }
-  .top-menu button img {
+  .top-menu-actions button img {
     object-fit: contain;
   }
-  .top-menu button svg {
+  .top-menu-actions button svg {
     stroke: currentColor;
     stroke-width: 2;
     fill: none;
@@ -276,16 +276,16 @@ main {
 
 
 .top-menu-character {
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: stretch;
   justify-content: center;
-  gap: 0.2rem;
+  gap: 0.25rem;
   font-size: calc(var(--menu-button-size) * 0.32);
   line-height: 1.1;
   font-weight: 600;
   color: var(--menu-color-dark);
-  text-align: right;
+  text-align: left;
   min-width: 0;
   padding: 0.35rem 0.9rem;
   border-radius: 999px;
@@ -294,24 +294,44 @@ main {
   box-shadow: var(--surface-chip-shadow);
   backdrop-filter: blur(calc(var(--surface-glass-blur) * 0.65));
   -webkit-backdrop-filter: blur(calc(var(--surface-glass-blur) * 0.65));
+  cursor: pointer;
+  appearance: none;
+  border-width: 1px;
+}
+
+.top-menu-character:focus-visible {
+  outline: 3px solid var(--accent-color, rgba(80, 120, 200, 0.65));
+  outline-offset: 3px;
+}
+
+.top-menu-character-header {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.5rem;
+}
+
+.top-menu-character-header img {
+  height: calc(var(--menu-button-size) * 0.4);
+  width: auto;
 }
 
 .top-menu-character .top-menu-item {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 0.35rem;
   max-width: 100%;
   flex-wrap: wrap;
   white-space: normal;
-  text-align: right;
+  text-align: left;
   overflow-wrap: anywhere;
 }
 
 .top-menu-character .currency {
   display: inline-flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 0.35rem;
   flex-wrap: wrap;
   max-width: 100%;
@@ -490,14 +510,14 @@ body.theme-sepia .top-resource-label {
   color: #5a4028;
 }
 
-.top-menu button:hover,
-.top-menu button:focus-visible {
+.top-menu-actions button:hover,
+.top-menu-actions button:focus-visible {
   transform: translateY(-0.08rem);
   box-shadow: var(--surface-chip-hover-shadow);
   filter: none !important;
 }
 
-.top-menu button:active {
+.top-menu-actions button:active {
   transform: translateY(0);
   box-shadow: var(--surface-chip-shadow);
   filter: none !important;
@@ -862,7 +882,7 @@ body.theme-dark {
 }
 
 /* Ensure menu icons blend with the background in dark mode */
-body.theme-dark .top-menu button {
+body.theme-dark .top-menu-actions button {
   color: var(--menu-color-light);
   -webkit-text-stroke: 0;
 }


### PR DESCRIPTION
## Summary
- replace the standalone character button with a combined character status chip that opens the character menu
- adjust styling so the chip displays the character icon beside the name while maintaining menu button styling for other controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68df4c850ad883259e13b754267d3b17