### PR TITLE
Adjust padding and alignment for top menu icons and character

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,7 +23,6 @@
   --settings-panel-width: calc(3 * var(--menu-button-size) + 2 * var(--settings-panel-gap));
   --settings-panel-buffer: 0.5rem;
   --top-menu-padding-right: 0.25rem;
-  --top-menu-character-extra-width: 25px;
   --time-icon-size: 30px;
   --time-icon-padding: calc(var(--time-icon-size) * 0.12);
   --time-icon-gap: 5px;
@@ -232,8 +231,9 @@ main {
 }
 
 .top-menu-primary .top-menu-character {
-  flex: 0 0 auto;
-  padding: 0.65rem 1.35rem 0.65rem 1.1rem;
+  flex: 0 0 190px;
+  width: 190px;
+  padding: 5px 10px;
   align-self: stretch;
 }
 
@@ -403,17 +403,17 @@ main {
 .top-menu-character {
   display: inline-flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: flex-end;
   justify-content: center;
   gap: 0.15rem;
   font-size: calc(var(--menu-button-size) * 0.32);
   line-height: 1.1;
   font-weight: 600;
   color: var(--menu-color-dark);
-  text-align: left;
+  text-align: right;
   min-width: 0;
-  padding: 0.65rem 1.35rem 0.65rem 1.1rem;
-  padding-right: calc(1.35rem + var(--top-menu-character-extra-width));
+  width: 190px;
+  padding: 5px 10px;
   border-radius: 0;
   border: 0;
   background: none;
@@ -435,7 +435,7 @@ main {
 .top-menu-character-header {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-end;
   gap: 0.5rem;
   width: 100%;
 }
@@ -443,18 +443,18 @@ main {
 .top-menu-character .top-menu-item {
   display: inline-flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: flex-end;
   gap: 0.35rem;
   max-width: 100%;
   flex-wrap: wrap;
   white-space: normal;
-  text-align: left;
+  text-align: right;
   overflow-wrap: anywhere;
 }
 
 .top-menu-character-header .top-menu-item {
-  justify-content: center;
-  text-align: center;
+  justify-content: flex-end;
+  text-align: right;
   width: 100%;
 }
 
@@ -518,7 +518,7 @@ main {
   row-gap: var(--time-icon-gap);
   flex-wrap: nowrap;
   margin-left: auto;
-  padding: 0.6rem 1.25rem 0.6rem 1.1rem;
+  padding: 5px 10px;
   flex: 0 0 auto;
   width: 190px;
   min-width: max-content;


### PR DESCRIPTION
## Summary
- update the time icon bar padding to 5px vertically and 10px horizontally while preserving the 190px width
- set the character panel to a fixed 190px width with right-aligned name and funds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e08c49a6e08325bae5f6f133619e3c