### PR TITLE
Ensure Guild Gate Stewards quest uses environment interactions

### DIFF
--- a/script.js
+++ b/script.js
@@ -8659,7 +8659,11 @@ function generateBuildingEncounter(buildingName, context) {
   );
   const envActionsByType = new Map(envActions.map(action => [action.type, action]));
   const consumedEnvironmentActions = new Set();
-  if (!state.managerFound) {
+  const activeQuestTitle = (questInfo?.quest?.title || '').trim();
+  const showEnvironmentInteractions =
+    !state.managerFound || activeQuestTitle === 'Guild Gate Stewards';
+
+  if (showEnvironmentInteractions) {
     ['look', 'explore', 'search'].forEach(type => {
       const envAction = envActionsByType.get(type);
       if (!envAction) return;


### PR DESCRIPTION
## Summary
- prevent the Adventurers' Guildhall encounter from switching to the quest request action when the Guild Gate Stewards posting is active
- keep the standard look, explore, and search environment interactions available for that posting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2c987bd0c832598904ec8f8bf4151