### PR TITLE
Revamp search interaction with quest-style minigame

### DIFF
--- a/style.css
+++ b/style.css
@@ -2664,6 +2664,129 @@ body.theme-dark .location-log-partial {
   margin-bottom: 0.5rem;
 }
 
+.search-minigame {
+  padding: 1.25rem 1rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.search-minigame-header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.search-minigame-context {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
+.search-minigame-intro {
+  margin: 0.5rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.search-minigame-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 40rem) {
+  .search-minigame-grid {
+    grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  }
+}
+
+.search-minigame-choice {
+  border: 1px solid var(--surface-chip-border);
+  background: var(--surface-chip-bg);
+  color: var(--foreground);
+  box-shadow: var(--surface-chip-shadow);
+  border-radius: 0.85rem;
+  padding: 0.95rem 1.1rem;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.search-minigame-choice:hover,
+.search-minigame-choice:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--surface-chip-hover-shadow);
+}
+
+.search-minigame-choice:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.6);
+  outline-offset: 2px;
+}
+
+.search-minigame-choice-title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.search-minigame-choice-text {
+  font-size: 0.9rem;
+  line-height: 1.4;
+  opacity: 0.85;
+}
+
+.search-minigame-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.search-minigame-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.08);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.search-minigame-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.search-minigame-actions button {
+  padding: 0.5rem 1.1rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--foreground);
+  background: transparent;
+  color: var(--foreground);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.search-minigame-actions button:hover,
+.search-minigame-actions button:focus-visible {
+  background: var(--foreground);
+  color: var(--background);
+}
+
+body.theme-dark .search-minigame-choice-text {
+  opacity: 0.8;
+}
+
+body.theme-dark .search-minigame-badge {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+body.theme-dark .search-minigame-actions button:hover,
+body.theme-dark .search-minigame-actions button:focus-visible {
+  background: var(--foreground);
+  color: var(--background);
+}
+
 .quest-item h3 {
   margin: 0 0 0.25rem;
   font-size: 1rem;


### PR DESCRIPTION
## Summary
- replace the prompt-based environment search selection with a location-aware selection screen that mirrors quest acceptance
- integrate the new minigame flow into environment interactions and respect chosen categories when resolving search actions
- style the search minigame with card-like options and contextual metadata, including a back action

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e31e4ac9ac8325bd38f8fd1d2997e7