### PR TITLE
Refine street vendor pricing layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -3364,12 +3364,19 @@ async function renderStreetVendorUI(city, district) {
     const saleQty = item.sale_quantity === 1 && item.unit === 'each'
       ? ''
       : `${item.sale_quantity} ${item.unit || ''}`.trim();
-    const priceLabel = `${cpToCoins(good.price, true, true)} (market ${cpToCoins(good.basePrice, true, true)})`;
+    const priceLabel = cpToCoins(good.price, true, true);
     const stockLabel = `Stock: ${good.quantity}`;
+    const metaParts = [];
+    if (saleQty) {
+      metaParts.push(`<span class="sale-qty">${saleQty}</span>`);
+    }
+    metaParts.push(`<span class="vendor-stock">${stockLabel}</span>`);
+    const metaHtml = metaParts.join('');
     html += `<li class="shop-item street-vendor-item">`
+      + `<div class="street-vendor-info">`
       + `<button class="item-name" data-i="${idx}">${escapeHtml(item.name)}</button>`
-      + `<span class="sale-qty">${saleQty}</span>`
-      + `<span class="vendor-stock">${stockLabel}</span>`
+      + `<div class="street-vendor-meta">${metaHtml}</div>`
+      + `</div>`
       + `<span class="item-price">${priceLabel}</span>`
       + `<input type="number" class="qty street-vendor-qty" value="1" min="1" max="${good.quantity}" data-i="${idx}">`
       + `<button class="buy-btn street-vendor-buy" data-i="${idx}">Buy</button>`

--- a/style.css
+++ b/style.css
@@ -3249,9 +3249,10 @@ body.theme-dark .quest-storyline-outcome-declined {
 }
 
 .street-vendor-icon {
-  width: clamp(2.75rem, 6vw, 3.5rem);
-  height: auto;
+  width: clamp(3rem, 8vw, 4rem);
+  height: clamp(3rem, 8vw, 4rem);
   display: block;
+  object-fit: contain;
 }
 
 .street-vendor-goods {
@@ -3267,21 +3268,40 @@ body.theme-dark .quest-storyline-outcome-declined {
   grid-template-columns:
     minmax(0, 1fr)
     max-content
-    max-content
-    max-content
     minmax(3.25rem, 4rem)
     minmax(3.25rem, 4rem);
-  gap: 0.35rem;
+  grid-auto-rows: auto;
+  align-items: center;
+  gap: 0.3rem;
+  row-gap: 0.2rem;
+}
+
+.street-vendor-info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+}
+
+.street-vendor-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9em;
 }
 
 .street-vendor-item .sale-qty,
-.street-vendor-item .vendor-stock,
-.street-vendor-item .item-price {
-  justify-self: end;
+.street-vendor-item .vendor-stock {
   white-space: nowrap;
 }
 
+.street-vendor-item .vendor-stock {
+  opacity: 0.85;
+}
+
 .street-vendor-item .item-price {
+  justify-self: end;
   display: flex;
   justify-content: flex-end;
 }
@@ -3289,10 +3309,6 @@ body.theme-dark .quest-storyline-outcome-declined {
 .street-vendor-item .qty,
 .street-vendor-item .buy-btn {
   width: 3.5rem;
-}
-
-.street-vendor-item .vendor-stock {
-  opacity: 0.85;
 }
 
 .shop-item .item-name {


### PR DESCRIPTION
## Summary
- remove the market value annotation from street vendor price labels and group supporting metadata beneath the item name
- adjust the street vendor item grid and metadata styling to prevent overlap while tightening spacing
- update the street vendor icon sizing to render consistently within the UI

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e791a1e08325a770c2559e9d7826