### PR TITLE
Refine top menu layout and settings controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,12 +10,19 @@
   <div id="app">
 <nav class="top-menu">
   <div class="top-menu-main">
-    <div id="menu-time" class="time-display" aria-label="Current time" title="Current time">
-      <div class="time-meta">
-        <span id="menu-date" class="time-date" aria-label="Current date" title="Current date">—</span>
-        <span class="time-meta-separator" aria-hidden="true">·</span>
-        <span class="time-clock">—</span>
-      </div>
+    <div class="top-menu-primary">
+      <button id="character-button" class="top-menu-character" aria-label="Open character menu" title="Open character menu" aria-live="polite" style="display:none;">
+        <span class="top-menu-character-header">
+          <span id="menu-character-name" class="top-menu-item" aria-label="Active character" title="Active character">—</span>
+        </span>
+        <span id="menu-money" class="top-menu-item currency" aria-label="Available funds" title="Available funds">—</span>
+      </button>
+      <div id="menu-time" class="time-display" aria-label="Current time" title="Current time">
+        <div class="time-meta">
+          <span id="menu-date" class="time-date" aria-label="Current date" title="Current date">—</span>
+          <span class="time-meta-separator" aria-hidden="true">·</span>
+          <span class="time-clock">—</span>
+        </div>
       <span class="time-label sr-only">—</span>
       <div class="time-icons" role="group" aria-label="Time, season, weather, and controls">
         <span id="menu-time-icon" class="time-icon time-of-day-icon tooltip-anchor" role="img" aria-label="Time of day">—</span>
@@ -42,20 +49,15 @@
         </div>
       </div>
     </div>
+    </div>
     <div class="top-menu-actions">
       <button id="back-button" aria-label="Back" style="display:none;">
         <img src="assets/images/icons/Back Arrow.png" alt="Back">
       </button>
     </div>
   </div>
-  <div class="top-menu-status" aria-live="polite">
-    <button id="character-button" class="top-menu-character" aria-label="Open character menu" title="Open character menu" style="display:none;">
-      <span class="top-menu-character-header">
-        <span id="menu-character-name" class="top-menu-item" aria-label="Active character" title="Active character">—</span>
-      </span>
-      <span id="menu-money" class="top-menu-item currency" aria-label="Available funds" title="Available funds">—</span>
-    </button>
-    <div class="top-menu-resource-bars" role="group" aria-label="Character resources" hidden>
+  <div class="top-menu-status">
+    <div class="top-menu-resource-bars" role="group" aria-label="Character resources" aria-live="polite" hidden>
       <div class="top-resource-bar hp tooltip-anchor" data-resource="hp" role="progressbar" aria-label="Hit points" aria-valuemin="0" aria-valuenow="0" aria-valuemax="0" data-tooltip="">
         <span class="top-resource-label">HP</span>
         <div class="top-resource-track"><div class="top-resource-fill"></div></div>

--- a/style.css
+++ b/style.css
@@ -22,6 +22,8 @@
   --settings-panel-width: calc(3 * var(--menu-button-size) + 2 * var(--settings-panel-gap));
   --settings-panel-buffer: 0.5rem;
   --top-menu-padding-right: 0.75rem;
+  --time-icon-size: calc(var(--menu-button-size) * 0.7);
+  --time-icon-padding: calc(var(--time-icon-size) * 0.12);
   --surface-glass-bg: rgba(255, 255, 255, 0.92);
   --surface-glass-border: rgba(0, 0, 0, 0.08);
   --surface-glass-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
