### PR TITLE
Simplify top menu layout and relocate XP bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,10 +24,6 @@
           <span class="time-clock">—</span>
         </div>
       <span class="time-label sr-only">—</span>
-        <div class="time-xp-bar top-resource-bar xp tooltip-anchor" data-resource="xp" role="progressbar" aria-label="Experience" aria-valuemin="0" aria-valuenow="0" aria-valuemax="0" data-tooltip="" hidden>
-          <span class="top-resource-label">XP</span>
-          <div class="top-resource-track"><div class="top-resource-fill"></div></div>
-        </div>
       </div>
       <div class="time-icons" role="group" aria-label="Time, season, weather, and controls">
         <span id="menu-time-icon" class="time-icon time-of-day-icon tooltip-anchor" role="img" aria-label="Time of day">—</span>
@@ -74,6 +70,12 @@
         <span class="top-resource-label">ST</span>
         <div class="top-resource-track"><div class="top-resource-fill"></div></div>
       </div>
+    </div>
+  </div>
+  <div class="top-menu-xp">
+    <div id="menu-xp-bar" class="top-resource-bar xp tooltip-anchor" data-resource="xp" role="progressbar" aria-label="Experience" aria-valuemin="0" aria-valuenow="0" aria-valuemax="0" data-tooltip="" hidden>
+      <span class="top-resource-label">XP</span>
+      <div class="top-resource-track"><div class="top-resource-fill"></div></div>
     </div>
   </div>
   </nav>

--- a/script.js
+++ b/script.js
@@ -1069,7 +1069,7 @@ const menuTimeIcon = document.getElementById('menu-time-icon');
 const menuSeasonIcon = document.getElementById('menu-season-icon');
 const menuWeatherIcon = document.getElementById('menu-weather-icon');
 const menuResourceBarContainer = document.querySelector('.top-menu-resource-bars');
-const menuXpBar = menuTimeDisplay ? menuTimeDisplay.querySelector('[data-resource="xp"]') : null;
+const menuXpBar = document.getElementById('menu-xp-bar');
 const menuResourceBars = {
   hp: menuResourceBarContainer
     ? menuResourceBarContainer.querySelector('[data-resource="hp"]')
@@ -1702,17 +1702,11 @@ function updateTopMenuIndicators() {
         menuResourceBars.xp.setAttribute('aria-valuetext', xpTooltip);
         menuResourceBars.xp.removeAttribute('hidden');
       }
-      if (menuTimeDisplay) {
-        menuTimeDisplay.classList.add('time-display--xp-visible');
-      }
     } else {
       if (topMenu) topMenu.classList.remove('top-menu--resources-visible');
       menuResourceBarContainer.setAttribute('hidden', '');
       if (menuResourceBars.xp) {
         menuResourceBars.xp.setAttribute('hidden', '');
-      }
-      if (menuTimeDisplay) {
-        menuTimeDisplay.classList.remove('time-display--xp-visible');
       }
     }
   }

