### PR TITLE
Reduce top menu spacing and align resource bars

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,7 +16,7 @@
   --stamina-color: #00ff00;
   --xp-color: #c07cff;
   --top-menu-resource-drop: 2.5rem;
-  --top-menu-content-width: 56rem;
+  --top-menu-content-width: 48rem;
   --menu-button-size: 2.625rem;
   --menu-height: var(--menu-button-size);
   --settings-panel-gap: 0.0625rem;
@@ -309,7 +309,7 @@ main {
   align-items: stretch;
   justify-content: center;
   gap: 0.75rem;
-  padding: 0 0.85rem;
+  padding: 0;
   background: none;
   border-radius: 0;
   box-shadow: none;
@@ -529,10 +529,10 @@ main {
   gap: var(--time-icon-gap);
   row-gap: var(--time-icon-gap);
   flex-wrap: nowrap;
-  margin-left: auto;
+  margin-left: 0;
   padding: 5px 10px;
   flex: 0 0 auto;
-  width: 190px;
+  width: var(--time-icons-width);
   min-width: max-content;
   border: 0;
   border-radius: 0;


### PR DESCRIPTION
## Summary
- reduce the top menu content width to tighten the header layout
- remove the auto margin from the time icons and rely on the computed icon width
- align the resource bar container width with the updated menu width

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e0acbf18c4832595fe70e850be4565