### PR TITLE
Adjust night time display width

### DIFF
--- a/style.css
+++ b/style.css
@@ -516,6 +516,12 @@ main {
   overflow: visible;
 }
 
+.time-display.time-band-night {
+  flex-basis: 21.875rem;
+  min-width: min(100%, 21.875rem);
+  max-width: 21.875rem;
+}
+
 .top-menu-primary > .time-icons {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- limit the time display component width when the night time band styling is active so it caps at 350px

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0a85f3e808325bac4a4c16347aa2d