--- a/style.css
+++ b/style.css
@@ -92,14 +92,11 @@ main {
   width: 100%;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  align-items: stretch;
+  gap: 0.35rem;
+  padding: 0.5rem 1rem 0.35rem;
   min-height: var(--menu-button-size);
   z-index: 300;
-}
-
-.top-menu {
   background: none;
   border-bottom: 0;
   box-shadow: none;
@@ -175,23 +172,20 @@ main {
 
 .top-menu-primary {
   display: flex;
-  align-items: stretch;
+  align-items: center;
   justify-content: flex-start;
   column-gap: 0.75rem;
-  row-gap: 0.75rem;
+  row-gap: 0.5rem;
   flex: 1 1 min(100%, var(--top-menu-content-width));
   width: min(100%, var(--top-menu-content-width));
   margin: 0 auto;
-  padding: 0.65rem 0.85rem;
-  border-radius: 1.75rem;
-  background: linear-gradient(155deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.58));
-  border: 1px solid rgba(255, 255, 255, 0.65);
-  box-shadow:
-    0 18px 32px rgba(15, 23, 42, 0.18),
-    inset 0 1px 0 rgba(255, 255, 255, 0.7),
-    inset 0 -1px 0 rgba(15, 23, 42, 0.08);
-  backdrop-filter: blur(calc(var(--surface-glass-blur) * 0.95));
-  -webkit-backdrop-filter: blur(calc(var(--surface-glass-blur) * 0.95));
+  padding: 0;
+  border-radius: 0;
+  background: none;
+  border: 0;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
   box-sizing: border-box;
   min-width: 0;
 }
@@ -223,6 +217,34 @@ main {
   justify-content: center;
   gap: 1.25rem;
   flex-wrap: wrap;
+}
+
+.top-menu-xp {
+  align-self: stretch;
+  padding: 0 1rem 0.35rem;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+}
+
+.top-menu-xp > .top-resource-bar {
+  width: min(100%, var(--top-menu-content-width));
+  margin: 0;
+  gap: 0.4rem;
+}
+
+.top-menu-xp .top-resource-track {
+  height: 0.35rem;
+  background: rgba(0, 0, 0, 0.15);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.18);
+}
+
+.top-menu-xp .top-resource-label {
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  opacity: 0.85;
+  justify-self: start;
+  text-align: left;
 }
 
 .top-menu-resource-bars {
@@ -324,26 +346,25 @@ main {
 .top-menu-character {
   display: inline-flex;
   flex-direction: column;
-  align-items: stretch;
+  align-items: flex-start;
   justify-content: center;
-  gap: 0.25rem;
+  gap: 0.15rem;
   font-size: calc(var(--menu-button-size) * 0.32);
   line-height: 1.1;
   font-weight: 600;
   color: var(--menu-color-dark);
   text-align: left;
   min-width: 0;
-  padding: 0.35rem 1.35rem;
-  padding-right: calc(1.35rem + var(--top-menu-character-extra-width));
-  border-radius: 1.5rem;
-  border: 1px solid var(--surface-chip-border);
-  background: var(--surface-chip-bg);
-  box-shadow: var(--surface-chip-shadow);
-  backdrop-filter: blur(calc(var(--surface-glass-blur) * 0.65));
-  -webkit-backdrop-filter: blur(calc(var(--surface-glass-blur) * 0.65));
+  padding: 0.25rem 0.75rem;
+  padding-right: calc(0.75rem + var(--top-menu-character-extra-width));
+  border-radius: 0;
+  border: 0;
+  background: none;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
   cursor: pointer;
   appearance: none;
-  border-width: 1px;
   position: relative;
   box-sizing: border-box;
 }
@@ -409,63 +430,26 @@ main {
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;
-  gap: 0.35rem;
+  gap: 0.25rem;
   flex: 1 1 28rem;
   min-width: min(100%, 22rem);
   width: 100%;
   max-width: 100%;
   margin: 0;
-  padding: 0.6rem 0.85rem 0.65rem 0.7rem;
+  padding: 0.35rem 0.5rem;
   font-size: calc(var(--menu-button-size) * 0.32 + 1px);
   line-height: 1.1;
   font-weight: 600;
   color: var(--menu-color-dark);
   text-align: left;
-  border-radius: 1.5rem;
-  border: 1px solid var(--surface-chip-border);
-  background: var(--surface-chip-bg);
-  box-shadow: var(--surface-chip-shadow);
-  backdrop-filter: blur(calc(var(--surface-glass-blur) * 0.65));
-  -webkit-backdrop-filter: blur(calc(var(--surface-glass-blur) * 0.65));
-  box-sizing: border-box;
-  overflow: visible;
-}
-
-.time-display.time-display--xp-visible {
-  padding-bottom: calc(0.65rem + 0.7rem);
-}
-
-.time-xp-bar {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  padding: 0.2rem 0.85rem 0 0.7rem;
-  box-sizing: border-box;
-  display: grid;
-  grid-template-columns: minmax(2.5rem, auto) 1fr;
-  align-items: center;
-  gap: 0.5rem;
-  border-radius: 0 0 1.5rem 1.5rem;
-  background: none;
+  border-radius: 0;
   border: 0;
+  background: none;
   box-shadow: none;
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
-  z-index: 1;
-}
-
-.time-xp-bar .top-resource-track {
-  height: 0.55rem;
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.16);
-}
-
-.time-xp-bar .top-resource-label {
-  font-size: 0.68rem;
-  letter-spacing: 0.12em;
-  opacity: 0.85;
-  justify-self: start;
-  text-align: left;
+  box-sizing: border-box;
+  overflow: visible;
 }
 
 .top-menu-primary > .time-icons {
@@ -476,17 +460,16 @@ main {
   row-gap: var(--time-icon-gap);
   flex-wrap: nowrap;
   margin-left: auto;
-  padding: 5px var(--time-icons-padding-inline-end) 5px
-    var(--time-icons-padding-inline);
+  padding: 0.25rem var(--time-icons-padding-inline-end) 0.25rem var(--time-icons-padding-inline);
   flex: 1 1 var(--time-icons-width);
   width: min(100%, var(--time-icons-width));
   min-width: min(100%, var(--time-icons-width));
-  border: 1px solid var(--surface-chip-border);
-  border-radius: 1.5rem;
-  background: var(--surface-chip-bg);
-  box-shadow: var(--surface-chip-shadow);
-  backdrop-filter: blur(calc(var(--surface-glass-blur) * 0.65));
-  -webkit-backdrop-filter: blur(calc(var(--surface-glass-blur) * 0.65));
+  border: 0;
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
   box-sizing: border-box;
   min-height: 100%;
 }
@@ -664,37 +647,14 @@ body.theme-dark .time-icons .time-icon {
 }
 
 body.theme-dark .top-menu-character,
-body.theme-dark .time-display {
+body.theme-dark .time-display,
+body.theme-dark .top-menu-primary > .time-icons {
   color: var(--menu-color-light);
 }
 
-body.theme-dark .top-menu-resource-bars {
-  color: var(--menu-color-light);
-}
-
+body.theme-dark .top-menu-resource-bars,
 body.theme-dark .top-resource-bar {
   color: var(--menu-color-light);
-}
-
-body.theme-dark .top-menu-primary {
-  background: linear-gradient(155deg, rgba(48, 60, 96, 0.82), rgba(18, 26, 52, 0.7));
-  border-color: rgba(120, 160, 220, 0.28);
-  box-shadow:
-    0 20px 36px rgba(3, 6, 18, 0.55),
-    inset 0 1px 0 rgba(180, 205, 255, 0.2),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.45);
-}
-
-body.theme-dark .time-display {
-  background: linear-gradient(160deg, rgba(44, 54, 88, 0.9), rgba(20, 28, 50, 0.82));
-  border-color: rgba(120, 160, 220, 0.32);
-  box-shadow: 0 12px 22px rgba(3, 6, 18, 0.45);
-}
-
-body.theme-dark .time-xp-bar {
-  background: linear-gradient(180deg, rgba(48, 60, 96, 0.85), rgba(18, 26, 52, 0.68));
-  border-top: 1px solid rgba(120, 160, 220, 0.32);
-  box-shadow: inset 0 1px 0 rgba(180, 205, 255, 0.25);
 }
 
 body.theme-dark .top-resource-track {
@@ -706,29 +666,17 @@ body.theme-dark .top-resource-label {
   color: var(--menu-color-light);
 }
 
+body.theme-dark .top-menu-xp .top-resource-track {
+  background: rgba(255, 255, 255, 0.25);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.35);
+}
+
+body.theme-dark .top-menu-xp .top-resource-label {
+  color: var(--menu-color-light);
+}
+
 body.theme-sepia .top-resource-bar {
   color: #5a4028;
-}
-
-body.theme-sepia .top-menu-primary {
-  background: linear-gradient(155deg, rgba(245, 220, 180, 0.88), rgba(210, 170, 120, 0.68));
-  border-color: rgba(150, 110, 70, 0.35);
-  box-shadow:
-    0 18px 32px rgba(90, 60, 28, 0.32),
-    inset 0 1px 0 rgba(255, 240, 220, 0.45),
-    inset 0 -1px 0 rgba(120, 80, 40, 0.25);
-}
-
-body.theme-sepia .time-display {
-  background: linear-gradient(160deg, rgba(245, 225, 190, 0.92), rgba(205, 165, 120, 0.78));
-  border-color: rgba(150, 110, 70, 0.38);
-  box-shadow: 0 12px 22px rgba(120, 80, 40, 0.25);
-}
-
-body.theme-sepia .time-xp-bar {
-  background: linear-gradient(180deg, rgba(245, 225, 190, 0.82), rgba(205, 165, 120, 0.55));
-  border-top: 1px solid rgba(150, 110, 70, 0.32);
-  box-shadow: inset 0 1px 0 rgba(255, 240, 220, 0.4);
 }
 
 body.theme-sepia .top-resource-track {
@@ -737,6 +685,15 @@ body.theme-sepia .top-resource-track {
 }
 
 body.theme-sepia .top-resource-label {
+  color: #5a4028;
+}
+
+body.theme-sepia .top-menu-xp .top-resource-track {
+  background: rgba(140, 110, 70, 0.28);
+  box-shadow: inset 0 1px 1px rgba(120, 90, 60, 0.32);
+}
+
+body.theme-sepia .top-menu-xp .top-resource-label {
   color: #5a4028;
 }
 


### PR DESCRIPTION
## Summary
- remove decorative borders from the top menu elements and tighten spacing for a cleaner, shorter header
- relocate the XP progress bar to a dedicated strip along the bottom edge of the top menu while keeping the other resource bars intact
- update XP bar styling and script bindings to reflect the new placement and dark/sepia theme variants

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0734349048325ba5742b664a78466