### PR TITLE
Adjust top menu spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -22,7 +22,7 @@
   --settings-panel-gap: 0.0625rem;
   --settings-panel-width: calc(3 * var(--menu-button-size) + 2 * var(--settings-panel-gap));
   --settings-panel-buffer: 0.5rem;
-  --top-menu-padding-right: 0.75rem;
+  --top-menu-padding-right: 0.25rem;
   --time-icon-size: calc(var(--menu-button-size) * 0.7);
   --time-icon-padding: calc(var(--time-icon-size) * 0.12);
   --surface-glass-bg: rgba(255, 255, 255, 0.92);
@@ -203,7 +203,7 @@ main {
   align-items: center;
   justify-content: center;
   gap: 0.8rem;
-  padding: 0.55rem 0.9rem;
+  padding: 0.55rem 0.65rem;
   background: var(--surface-glass-bg);
   border-radius: 1.5rem;
   box-shadow: var(--surface-glass-shadow);
@@ -311,7 +311,7 @@ main {
   color: var(--menu-color-dark);
   text-align: left;
   min-width: 0;
-  padding: 0.35rem 0.9rem;
+  padding: 0.35rem 1.35rem;
   border-radius: 1.5rem 0 0 1.5rem;
   border: 1px solid var(--surface-chip-border);
   border-right: 0;
@@ -398,7 +398,7 @@ body.theme-dark .top-menu-character::after {
   min-width: min(100%, 22rem);
   max-width: min(100%, 42rem);
   margin: 0;
-  padding: 0.35rem calc(var(--top-menu-padding-right) + 0.25rem) 0.35rem 0.65rem;
+  padding: 0.35rem calc(var(--top-menu-padding-right) + 0.25rem) 0.35rem 0.55rem;
   font-size: calc(var(--menu-button-size) * 0.32);
   line-height: 1.1;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- reduce the top menu time display padding so the top and resource bars share the same width
- tighten the resource bar padding to match the updated top bar proportions
- widen the character button by 50% while keeping the overall menu scale unchanged

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00065e5948325aa0c171b9a1ad89c