### PR TITLE
Add icons for dive and swim environment actions

### DIFF
--- a/data/game/environment_interactions.js
+++ b/data/game/environment_interactions.js
@@ -62,6 +62,14 @@ const ACTION_METADATA = {
     label: 'Tidepooling',
     icon: 'assets/images/icons/actions/Tidepooling.png',
   },
+  dive: {
+    label: 'Dive',
+    icon: 'assets/images/icons/actions/Diving.png',
+  },
+  swim: {
+    label: 'Swim',
+    icon: 'assets/images/icons/actions/Swimming.png',
+  },
 };
 
 function pickIconVariant(value) {


### PR DESCRIPTION
## Summary
- assign the dedicated Diving and Swimming icon assets to the dive and swim environment actions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3381487088325880b3dc427cd872d