### PR TITLE
Add generic Ask Around icon prompt

### DIFF
--- a/docs/ask_around_icon_prompt.md
+++ b/docs/ask_around_icon_prompt.md
@@ -1,0 +1,35 @@
+Ask Around Icon Prompt (Generic Fantasy — Borderless, Scroll Label)
+
+**Canvas & Style**
+Square canvas, 1024 × 1024 px, transparent background.
+No outer frame or drop shadow—icon floats freely.
+Welcoming high-fantasy RPG aesthetic with crisp line art, soft gradients, and lantern-lit warmth; avoid regional motifs so it fits any setting.
+
+**Scroll Banner**
+Parchment scroll banner anchored along the bottom (approx. 700 × 160 px), softly curled ends, light tan base (#d7ccc8) with gentle parchment lowlights (#c5a880).
+“Ask Around” in bold rune-styled serif, deep midnight blue fill (#1a2b6d) with thin charcoal outline (#2f2f2f) and a faint inner glow in mellow gold (#e4b74f).
+
+**Central Motif**
+Circular conversation nook composed of a small round table and two inviting chairs angled toward one another, suggesting friendly discourse.
+Table surface hosts a neatly stacked pair of parchment notes, an ink bottle with quill, and a softly glowing crystal orb symbolizing shared information.
+Behind the table, a freestanding bulletin pole holds a trio of anonymous message ribbons and sealed envelopes fluttering gently; keep designs neutral to avoid faction or city markings.
+A subtle halo of sound waves—delicate concentric arcs in translucent pearl—radiates upward from the crystal orb, implying whispered rumors without creating a backdrop.
+Scatter a few conversational tokens on the table such as a brass pocket watch and neutral wax seal stamp to reinforce the theme of gathering clues.
+
+**Color Palette**
+Furniture & Wood: Honey maple to warm chestnut gradient (#c18b56 → #875232) with soft charcoal shadows (#424242) and pearl edge glints (#f5f5f5).
+Paper & Fabric: Parchment creams and warm ivories (#f5e6c5, #e8d7aa) with muted sepia ink strokes (#4a3a24); chair cushions in subdued mulberry (#7b4a63) and forest green (#3f6b4f).
+Metal & Accents: Brass details on pocket watch, seal stamp, and chair studs (#d4a552 → #9c6b2f) with restrained gold highlights (#ffcc66).
+Magical Glow: Crystal orb and sound-wave arcs in cool moonlit aqua (#8fd3d1) fading to pearl-white (#f5f5f5), ensuring the glow stays soft and non-directional.
+Maintain overall palette balanced between warm neutrals and gentle jewel tones to keep the prompt broadly applicable.
+
+**Line & Texture**
+Clean, moderately thin outlines in deep charcoal (#2f2f2f).
+Subtle wood grain on furniture, light parchment fiber texture on notes and ribbons, and soft upholstery shading on chair cushions.
+Use delicate gradients for the magical glow and sound-wave arcs; reserve tiny sparkle highlights for metal accessories and the crystal orb to avoid over-embellishment.
+Keep background empty beyond the icon silhouette so it can layer over any interface.
+
+**Output Format**
+Format: PNG
+File Name: AskAround.png
+Background: Transparent

--- a/docs/city_explore_icon_prompt.md
+++ b/docs/city_explore_icon_prompt.md
@@ -1,0 +1,36 @@
+City Explore Icon Prompt (Port District Palette — Borderless, Scroll Label)
+
+**Canvas & Style**  
+Square canvas, 1024 × 1024 px, transparent background.  
+No outer frame or drop shadow—icon floats freely.  
+Cute‑elegant fantasy RPG aesthetic consistent with Wave’s Break location icons: crisp line art, subtle gradients, gentle highlights.
+
+**Scroll Banner**  
+Parchment scroll banner anchored along the bottom (approx. 700 × 160 px), softly curled ends, light tan base (#d7ccc8) with sandy lowlights (#c5a880).  
+“Explore” in bold rune‑styled serif, deep harbor blue fill (#0d47a1) with thin charcoal outline (#2f2f2f) and a faint inner glow in warm gold (#ffb300).
+
+**Central Motif**  
+Circular compass rose inset into a polished stone plinth, tilted slightly forward for visibility.  
+Compass body features alternating honey oak and weathered chestnut segments (#b68653 → #7a5031) with pearl edge glints (#f5f5f5); directional tips outlined in deep charcoal (#2f2f2f).  
+A delicate brass armillary ring arcs around the compass, accented with a hanging sea‑teal pennant (#00838f) and deep navy bead (#0d47a1) near the north point.  
+Magnifying glass leaning against the plinth on the right, glass rim in charcoal metal with subtle sparkle highlights and lens catching warm lantern gold reflections.  
+Map scroll partially unfurled on the left, parchment ivory (#f5e6c5) with sea‑teal routes, dotted navy landmarks, and an “X” in warm gold—ensure edges curl and overlap for depth.  
+Subtle cobblestone texture beneath the plinth with two small embedded wayfinding arrows pointing outward; keep surrounding background empty.
+
+**Color Palette**  
+Compass & Plinth: Wood and stone gradient (#b68653 → #7a5031) with charcoal shadows (#424242) and pearl highlights (#f5f5f5).  
+Metal Accents: Deep charcoal (#2f2f2f) with selective lantern gold glints (#ffb300).  
+Map Elements: Parchment creams and warm ivories (#f5e6c5, #e8d7aa) with sea‑teal and deep navy ink strokes (#00838f, #0d47a1).  
+Accessory Details: Warm sepia leather wrap on magnifying handle (#5c4033) and subtle amber glass glow.  
+Port District Accents: Maintain touches of deep navy (#0d47a1), sea‑teal (#00838f), and warm lantern gold (#ffb300) for cohesive palette.
+
+**Line & Texture**  
+Clean, moderately thin outlines in deep charcoal (#2f2f2f).  
+Subtle wood grain and engraved marks on compass segments; faint etched rings on the armillary and compass face markings.  
+Map scroll displays gentle paper fibers and soft shading under folds; magnifying lens uses transparent gradients with a slight highlight streak.  
+Reserve tiny sparkle highlights for metal rivets, compass points, and the magnifying rim; keep the negative space clear beyond the icon silhouette.
+
+**Output Format**  
+Format: PNG  
+File Name: Explore.png  
+Background: Transparent

--- a/docs/city_look_for_work_icon_prompt.md
+++ b/docs/city_look_for_work_icon_prompt.md
@@ -1,0 +1,35 @@
+City Look For Work Icon Prompt (Port District Palette — Borderless, Scroll Label)
+
+**Canvas & Style**
+Square canvas, 1024 × 1024 px, transparent background.
+No outer frame or drop shadow—icon floats freely.
+Cute‑elegant fantasy RPG aesthetic consistent with Wave’s Break location icons: crisp line art, subtle gradients, gentle highlights.
+
+**Scroll Banner**
+Parchment scroll banner anchored along the bottom (approx. 700 × 160 px), softly curled ends, light tan base (#d7ccc8) with sandy lowlights (#c5a880).
+“Look For Work” in bold rune‑styled serif, deep harbor blue fill (#0d47a1) with thin charcoal outline (#2f2f2f) and a faint inner glow in warm gold (#ffb300).
+
+**Central Motif**
+Compact hiring pavilion composed of a waist‑high stone counter with a curved honey oak canopy supported by twin posts.
+Behind the counter, a parchment job ledger stands open on a brass stand, pages filled with neat deep sepia entries and a few sea‑teal ribbons marking urgent postings.
+Foreground features a polished brass bell with a pearl highlight and a small stack of folded application forms secured by a warm gold wax seal.
+To the side, hang a trio of dangling job tags—mini parchment cards clipped to a cord—with varied corner curls and tiny navy symbols indicating trade, craft, and service roles.
+Soft cobblestone base with subtle directional arrows etched toward the counter; keep distant city silhouettes minimal and misty so the scene remains icon-like.
+
+**Color Palette**
+Counter & Canopy: Honey oak to weathered chestnut wood gradient (#b68653 → #7a5031) with pearl edge glints (#f5f5f5); stone counter base in misty sandstone (#d0c4ad → #a49580) with charcoal shadows (#424242).
+Ledger & Forms: Parchment creams and warm ivories (#f5e6c5, #e8d7aa) with deep sepia ink strokes (#4a3a24); ribbon markers and job tag icons in sea‑teal (#00838f) and deep navy (#0d47a1).
+Metal Accents: Brass bell and stand in polished gradient (#d4a552 → #9c6b2f) with selective lantern gold highlights (#ffb300).
+Cobblestones: Muted harbor gray-beige tones (#b0a999 → #8b8374) with soft charcoal seams.
+Port District Touches: Maintain warm lantern gold (#ffb300) sparingly on seals, bell glow, and canopy trim to tie into the palette.
+
+**Line & Texture**
+Clean, moderately thin outlines in deep charcoal (#2f2f2f).
+Subtle wood grain on canopy and posts, gentle parchment fiber details on ledger pages and job tags, and lightly engraved stone texture on the counter base.
+Add faint crease marks on folded forms and restrained sparkle highlights on metal elements like the bell and brass stand.
+Keep surrounding background empty beyond the icon silhouette to maintain borderless presentation.
+
+**Output Format**
+Format: PNG
+File Name: LookForWork.png
+Background: Transparent

--- a/docs/city_rest_icon_prompt.md
+++ b/docs/city_rest_icon_prompt.md
@@ -1,0 +1,36 @@
+City Rest Icon Prompt (Port District Palette — Borderless, Scroll Label)
+
+**Canvas & Style**
+Square canvas, 1024 × 1024 px, transparent background.
+No outer frame or drop shadow—icon floats freely.
+Cute‑elegant fantasy RPG aesthetic consistent with Wave’s Break location icons: crisp line art, subtle gradients, gentle highlights.
+
+**Scroll Banner**
+Parchment scroll banner anchored along the bottom (approx. 700 × 160 px), softly curled ends, light tan base (#d7ccc8) with sandy lowlights (#c5a880).
+“Rest” in bold rune‑styled serif, deep harbor blue fill (#0d47a1) with thin charcoal outline (#2f2f2f) and a faint inner glow in warm gold (#ffb300).
+
+**Central Motif**
+Secluded woodland clearing edged with low dune grass and riverstone outcrops, framing the scene without enclosing the silhouette.
+A compact campfire of driftwood logs sits at center, flames rendered in layered lantern gold and coral hues with a suspended brass kettle heating over a simple tripod.
+To the left, a weathered pine log and a chopped stump form rustic seating, each draped with a folded sea‑teal cloak and deep navy canteen to suggest prepared travelers.
+On the right, a rolled-out bedroll-and-mat setup rests atop woven reed groundcloth: thick canvas mat, parchment-cream pillow, and a folded cloak serving as a blanket.
+A travel pack leans against a nearby rock with a hanging charm of gull feathers and seashells; a pair of resting boots and a sheathed knife lie neatly beside the mat to imply readiness.
+Keep background details minimal—only faint silhouettes of distant pines and firefly motes—to preserve the icon’s open silhouette.
+
+**Color Palette**
+Ground & Foliage: Mossy meadow greens (#8fae72 → #5f7a4f) blended with sandy undertones (#b7956d) and charcoal shadows (#424242); riverstones in cool slate gray (#8b8f95 → #5f6569) with pearl highlights (#f5f5f5).
+Campfire & Glow: Firewood in honey oak to weathered chestnut gradient (#b68653 → #7a5031); flames layered in lantern gold (#ffb300), coral blush (#f2b8a0), and warm amber (#d98b4c) with subtle aqua sparks (#6fa5b4).
+Gear & Seating: Log seats in rich chestnut wood with visible rings; cloaks and canteen straps in sea‑teal (#00838f) and deep navy (#0d47a1); bedroll canvas in parchment cream (#f5e6c5) with pearl-white highlights.
+Accessories: Brass kettle, tripod fittings, and knife guard in polished brass (#d4a552 → #9c6b2f); travel pack in muted sepia leather (#5c4033) with sea‑teal stitching; feathers in pearl-white with lantern gold tips.
+Atmospheric Accents: Firefly motes and ember trails rendered in soft pearl-white (#f5f5f5) with restrained lantern gold glints to keep the mood tranquil.
+
+**Line & Texture**
+Clean, moderately thin outlines in deep charcoal (#2f2f2f).
+Subtle bark texture on logs, woven patterns on reed groundcloth, and crosshatched canvas folds on the bedroll.
+Fire glow and ember trails use translucent gradients and tiny sparkle highlights; metallic surfaces receive restrained gleams.
+Maintain empty transparency beyond the icon silhouette.
+
+**Output Format**
+Format: PNG
+File Name: Rest.png
+Background: Transparent


### PR DESCRIPTION
## Summary
- add a new prompt specification for a generic fantasy "Ask Around" icon, covering canvas, banner, motif, palette, and texture guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d35d9383708325a3319c239ed568a3