@@ -153,10 +155,27 @@ main {
 
 .top-menu-main {
   display: flex;
-  align-items: center;
-  justify-content: center;
+  align-items: stretch;
+  justify-content: space-between;
   gap: 1rem;
   flex-wrap: wrap;
+}
+
+.top-menu-primary {
+  display: flex;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: 0.75rem;
+  flex: 1 1 32rem;
+  min-width: 0;
+}
+
+.top-menu-primary .top-menu-character {
+  flex: 0 0 auto;
+}
+
+.top-menu-primary .time-display {
+  flex: 1 1 auto;
 }
 
 .top-menu-actions {
@@ -352,8 +371,8 @@ main {
   gap: 0.65rem;
   flex-wrap: wrap;
   min-width: 0;
-  flex: 1 1 32rem;
-  min-width: min(100%, 28rem);
+  flex: 1 1 28rem;
+  min-width: min(100%, 22rem);
   max-width: min(100%, 42rem);
   margin: 0;
   padding: 0.3rem calc(var(--top-menu-padding-right) + 0.25rem) 0.3rem 0.65rem;
@@ -386,8 +405,8 @@ main {
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 0.35rem;
-  row-gap: 0.35rem;
+  gap: clamp(0.2rem, calc(var(--menu-button-size) * 0.18), 0.45rem);
+  row-gap: clamp(0.2rem, calc(var(--menu-button-size) * 0.18), 0.45rem);
   flex-wrap: wrap;
 }
 
@@ -397,18 +416,18 @@ main {
   justify-content: center;
   line-height: 1;
   text-align: center;
-  border-radius: 0.55rem;
-  padding: 0.25rem;
+  border-radius: 0.5rem;
+  padding: var(--time-icon-padding);
   color: var(--menu-color-dark);
-  background: rgba(255, 255, 255, 0.65);
-  box-shadow: inset 0 0 0 1px rgba(51, 51, 51, 0.15);
+  background: none;
+  box-shadow: none;
   box-sizing: border-box;
-  width: calc(var(--menu-button-size) - 0.6rem);
+  width: var(--time-icon-size);
   max-width: 100%;
-  height: calc(var(--menu-button-size) - 0.6rem);
+  height: var(--time-icon-size);
   max-height: 100%;
   aspect-ratio: 1 / 1;
-  font-size: clamp(1.1rem, calc(var(--menu-button-size) * 0.5), 2.35rem);
+  font-size: clamp(1rem, calc(var(--menu-button-size) * 0.45), 2rem);
 }
 
 .time-display .time-icon.tooltip-anchor {
@@ -419,6 +438,13 @@ main {
   cursor: pointer;
   border: none;
   color: inherit;
+  background: none;
+  padding: var(--time-icon-padding);
+  width: var(--time-icon-size);
+  height: var(--time-icon-size);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .time-display .time-action-button img {
@@ -426,6 +452,11 @@ main {
   height: 100%;
   display: block;
   object-fit: contain;
+}
+
+.time-display .time-action-button:focus-visible {
+  outline: 2px solid var(--menu-color-dark);
+  outline-offset: 2px;
 }
 
 .time-display .time-action {
@@ -438,8 +469,6 @@ main {
 }
 
 body.theme-dark .time-display .time-icon {
-  background: rgba(20, 28, 48, 0.7);
-  box-shadow: inset 0 0 0 1px rgba(220, 230, 255, 0.22);
   color: var(--menu-color-light);
 }
 
@@ -610,11 +639,45 @@ body.theme-sepia .top-resource-label {
   box-shadow: var(--surface-chip-shadow);
   backdrop-filter: blur(calc(var(--surface-glass-blur) * 0.65));
   -webkit-backdrop-filter: blur(calc(var(--surface-glass-blur) * 0.65));
+  width: var(--settings-panel-width);
+  max-width: var(--settings-panel-width);
+  box-sizing: border-box;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 
 #settings-panel.active {
   pointer-events: auto;
   transform: scaleX(1);
+}
+
+#settings-panel button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(var(--menu-button-size) - 0.6rem);
+  height: calc(var(--menu-button-size) - 0.6rem);
+  padding: calc(var(--menu-button-size) * 0.12);
+  border-radius: calc(var(--menu-button-size) * 0.35);
+  border: 1px solid var(--surface-chip-border);
+  background: var(--surface-chip-bg);
+  box-shadow: var(--surface-chip-shadow);
+  color: var(--menu-color-dark);
+  cursor: pointer;
+}
+
+#settings-panel button img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+body.theme-dark #settings-panel button {
+  background: rgba(20, 28, 48, 0.85);
+  border-color: rgba(220, 230, 255, 0.22);
+  color: var(--menu-color-light);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
 }
 
 #dropdownMenu {


### PR DESCRIPTION
## Summary
- reposition the character menu button beside the time display and align the layout with the resource bar width
- restyle the time bar icons to render without bulky button chrome and keep icon sizes consistent
- constrain the slide-out settings panel buttons so the drawer opens at the intended compact width

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dff50eacf08325a3e51a10d5a65693