### PR TITLE
Adjust time icons padding

### DIFF
--- a/style.css
+++ b/style.css
@@ -591,9 +591,7 @@ main {
   .top-menu-main:has(.top-menu-actions button:not([hidden]):not([style*="display: none"]))
     .top-menu-primary
     > .time-icons {
-    padding-right: calc(
-      var(--top-menu-padding-right) + var(--time-icon-padding) + var(--settings-panel-width)
-    );
+    padding-right: var(--time-icons-padding-inline-end);
   }
 
   .top-menu-actions:not(:has(button:not([hidden]):not([style*="display: none"]))) {


### PR DESCRIPTION
## Summary
- reduce the right padding applied to the time icons container when the actions menu is present so it matches the standard spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0977714f08325aaf1592019ea8ec2