### PR TITLE
Integrate controls into time display

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,41 +17,40 @@
         <span class="time-clock">—</span>
       </div>
       <span class="time-label sr-only">—</span>
-      <div class="time-icons">
+      <div class="time-icons" role="group" aria-label="Time, season, weather, and controls">
         <span id="menu-time-icon" class="time-icon time-of-day-icon tooltip-anchor" role="img" aria-label="Time of day">—</span>
         <span id="menu-season-icon" class="time-icon season-icon tooltip-anchor" role="img" aria-label="Season">—</span>
         <span id="menu-weather-icon" class="time-icon weather-icon tooltip-anchor" role="img" aria-label="Weather">—</span>
+        <button id="menu-button" class="time-icon time-action-button" aria-label="Menu" title="Menu">
+          <img src="assets/images/icons/Menu.png" alt="">
+        </button>
+        <div class="time-action settings-action">
+          <button id="settings-button" class="time-icon time-action-button" aria-label="Settings" title="Settings">
+            <img src="assets/images/icons/Settings.png" alt="">
+          </button>
+          <div id="settings-panel" class="time-settings-panel">
+            <button id="theme-toggle" aria-label="Toggle theme">
+              <img src="assets/images/icons/Theme.png" alt="Theme">
+            </button>
+            <button id="scale-dec" aria-label="Decrease UI size">
+              <img src="assets/images/icons/Minus.png" alt="Decrease">
+            </button>
+            <button id="scale-inc" aria-label="Increase UI size">
+              <img src="assets/images/icons/Plus.png" alt="Increase">
+            </button>
+          </div>
+        </div>
       </div>
     </div>
     <div class="top-menu-actions">
-      <button id="menu-button" aria-label="Menu">
-        <img src="assets/images/icons/Menu.png" alt="Menu">
-      </button>
       <button id="back-button" aria-label="Back" style="display:none;">
         <img src="assets/images/icons/Back Arrow.png" alt="Back">
       </button>
-      <div class="settings-group">
-        <button id="settings-button" aria-label="Settings">
-          <img src="assets/images/icons/Settings.png" alt="Settings">
-        </button>
-        <div id="settings-panel">
-          <button id="theme-toggle" aria-label="Toggle theme">
-            <img src="assets/images/icons/Theme.png" alt="Theme">
-          </button>
-          <button id="scale-dec" aria-label="Decrease UI size">
-            <img src="assets/images/icons/Minus.png" alt="Decrease">
-          </button>
-          <button id="scale-inc" aria-label="Increase UI size">
-            <img src="assets/images/icons/Plus.png" alt="Increase">
-          </button>
-        </div>
-      </div>
     </div>
   </div>
   <div class="top-menu-status" aria-live="polite">
     <button id="character-button" class="top-menu-character" aria-label="Open character menu" title="Open character menu" style="display:none;">
       <span class="top-menu-character-header">
-        <img id="character-icon" src="assets/images/icons/Character Menu Male.png" alt="" aria-hidden="true">
         <span id="menu-character-name" class="top-menu-item" aria-label="Active character" title="Active character">—</span>
       </span>
       <span id="menu-money" class="top-menu-item currency" aria-label="Available funds" title="Available funds">—</span>

--- a/script.js
+++ b/script.js
@@ -12713,13 +12713,6 @@ function updateCharacterButton() {
     mapContainer.style.display = 'none';
     return;
   }
-  const iconFile = currentCharacter.sex === 'Male'
-    ? 'Character Menu Male.png'
-    : 'Character Menu Female.png';
-  const characterIcon = document.getElementById('character-icon');
-  if (characterIcon) {
-    characterIcon.src = `assets/images/icons/${iconFile}`;
-  }
   characterButton.style.display = 'inline-flex';
 }
 

--- a/style.css
+++ b/style.css
@@ -311,11 +311,6 @@ main {
   gap: 0.5rem;
 }
 
-.top-menu-character-header img {
-  height: calc(var(--menu-button-size) * 0.4);
-  width: auto;
-}
-
 .top-menu-character .top-menu-item {
   display: inline-flex;
   align-items: center;
@@ -349,16 +344,13 @@ main {
 }
 
 
+
 .time-display {
-  display: grid;
-  grid-auto-flow: column;
-  grid-template-columns:
-    minmax(0, auto)
-    repeat(3, minmax(0, var(--menu-button-size)));
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  justify-items: center;
-  column-gap: 0.35rem;
+  justify-content: space-between;
+  gap: 0.65rem;
+  flex-wrap: wrap;
   min-width: 0;
   flex: 1 1 32rem;
   min-width: min(100%, 28rem);
@@ -369,7 +361,7 @@ main {
   line-height: 1.1;
   font-weight: 600;
   color: var(--menu-color-dark);
-  text-align: center;
+  text-align: left;
   border-radius: 1.5rem;
   border: 1px solid var(--surface-chip-border);
   background: var(--surface-chip-bg);
@@ -384,8 +376,6 @@ main {
   justify-content: center;
   gap: 0.35rem;
   white-space: nowrap;
-  align-self: center;
-  justify-self: center;
 }
 
 .time-display .time-meta-separator {
@@ -393,11 +383,16 @@ main {
 }
 
 .time-display .time-icons {
-  display: contents;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  row-gap: 0.35rem;
+  flex-wrap: wrap;
 }
 
 .time-display .time-icon {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   line-height: 1;
@@ -414,12 +409,32 @@ main {
   max-height: 100%;
   aspect-ratio: 1 / 1;
   font-size: clamp(1.1rem, calc(var(--menu-button-size) * 0.5), 2.35rem);
-  align-self: center;
-  justify-self: stretch;
 }
 
 .time-display .time-icon.tooltip-anchor {
   cursor: default;
+}
+
+.time-display .time-action-button {
+  cursor: pointer;
+  border: none;
+  color: inherit;
+}
+
+.time-display .time-action-button img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
+}
+
+.time-display .time-action {
+  position: relative;
+  display: inline-flex;
+}
+
+.time-display .settings-action {
+  align-items: center;
 }
 
 body.theme-dark .time-display .time-icon {
@@ -523,13 +538,6 @@ body.theme-sepia .top-resource-label {
   filter: none !important;
 }
 
-.settings-group {
-  display: flex;
-  gap: var(--settings-panel-gap);
-  position: relative;
-  align-items: center;
-}
-
 @media (orientation: portrait) {
   :root {
     --menu-height: var(--menu-button-size);
@@ -554,6 +562,10 @@ body.theme-sepia .top-resource-label {
   .time-display {
     width: 100%;
     max-width: none;
+  }
+
+  .time-display .time-icons {
+    justify-content: center;
   }
 
   .top-menu-actions {


### PR DESCRIPTION
## Summary
- move the menu and settings controls into the time bar so they share the same visual style as the status icons
- keep the back button separate while preserving the settings flyout for theme and scale options
- simplify the character status chip by removing the redundant character portrait icon

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe416da4c83259bea12ef2cc35a3f