### PR TITLE
Fix settings panel stacking order

### DIFF
--- a/style.css
+++ b/style.css
@@ -838,7 +838,7 @@ body.theme-sepia .time-display-xp .top-resource-label {
   position: absolute;
   pointer-events: none;
   transition: transform 0.25s ease, opacity 0.25s ease;
-  z-index: 350;
+  z-index: 450;
   flex-direction: row;
   top: calc(100% + var(--settings-panel-gap));
   right: 0;


### PR DESCRIPTION
## Summary
- raise the settings panel stacking context so it renders above the resource bars

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e29f7edf9c83258919104c01c3b3eb